### PR TITLE
Add personal token to workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,5 +50,6 @@ jobs:
       - name: Deploy Coverage Badge to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
+          token: ${{ secrets.GH_PAT }}
           branch: gh-pages
           folder: badges


### PR DESCRIPTION
# Description
PRs from forks are unable to pass the coverage test due to access issues.

Summary of changes

* Added personal token to the repo.

## Resolved Issues

- [ ] fixes #252 

## How Has This Been Tested?
workflow pass

