### PR TITLE
Fix micromamba command

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -41,6 +41,7 @@ jobs:
           environment-file: environment.yml
           environment-name: leakpro
           cache-downloads: true
+          micromamba-args: "--root-prefix /home/runner/micromamba-root"
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,8 +36,12 @@ jobs:
           python-version: 3.9
 
       - name: Install dependencies with micromamba
-        run: |
-          micromamba create --file environment.yml --name leakpro --root-prefix /home/runner/micromamba-root
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: environment.yml
+          environment-name: leakpro
+          cache-downloads: true
+          micromamba-args: "--root-prefix /home/runner/micromamba-root"
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,12 +36,8 @@ jobs:
           python-version: 3.9
 
       - name: Install dependencies with micromamba
-        uses: mamba-org/provision-with-micromamba@main
-        with:
-          environment-file: environment.yml
-          environment-name: leakpro
-          cache-downloads: true
-          micromamba-args: "--root-prefix /home/runner/micromamba-root"
+        run: |
+          micromamba create --file environment.yml --name leakpro --root-prefix /home/runner/micromamba-root
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,13 +35,13 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Install micromamba
+        run: |
+          curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin/ --strip-components=1 bin/micromamba
+
       - name: Install dependencies with micromamba
-        uses: mamba-org/provision-with-micromamba@main
-        with:
-          environment-file: environment.yml
-          environment-name: leakpro
-          cache-downloads: true
-          micromamba-args: "--root-prefix /home/runner/micromamba-root"
+        run: |
+          micromamba create --file environment.yml --name leakpro --root-prefix /home/runner/micromamba-root
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,10 +35,6 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install micromamba
-        run: |
-          curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin/ --strip-components=1 bin/micromamba
-
       - name: Install dependencies with micromamba
         run: |
           micromamba create --file environment.yml --name leakpro --root-prefix /home/runner/micromamba-root

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,6 +34,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
+      
+      - name: Install micromamba
+        run: |
+          curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin/ --strip-components=1 bin/micromamba
 
       - name: Install dependencies with micromamba
         run: |


### PR DESCRIPTION
# Description


Issue: The GitHub Actions workflow was failing due to an unexpected -p argument being passed to the micromamba command.

Changes:
Added a step to install micromamba using a curl command.
Updated the micromamba command to create the environment without the -p argument.


## How Has This Been Tested?
Verified that the workflow runs successfully with the changes.

## Related Pull Requests

- #PR
