### PR TITLE
Update run_tests.yml

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -41,10 +41,6 @@ jobs:
         run: |
           pytest --cov=leakpro --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html leakpro/tests/
           cat ./coverage.xml
-
-      - name: Debug GitHub Secrets
-        run: |
-          echo "GH_PAT is set: ${#secrets.GH_PAT} characters long"
           
       - name: Create Coverage Badge
         run: |
@@ -54,6 +50,6 @@ jobs:
       - name: Deploy Coverage Badge to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
           folder: badges

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -41,7 +41,14 @@ jobs:
         run: |
           pytest --cov=leakpro --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html leakpro/tests/
           cat ./coverage.xml
-          
+      
+      - name: Check if running in a fork
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
+            echo "Skipping coverage badge generation because this is a forked PR."
+            exit 0
+          fi
+      
       - name: Create Coverage Badge
         run: |
           mkdir -p badges

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -42,6 +42,10 @@ jobs:
           pytest --cov=leakpro --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html leakpro/tests/
           cat ./coverage.xml
 
+      - name: Debug GitHub Secrets
+        run: |
+          echo "GH_PAT is set: ${#secrets.GH_PAT} characters long"
+          
       - name: Create Coverage Badge
         run: |
           mkdir -p badges


### PR DESCRIPTION
# Description

Turns out it is very annoying to have the coverage updated from a fork. The coverage badge gets updated on a different branch, i.e., the PR pushes the updated coverage onto the gh-pages branch which is then read into the readme. Hence, the fork must be able to push onto the gh-pages branch and this is not smooth. 

It works if we impose that the fork must enable push permission in the forked repo (I think). However, I think the ROI is very small for this so my 5 cents is to skip the coverage if the PR is coming from a fork. Hence, the badge will not get updated from fork PRs.

Summary of changes

* Added if-statement to check if the PR is coming from a fork, if so, dont run coverage.

## Resolved Issues

- [ ] fixes #256 

## How Has This Been Tested?
Workflow pass.


