### PR TITLE
GPJ: fix for linting rules after ruff update in synthetic_data_attacks tests

### DIFF
--- a/leakpro/tests/tests_synthetic_data_attacks/anonymeter_tests/test_confidence.py
+++ b/leakpro/tests/tests_synthetic_data_attacks/anonymeter_tests/test_confidence.py
@@ -23,13 +23,13 @@ def test_assert_x_in_bound() -> None:
     #Case not correct type input
     with pytest.raises(TypeError) as e:
         assert_x_in_bound(x="not_float_or_int")
-    assert e.type == TypeError
+    assert e.type is TypeError
     assert str(e.value) == "'<=' not supported between instances of 'str' and 'float'"
     #Case ValueError when x not in bounds
     e_msg = "Parameter `param1` must be > 0.0 and < 10. Got 11 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         assert_x_in_bound(x=11, x_name="param1", high_bound=10)
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case x in bounds
     assert_x_in_bound(x=0.5)
     assert_x_in_bound(x=9, high_bound=10)
@@ -40,11 +40,11 @@ def test_assert_x_in_bound() -> None:
     e_msg = "Parameter must be > 0.0 and < 1.0. Got 0 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         assert_x_in_bound(x=0, inclusive_flag=False)
-    assert e.type == ValueError
+    assert e.type is ValueError
     e_msg = "Parameter must be > 0.0 and < 1.0. Got 1 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         assert_x_in_bound(x=1, inclusive_flag=False)
-    assert e.type == ValueError
+    assert e.type is ValueError
 
 @pytest.mark.parametrize(
     ("rate", "error", "e_lower_b", "e_upper_b"),
@@ -72,7 +72,7 @@ def test_SuccessRate_init() -> None: # noqa: N802
     e_msg = "Parameter `error` must be > 0.0. Got 0.0 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         SuccessRate(rate=0.0, error=0.0)
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case normal input
     sr = SuccessRate(rate=0.05, error=0.1)
     assert sr.rate == 0.05
@@ -85,21 +85,21 @@ def test_success_rate_input_errors() -> None:
     #Case n_total <= 0
     with pytest.raises(AssertionError) as e:
         success_rate(n_total=0, n_success=0, confidence_level=0.95)
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case n_success < 0
     with pytest.raises(AssertionError) as e:
         success_rate(n_total=1, n_success=-1, confidence_level=0.95)
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case n_success > n_total
     e_msg = "Parameter n_sucess can not be larger than n_total."
     with pytest.raises(ValueError, match=e_msg) as e:
         success_rate(n_total=1, n_success=2, confidence_level=0.95)
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case confidence_level not in (0,1)
     e_msg = "Parameter `confidence_level` must be > 0.0 and < 1.0. Got 1.0 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         success_rate(n_total=1, n_success=0, confidence_level=1.0)
-    assert e.type == ValueError
+    assert e.type is ValueError
 
 @pytest.mark.parametrize(
     ("n_success", "e_risk", "e_error", "e_low_bound", "e_high_bound"),
@@ -162,7 +162,7 @@ def test_EvaluationResults_init_error() -> None: # noqa: N802
             n_naive=0,
             confidence_level=0,
         )
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case n_naive or n_naive < 0
     e_msg = "n_main and n_naive must be greater or equal to 0."
     with pytest.raises(ValueError, match=e_msg) as e:
@@ -171,14 +171,14 @@ def test_EvaluationResults_init_error() -> None: # noqa: N802
             n_main=-1,
             n_naive=0
         )
-    assert e.type == ValueError
+    assert e.type is ValueError
     with pytest.raises(ValueError, match=e_msg) as e:
         EvaluationResults(
             n_total=1,
             n_main=0,
             n_naive=-1
         )
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case n_total not max of n_main and n_naive
     e_msg = "n_total must be greater or equal than n_main and n_naive."
     with pytest.raises(ValueError, match=e_msg) as e:
@@ -187,14 +187,14 @@ def test_EvaluationResults_init_error() -> None: # noqa: N802
             n_main=2,
             n_naive=1
         )
-    assert e.type == ValueError
+    assert e.type is ValueError
     with pytest.raises(ValueError, match=e_msg) as e:
         EvaluationResults(
             n_total=1,
             n_main=1,
             n_naive=2
         )
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case confidence_level not in (0,1) interval
     e_msg = "Parameter `confidence_level` must be > 0.0 and < 1.0. Got 0.0 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
@@ -204,7 +204,7 @@ def test_EvaluationResults_init_error() -> None: # noqa: N802
             n_naive=0,
             confidence_level=0
         )
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case no error on input
     EvaluationResults(
         n_total=1,

--- a/leakpro/tests/tests_synthetic_data_attacks/anonymeter_tests/test_inference_evaluator.py
+++ b/leakpro/tests/tests_synthetic_data_attacks/anonymeter_tests/test_inference_evaluator.py
@@ -18,21 +18,21 @@ def test_InferenceGuesses_init() -> None: # noqa: N802
     #Case len(guesses.shape)<1
     with pytest.raises(AssertionError) as e:
         InferenceGuesses(guesses=np.array([[]]), secrets=np.array([]), regression=False)
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case guesses.shape[0]==0
     with pytest.raises(AssertionError) as e:
         InferenceGuesses(guesses=np.array([]), secrets=np.array([]), regression=False)
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case guesses.shape!=secrets.shape
     input_array = np.array([0])
     with pytest.raises(AssertionError) as e:
         InferenceGuesses(guesses=input_array, secrets=np.array([]), regression=False)
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case tolerance not in range
     e_msg = "Parameter `tolerance` must be >= 0.0 and <= 1.0. Got -0.1 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceGuesses(guesses=input_array, secrets=input_array, regression=False, tolerance=-0.1)
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case no errors on init
     ig = InferenceGuesses(guesses=input_array, secrets=input_array, regression=False)
     assert ig.guesses == input_array
@@ -119,46 +119,46 @@ def test_InferenceEvaluator_init() -> None: # noqa: N802, PLR0915
     e_msg = "ori and syn must contain rows."
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceEvaluator(ori=pd.DataFrame(), syn=pd.DataFrame([1]), aux_cols=[], secret="")
-    assert e.type == ValueError
+    assert e.type is ValueError
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceEvaluator(ori=pd.DataFrame([1]), syn=pd.DataFrame(), aux_cols=[], secret="")
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case ori contains only 1 column
     e_msg = "ori must contain at least 2 columns."
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceEvaluator(ori=pd.DataFrame([1]), syn=pd.DataFrame([1]), aux_cols=[], secret="")
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case ori and syn columns differ
     df_ex = pd.DataFrame([[1,1]], columns=["a", "b"])
     e_msg = "ori and syn columns must be equal."
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceEvaluator(ori=df_ex, syn=pd.DataFrame([1]), aux_cols=[], secret="")
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case aux_cols contains no elements
     e_msg = "aux_cols must contain at least 1 element."
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceEvaluator(ori=df_ex, syn=df_ex, aux_cols=[], secret="")
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case aux_cols not subset of ori.columns
     e_msg = "aux_cols not subset of ori.columns."
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceEvaluator(ori=df_ex, syn=df_ex, aux_cols=[""], secret="")
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case secret not in ori.columns
     e_msg = "secret not in ori.columns."
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceEvaluator(ori=df_ex, syn=df_ex, aux_cols=["a"], secret="")
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case secret included in aux_columns
     e_msg = "secret can't be included in aux_columns."
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceEvaluator(ori=df_ex, syn=df_ex, aux_cols=["a"], secret="a") # noqa: S106
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case confidence_level not in bound
     e_msg = "Parameter `confidence_level` must be > 0.0 and < 1.0. Got 0.0 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         InferenceEvaluator(ori=df_ex, syn=df_ex, aux_cols=["a"], secret="b", confidence_level=0.0) # noqa: S106
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case no error raised
     ie = InferenceEvaluator(ori=df_ex, syn=df_ex, aux_cols=["a"], secret="b") # noqa: S106
     assert ie.ori.equals(df_ex)

--- a/leakpro/tests/tests_synthetic_data_attacks/anonymeter_tests/test_linkability_evaluator.py
+++ b/leakpro/tests/tests_synthetic_data_attacks/anonymeter_tests/test_linkability_evaluator.py
@@ -17,16 +17,16 @@ def test_LinkabilityIndexes_init() -> None: # noqa: N802
     #Case len(idx_0.shape)==1
     with pytest.raises(AssertionError) as e:
         LinkabilityIndexes(idx_0=np.array([]), idx_1=np.array([]))
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case len(idx_0.shape)>1 but idx_0.shape[1]==0
     with pytest.raises(AssertionError) as e:
         LinkabilityIndexes(idx_0=np.array([[]]), idx_1=np.array([[]]))
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case len(idx_0.shape)>1, idx_0.shape[1]>0 and idx_0.shape!=idx_1.shape
     np_ex = np.array([[1]])
     with pytest.raises(AssertionError) as e:
         LinkabilityIndexes(idx_0=np_ex, idx_1=np.array([[1,2]]))
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case no errors on init
     li = LinkabilityIndexes(idx_0=np_ex, idx_1=np_ex)
     assert li.idx_0 == np_ex
@@ -41,11 +41,11 @@ def test_LinkabilityIndexes_find_links_errors() -> None: # noqa: N802
     e_msg = "Parameter `n_neighbors` must be >= 1 and <= 1. Got 0 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         LinkabilityIndexes(idx_0=np_ex, idx_1=np_ex).find_links(n_neighbors=0)
-    assert e.type == ValueError
+    assert e.type is ValueError
     e_msg = "Parameter `n_neighbors` must be >= 1 and <= 1. Got 2 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         LinkabilityIndexes(idx_0=np_ex, idx_1=np_ex).find_links(n_neighbors=2)
-    assert e.type == ValueError
+    assert e.type is ValueError
 
 @pytest.mark.parametrize(
     ("n_neighbors", "idx_0", "idx_1", "e_links", "e_count"),
@@ -73,30 +73,30 @@ def test_LinkabilityEvaluator_init() -> None: # noqa: N802
     e_msg = "ori and syn must contain rows."
     with pytest.raises(ValueError, match=e_msg) as e:
         LinkabilityEvaluator(ori=pd.DataFrame(), syn=pd.DataFrame([1]), aux_cols=([],[]))
-    assert e.type == ValueError
+    assert e.type is ValueError
     with pytest.raises(ValueError, match=e_msg) as e:
         LinkabilityEvaluator(ori=pd.DataFrame([1]), syn=pd.DataFrame(), aux_cols=([],[]))
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case ori and syn columns differ
     df_ex = pd.DataFrame([1], columns=["a"])
     e_msg = "ori and syn columns must be equal."
     with pytest.raises(ValueError, match=e_msg) as e:
         LinkabilityEvaluator(ori=df_ex, syn=pd.DataFrame([1]), aux_cols=([],[]))
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case aux_cols contains no elements
     e_msg = "aux_cols tuple must contain 2 list with at least 1 element."
     with pytest.raises(ValueError, match=e_msg) as e:
         LinkabilityEvaluator(ori=df_ex, syn=df_ex, aux_cols=([],["a"]))
-    assert e.type == ValueError
+    assert e.type is ValueError
     with pytest.raises(ValueError, match=e_msg) as e:
         LinkabilityEvaluator(ori=df_ex, syn=df_ex, aux_cols=(["a"],[]))
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case confidence_level not in bound
     aux_cols = (["a"],["a"])
     e_msg = "Parameter `confidence_level` must be > 0.0 and < 1.0. Got 0.0 instead."
     with pytest.raises(ValueError, match=e_msg) as e:
         LinkabilityEvaluator(ori=df_ex, syn=df_ex, aux_cols=aux_cols, confidence_level=0.0)
-    assert e.type == ValueError
+    assert e.type is ValueError
     #Case no error raised
     le = LinkabilityEvaluator(ori=df_ex, syn=df_ex, aux_cols=aux_cols)
     assert le.ori.equals(df_ex)

--- a/leakpro/tests/tests_synthetic_data_attacks/test_linkability_utils.py
+++ b/leakpro/tests/tests_synthetic_data_attacks/test_linkability_utils.py
@@ -27,7 +27,7 @@ def test_aux_assert_input_values_get_combs_2_buckets(cols: List[str], buck1_nr: 
     if raises_error:
         with pytest.raises(AssertionError) as e:
             lu.aux_assert_input_values_get_combs_2_buckets(cols=cols, buck1_nr=buck1_nr, buck2_nr=buck2_nr)
-        assert e.type == AssertionError
+        assert e.type is AssertionError
     else:
         lu.aux_assert_input_values_get_combs_2_buckets(cols=cols, buck1_nr=buck1_nr, buck2_nr=buck2_nr)
 
@@ -77,19 +77,19 @@ def test_get_n_sample_combinations() -> None:
     buck2_nr_arr = np.array([])
     with pytest.raises(AssertionError) as e:
         lu.get_n_sample_combinations(cols=cols, buck1_nr_arr=buck1_nr_arr, buck2_nr_arr=buck2_nr_arr)
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case buck1_nr_arr.shape[0]==0
     buck1_nr_arr = np.array([])
     buck2_nr_arr = np.array([])
     with pytest.raises(AssertionError) as e:
         lu.get_n_sample_combinations(cols=cols, buck1_nr_arr=buck1_nr_arr, buck2_nr_arr=buck2_nr_arr)
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     #Case buck1_nr_arr.shape!=buck2_nr_arr.shape
     buck1_nr_arr = np.array([1])
     buck2_nr_arr = np.array([])
     with pytest.raises(AssertionError) as e:
         lu.get_n_sample_combinations(cols=cols, buck1_nr_arr=buck1_nr_arr, buck2_nr_arr=buck2_nr_arr)
-    assert e.type == AssertionError
+    assert e.type is AssertionError
     ##Case normal input results
     #Simple test
     buck1_nr_arr = np.array([1])


### PR DESCRIPTION
# Description

Summary of changes

Ruff got updated on June 27 to version 0.5. Change broke some linting rules. PR fixes those rules that were broken in tests folder for synthetic data attacks.
