### PR TITLE
Limit attack dataset

### DIFF
--- a/config/audit.yaml
+++ b/config/audit.yaml
@@ -2,7 +2,8 @@ audit:  # Configurations for auditing
   random_seed: 1234  # Integer specifying the random seed
   attack_list:
     rmia:
-      data_fraction: 0.3  # Fraction of the auxilary dataset to use for this attack (in each shadow model training)
+      training_data_fraction: 0.3  # Fraction of the auxilary dataset to use for this attack (in each shadow model training)
+      attack_data_fraction: 0.1 # Fraction of auxiliary dataset to sample from during attack
       num_shadow_models: 5 # Number of shadow models to train
       online: True # perform online or offline attack
       temperature: 2
@@ -10,10 +11,10 @@ audit:  # Configurations for auditing
       offline_a: 0.33 # parameter from which we compute p(x) from p_OUT(x) such that p_IN(x) = a p_OUT(x) + b.
       offline_b: 0.66
     qmia:
-      data_fraction: 0.4  # Fraction of the auxilary dataset (data without train and test indices) to use for this attack
+      training_data_fraction: 0.1  # Fraction of the auxilary dataset (data without train and test indices) to use for this attack
       epochs: 10  # Number of training epochs for quantile regression
     population:
-      data_fraction: 0.4  # Fraction of the auxilary dataset to use for this attack
+      attack_data_fraction: 0.1  # Fraction of the auxilary dataset to use for this attack
 
   report_log: "./leakpro_output/results"  # Folder to save the auditing report
   target_model_folder: "./target"
@@ -26,7 +27,7 @@ target:
   model_class: "ConvNet"
   trained_model_path: "./target/target_model.pkl" 
   trained_model_metadata_path: "./target/model_metadata.pkl"
-  data_path: "./target/data/cifar10.pkl"
+  data_path: "./target/data/cinic10.pkl"
 
 
 shadow_model:

--- a/config/audit.yaml
+++ b/config/audit.yaml
@@ -11,7 +11,7 @@ audit:  # Configurations for auditing
       offline_a: 0.33 # parameter from which we compute p(x) from p_OUT(x) such that p_IN(x) = a p_OUT(x) + b.
       offline_b: 0.66
     qmia:
-      training_data_fraction: 0.1  # Fraction of the auxilary dataset (data without train and test indices) to use for this attack
+      training_data_fraction: 0.1  # Fraction of the auxilary dataset (data without train and test indices) to use for training the quantile regressor
       epochs: 10  # Number of training epochs for quantile regression
     population:
       attack_data_fraction: 0.1  # Fraction of the auxilary dataset to use for this attack

--- a/leakpro/attacks/mia_attacks/attack_p.py
+++ b/leakpro/attacks/mia_attacks/attack_p.py
@@ -44,11 +44,11 @@ class AttackP(AbstractMIA):
         self._configure_attack(configs)
 
     def _configure_attack(self:Self, configs:dict) -> None:
-        self.training_data_fraction = configs.get("training_data_fraction", 0.5)
+        self.attack_data_fraction = configs.get("attack_data_fraction", 0.5)
 
         # Define the validation dictionary as: {parameter_name: (parameter, min_value, max_value)}
         validation_dict = {
-            "training_data_fraction": (self.training_data_fraction, 0.01, 1)
+            "attack_data_fraction": (self.attack_data_fraction, 0.01, 1)
         }
 
         # Validate parameters

--- a/leakpro/attacks/mia_attacks/attack_p.py
+++ b/leakpro/attacks/mia_attacks/attack_p.py
@@ -44,11 +44,11 @@ class AttackP(AbstractMIA):
         self._configure_attack(configs)
 
     def _configure_attack(self:Self, configs:dict) -> None:
-        self.f_attack_data_size = configs.get("data_fraction", 0.5)
+        self.training_data_fraction = configs.get("training_data_fraction", 0.5)
 
         # Define the validation dictionary as: {parameter_name: (parameter, min_value, max_value)}
         validation_dict = {
-            "f_attack_data_size": (self.f_attack_data_size, 0.01, 1)
+            "training_data_fraction": (self.training_data_fraction, 0.01, 1)
         }
 
         # Validate parameters
@@ -90,6 +90,15 @@ class AttackP(AbstractMIA):
             test_data_included_in_auxiliary_data = False,
             logger = self.logger
         )
+
+        # subsample the attack data based on the fraction
+        self.logger.info(f"Subsampling attack data from {len(self.attack_data_index)} points")
+        self.attack_data_index = np.random.choice(
+            self.attack_data_index,
+            int(self.attack_data_fraction * len(self.attack_data_index)),
+            replace=False
+        )
+        self.logger.info(f"Number of attack data points after subsampling: {len(self.attack_data_index)}")
 
         attack_data = self.population.subset(self.attack_data_index)
         # Load signals if they have been computed already; otherwise, compute and save them

--- a/leakpro/attacks/mia_attacks/qmia.py
+++ b/leakpro/attacks/mia_attacks/qmia.py
@@ -119,7 +119,7 @@ class AttackQMIA(AbstractMIA):
         self.quantile_regressor = QuantileRegressor(len(self.quantiles))
 
     def _configure_attack(self:Self, configs:dict) -> None:
-        self.f_attack_data_size = configs.get("data_fraction", 0.5)
+        self.training_data_fraction = configs.get("training_data_fraction", 0.5)
         self.quantiles = configs.get("quantiles", [0, 0.5, 0.9, 0.95, 0.99, 0.995, 0.999, 0.9995, 0.9999, 0.99995, 0.99999])
         self.epochs = configs.get("epochs", 100)
 
@@ -129,7 +129,7 @@ class AttackQMIA(AbstractMIA):
             "max_quantile": (max(self.quantiles), min(self.quantiles), 1.0),
             "num_quantiles": (len(self.quantiles), 1, None),
             "epochs": (self.epochs, 0, None),
-            "f_attack_data_size": (self.f_attack_data_size, 0, 1)
+            "training_data_fraction": (self.training_data_fraction, 0, 1)
         }
 
         # Validate parameters
@@ -171,6 +171,17 @@ class AttackQMIA(AbstractMIA):
             test_data_included_in_auxiliary_data = False,
             logger = self.logger
         )
+
+        # subsample the attack data based on the fraction
+        self.logger.info(f"Subsampling attack data from {len(self.attack_data_index)} points")
+        self.attack_data_index = np.random.choice(
+            self.attack_data_index,
+            int(self.attack_data_fraction * len(self.attack_data_index)),
+            replace=False
+        )
+        self.logger.info(f"Number of attack data points after subsampling: {len(self.attack_data_index)}")
+
+        # create attack dataset
         attack_data = self.population.subset(self.attack_data_index)
 
         # create labels and change dataset to be used for regression

--- a/leakpro/attacks/mia_attacks/qmia.py
+++ b/leakpro/attacks/mia_attacks/qmia.py
@@ -176,7 +176,7 @@ class AttackQMIA(AbstractMIA):
         self.logger.info(f"Subsampling attack data from {len(self.attack_data_index)} points")
         self.attack_data_index = np.random.choice(
             self.attack_data_index,
-            int(self.attack_data_fraction * len(self.attack_data_index)),
+            int(self.training_data_fraction * len(self.attack_data_index)),
             replace=False
         )
         self.logger.info(f"Number of attack data points after subsampling: {len(self.attack_data_index)}")

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -149,19 +149,12 @@ class AttackRMIA(AbstractMIA):
             include_target_testing_data,
             self.logger
         )
-        # subsample the attack data based on the fraction
-        self.logger.info(f"Subsampling attack data from {len(self.attack_data_index)} points")
-        self.attack_data_index = np.random.choice(
-            self.attack_data_index,
-            int(self.attack_data_fraction * len(self.attack_data_index)),
-            replace=False
-        )
-        self.logger.info(f"Number of attack data points after subsampling: {len(self.attack_data_index)}")
 
         # create attack dataset
         attack_data = self.population.subset(self.attack_data_index)
 
         # train shadow models
+        self.logger.info(f"Training shadow models on {len(attack_data)} points")
         ShadowModelHandler().create_shadow_models(
             self.num_shadow_models,
             attack_data,
@@ -175,6 +168,16 @@ class AttackRMIA(AbstractMIA):
         if self.online is False:
             # compute the ratio of p(z|theta) (target model) to p(z)=sum_{theta'} p(z|theta') (shadow models)
             # for all points in the attack dataset output from signal: # models x # data points x # classes
+
+            # subsample the attack data based on the fraction
+            self.logger.info(f"Subsampling attack data from {len(self.attack_data_index)} points")
+            self.attack_data_index = np.random.choice(
+                self.attack_data_index,
+                int(self.attack_data_fraction * len(self.attack_data_index)),
+                replace=False
+            )
+            self.logger.info(f"Number of attack data points after subsampling: {len(self.attack_data_index)}")
+
 
             # get the true label indices
             z_true_labels = np.array(attack_data._labels)
@@ -249,6 +252,15 @@ class AttackRMIA(AbstractMIA):
             False,
             self.logger
         )
+
+        # subsample the attack data based on the fraction
+        self.logger.info(f"Subsampling attack data from {len(self.attack_data_index)} points")
+        self.attack_data_index = np.random.choice(
+            self.attack_data_index,
+            int(self.attack_data_fraction * len(self.attack_data_index)),
+            replace=False
+        )
+        self.logger.info(f"Number of attack data points after subsampling: {len(self.attack_data_index)}")
 
         attack_data = self.population.subset(self.attack_data_index)
         # get the true label indices

--- a/leakpro/dev_utils/data_preparation.py
+++ b/leakpro/dev_utils/data_preparation.py
@@ -83,6 +83,7 @@ def get_cifar10_dataset(dataset_name: str, data_dir: str, logger:logging.Logger)
             all_data = joblib.load(file)
         logger.info(f"Load data from {path}.pkl")
     else:
+        logger.info("Downloading CIFAR-10 dataset")
         transform = transforms.Compose([transforms.ToTensor(),transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
         trainset = torchvision.datasets.CIFAR10(root="./data/cifar10", train=True, download=True, transform=transform)
         testset = torchvision.datasets.CIFAR10(root="./data/cifar10", train=False,download=True, transform=transform)
@@ -116,6 +117,7 @@ def get_cinic10_dataset(dataset_name: str, data_dir: str, logger:logging.Logger)
         logger.info(f"Load data from {path}.pkl")
     else:
         if not os.path.exists("./data/cinic10"):
+            logger.info("Downloading CINIC-10 dataset")
             os.makedirs("./data/cinic10")
             url = "https://datashare.is.ed.ac.uk/bitstream/handle/10283/3192/CINIC-10.tar.gz"
             download_path = "./data/CINIC-10.tar.gz"


### PR DESCRIPTION
# Description

Summary of changes

* Introduced training_data_fraction in audit.yaml to determine the fraction of auxiliary data that should be used to train a shadow model.
* Introduced attack_data_fraction in audit.yaml to determine the fraction of data that should go into the actual attack.

## Resolved Issues

- [ ] fixes #48 

## How Has This Been Tested?
- attacks are running
- printing the dataset sizes