### PR TITLE
Shadow test accuracy

### DIFF
--- a/examples/mia/tabular_mia/adult_handler.py
+++ b/examples/mia/tabular_mia/adult_handler.py
@@ -60,7 +60,7 @@ class AdultInputHandler(AbstractInputHandler):
 
                 loss.backward()
                 optimizer.step()
-                train_loss += loss.item() * target.size(0)
+                train_loss += loss.item() 
                 total_samples += target.size(0)
 
         train_acc = train_acc/len(dataloader.dataset)

--- a/examples/mia/tabular_mia/audit.yaml
+++ b/examples/mia/tabular_mia/audit.yaml
@@ -6,9 +6,9 @@ audit:  # Configurations for auditing
       attack_data_fraction: 0.5 # Fraction of auxiliary dataset to sample from during attack
       num_shadow_models: 3 # Number of shadow models to train
       online: True # perform online or offline attack
-    qmia:
-      training_data_fraction: 1.0  # Fraction of the auxilary dataset (data without train and test indices) to use for training the quantile regressor
-      epochs: 5  # Number of training epochs for quantile regression
+    # qmia:
+    #   training_data_fraction: 1.0  # Fraction of the auxilary dataset (data without train and test indices) to use for training the quantile regressor
+    #   epochs: 5  # Number of training epochs for quantile regression
     population:
       attack_data_fraction: 1.0  # Fraction of the auxilary dataset to use for this attack
     lira:

--- a/examples/mia/tabular_mia/main.ipynb
+++ b/examples/mia/tabular_mia/main.ipynb
@@ -43,7 +43,7 @@
     "train_acc, train_loss, test_acc, test_loss = create_trained_model_and_metadata(model,\n",
     "                                                                               train_loader,\n",
     "                                                                               test_loader,\n",
-    "                                                                               epochs=1)"
+    "                                                                               epochs=10)"
    ]
   },
   {

--- a/examples/mia/tabular_mia/utils/adult_model_preparation.py
+++ b/examples/mia/tabular_mia/utils/adult_model_preparation.py
@@ -61,7 +61,7 @@ def create_trained_model_and_metadata(model, train_loader, test_loader, epochs =
             output = model(data)
 
             loss = criterion(output, target)
-            pred = sigmoid(output) >= 0.5
+            pred = output >= 0.5
             train_acc += pred.eq(target).sum().item()
 
             loss.backward()

--- a/leakpro/attacks/mia_attacks/lira.py
+++ b/leakpro/attacks/mia_attacks/lira.py
@@ -287,6 +287,8 @@ class AttackLiRA(AbstractMIA):
                 pr_in = 0
 
             score[i] = (pr_in - pr_out)  # Append the calculated probability density value to the score list
+            if np.isnan(score[i]):
+                raise ValueError("Score is NaN")
 
         # Generate thresholds based on the range of computed scores for decision boundaries
         self.thresholds = np.linspace(np.min(score), np.max(score), 1000)

--- a/leakpro/attacks/utils/shadow_model_handler.py
+++ b/leakpro/attacks/utils/shadow_model_handler.py
@@ -65,13 +65,9 @@ class ShadowModelHandler(ModelHandler):
         self.model_storage_name = "shadow_model"
         self.metadata_storage_name = "metadata"
 
-<<<<<<< HEAD
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    def _filter(self:Self, data_size:int, online:bool, model_type: str)->list[int]:
-=======
     def _filter(self:Self, data_size:int, online:bool)->list[int]:
->>>>>>> shadow_leakage
         # Get the metadata for the shadow models
         entries = os.listdir(self.storage_path)
         pattern = re.compile(rf"^{self.metadata_storage_name}_\d+\.pkl$")
@@ -185,6 +181,7 @@ class ShadowModelHandler(ModelHandler):
                 "model_class": self.model_class,
                 "target_model_hash": self.target_model_hash,
             }
+            logger.info(f"Metadata for shadow model {i}:\n{meta_data}")
             validated_meta = ShadowModelTrainingSchema(**meta_data)
             with open(f"{self.storage_path}/{self.metadata_storage_name}_{i}.pkl", "wb") as f:
                 pickle.dump(validated_meta, f)

--- a/leakpro/attacks/utils/shadow_model_handler.py
+++ b/leakpro/attacks/utils/shadow_model_handler.py
@@ -208,12 +208,13 @@ class ShadowModelHandler(ModelHandler):
         model.eval()
         model.to(self.device)
         data_loader = self.handler.get_dataloader(indices, self.batch_size)
-        for data, target in data_loader:
-            data, target = data.to(self.device), target.to(self.device)
-            output = model(data).squeeze()
-            loss += criterion(output, target).item()
-            predictions = (output.squeeze() > 0.5).long() if output.ndim == 1 or output.shape[0] == 1 else output.argmax(1)
-            accuracy += (predictions == target).sum().item()
+        with torch.no_grad():
+            for data, target in data_loader:
+                data, target = data.to(self.device), target.to(self.device)
+                output = model(data).squeeze()
+                loss += criterion(output, target).item()
+                predictions = (output.squeeze() > 0.5).long() if output.ndim == 1 or output.shape[0] == 1 else output.argmax(1)
+                accuracy += (predictions == target).sum().item()
         loss /= len(data_loader)
         accuracy /= len(indices)
         return accuracy, loss

--- a/leakpro/attacks/utils/shadow_model_handler.py
+++ b/leakpro/attacks/utils/shadow_model_handler.py
@@ -157,7 +157,7 @@ class ShadowModelHandler(ModelHandler):
             if len(remaining_indices) == 0:
                 test_loss, test_acc = 0.0, 0.0
             else:
-                test_loss, test_acc = self._eval_shadow_model(shadow_model, criterion, remaining_indices)
+                test_acc, test_loss = self._eval_shadow_model(shadow_model, criterion, remaining_indices)
 
             logger.info(f"Training shadow model {i} complete")
             with open(f"{self.storage_path}/{self.model_storage_name}_{i}.pkl", "wb") as f:

--- a/leakpro/attacks/utils/shadow_model_handler.py
+++ b/leakpro/attacks/utils/shadow_model_handler.py
@@ -72,6 +72,8 @@ class ShadowModelHandler(ModelHandler):
         self.model_storage_name = "shadow_model"
         self.metadata_storage_name = "metadata"
 
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
     def _filter(self:Self, data_size:int, online:bool, model_type: str)->list[int]:
         # Get the metadata for the shadow models
         entries = os.listdir(self.storage_path)
@@ -161,11 +163,19 @@ class ShadowModelHandler(ModelHandler):
             # Train shadow model
             logger.info(f"Training shadow model {i} on {len(data_loader)* data_loader.batch_size} points")
             training_results = self.handler.train(data_loader, model, criterion, optimizer, self.epochs)
+
             # Read out results
             assert isinstance(training_results, TrainingOutput)
             shadow_model = training_results.model
             train_acc = training_results.metrics.get("accuracy", 0)
             train_loss = training_results.metrics.get("loss", 0)
+
+            # Evaluate shadow model on remaining aux data
+            remaining_indices = list(set(shadow_population) - set(data_indices))
+            if len(remaining_indices) == 0:
+                test_loss, test_acc = 0.0, 0.0
+            else:
+                test_loss, test_acc = self._eval_shadow_model(shadow_model, criterion, remaining_indices)
 
             logger.info(f"Training shadow model {i} complete")
             with open(f"{self.storage_path}/{self.model_storage_name}_{i}.pkl", "wb") as f:
@@ -183,6 +193,8 @@ class ShadowModelHandler(ModelHandler):
                 "epochs": self.epochs,
                 "train_acc": train_acc,
                 "train_loss": train_loss,
+                "test_acc": test_acc,
+                "test_loss": test_loss,
                 "online": online,
                 "model_type": shadow_model_type,
             }
@@ -192,6 +204,35 @@ class ShadowModelHandler(ModelHandler):
 
             logger.info(f"Metadata for shadow model {i} stored in {self.storage_path}")
         return filtered_indices + indices_to_use
+
+    def _eval_shadow_model(self:Self, model:Module, criterion:Module, indices:list[int])->Tuple[float, float]:
+        """Evaluate the shadow models.
+
+        Args:
+        ----
+            model (Module): The shadow model to evaluate.
+            criterion (Module): The loss function to use.
+            indices (list[int]): The indices in the aux dataset to evaluate.
+
+        Returns:
+        -------
+            Tuple[float, float]: The average accuracy and loss of the shadow models.
+
+        """
+        accuracy = 0.0
+        loss = 0.0
+        model.eval()
+        model.to(self.device)
+        data_loader = self.handler.get_dataloader(indices, self.batch_size)
+        for data, target in data_loader:
+            data, target = data.to(self.device), target.to(self.device)
+            output = model(data).squeeze()
+            loss += criterion(output, target).item()
+            predictions = (output.squeeze() > 0.5).long() if output.ndim == 1 or output.shape[0] == 1 else output.argmax(1)
+            accuracy += (predictions == target).sum().item()
+        loss /= len(data_loader)
+        accuracy /= len(indices)
+        return accuracy, loss
 
     def _load_shadow_model(self:Self, index:int) -> Module:
         """Load a shadow model from a saved state.

--- a/leakpro/schemas.py
+++ b/leakpro/schemas.py
@@ -134,6 +134,8 @@ class ShadowModelTrainingSchema(BaseModel):
     epochs: int = Field(..., ge=1, description="Number of training epochs")
     train_acc: float = Field(..., ge=0.0, le=1.0, description="Training accuracy (0 to 1)")
     train_loss: float = Field(..., ge=0.0, description="Training loss")
+    test_acc: float = Field(..., ge=0.0, le=1.0, description="Test accuracy (0 to 1)")
+    test_loss: float = Field(..., ge=0.0, description="Test loss")
     online: bool = Field(..., description="Online vs. offline training")
     model_type: str = Field(..., description="Type of shadow model")
 


### PR DESCRIPTION
# Description

Summary of changes

* Storing the test acc and test loss for the shadow models when trained in the ShadowModelSchema. The test data equals D_aux \ D_{shadow model}
* ShadowModelSchema updated

## Resolved Issues

- [ ] fixes #157 
- [ ] fixes #19 

## How Has This Been Tested?
- Unit tests pass
- Tested that the adult dataset works still

## Related Pull Requests

- #220 #235 must go in before this PR
