### PR TITLE
fixing small details for cifar10 example

### DIFF
--- a/examples/mia/cifar/audit.yaml
+++ b/examples/mia/cifar/audit.yaml
@@ -1,14 +1,14 @@
 audit:  # Configurations for auditing
   random_seed: 1236  # Integer specifying the random seed
   attack_list:
-    rmia:
-      online: False
-      num_shadow_models: 2
-      gamma: 1
+    # rmia:
+    #   online: True
+    #   num_shadow_models: 3
+    #   gamma: 1
     # population:
     lira:
       online: True
-      num_shadow_models: 3
+      num_shadow_models: 4
       training_data_fraction: 0.6
 
     # loss_traj:

--- a/examples/mia/cifar/audit.yaml
+++ b/examples/mia/cifar/audit.yaml
@@ -3,7 +3,7 @@ audit:  # Configurations for auditing
   attack_list:
     rmia:
       online: True
-      num_shadow_models: 3
+      num_shadow_models: 2
       gamma: 1
     # population:
     lira:

--- a/examples/mia/cifar/audit.yaml
+++ b/examples/mia/cifar/audit.yaml
@@ -2,7 +2,7 @@ audit:  # Configurations for auditing
   random_seed: 1236  # Integer specifying the random seed
   attack_list:
     rmia:
-      online: True
+      online: False
       num_shadow_models: 2
       gamma: 1
     # population:

--- a/examples/mia/cifar/audit.yaml
+++ b/examples/mia/cifar/audit.yaml
@@ -1,14 +1,14 @@
 audit:  # Configurations for auditing
   random_seed: 1236  # Integer specifying the random seed
   attack_list:
-    # rmia:
-    #   online: True
-    #   num_shadow_models: 3
-    #   gamma: 1
+    rmia:
+      online: True
+      num_shadow_models: 3
+      gamma: 1
     # population:
     lira:
       online: True
-      num_shadow_models: 4
+      num_shadow_models: 3
       training_data_fraction: 0.6
 
     # loss_traj:

--- a/examples/mia/cifar/cifar_main.ipynb
+++ b/examples/mia/cifar/cifar_main.ipynb
@@ -173,7 +173,7 @@
     "                            epochs=epochs)\n",
     "\n",
     "# Evaluate on test set\n",
-    "test_result = CifarInputHandler().eval(test_loader, model, criterion, \"cpu\")\n",
+    "test_result = CifarInputHandler().eval(test_loader, model, criterion)\n",
     "\n",
     "# Store the model and metadata\n",
     "model = train_result.model\n",

--- a/leakpro/metrics/attack_result.py
+++ b/leakpro/metrics/attack_result.py
@@ -20,7 +20,7 @@ from torch import Tensor, clamp, stack
 from torch.utils.data import DataLoader, Dataset, Subset
 from torchvision.utils import save_image
 
-from leakpro.utils.import_helper import Any, List, Self, Union
+from leakpro.utils.import_helper import Any, List, Self
 
 ########################################################################################################################
 # METRIC_RESULT CLASS
@@ -281,10 +281,7 @@ class MIAResult:
     def save(self:Self, path: str, name: str, config: dict = None, show_plot:bool = False) -> None:
         """Save the MIAResults to disk."""
 
-        if isinstance(config, dict):
-            config = config["attack_list"][name]
-        else:
-            config = config.attack_list.get(name, None)
+        config = config["attack_list"][name] if isinstance(config, dict) else config.attack_list.get(name, None)
 
         fixed_fpr_table = get_result_fixed_fpr(self.fpr, self.tpr)
 

--- a/leakpro/metrics/attack_result.py
+++ b/leakpro/metrics/attack_result.py
@@ -249,9 +249,9 @@ class MIAResult:
         self.tpr = self.tpr[not_nan]
 
         # In case the fpr are not sorted in ascending order.
-        sorted_indices = np.argsort(self.fpr)
-        self.fpr = self.fpr[sorted_indices]
-        self.tpr = self.tpr[sorted_indices]
+        sorted_indices_fpr = np.argsort(self.fpr)
+        self.fpr = self.fpr[sorted_indices_fpr]
+        self.tpr = self.tpr[sorted_indices_fpr]
 
         self.roc_auc = auc(self.fpr, self.tpr)
 


### PR DESCRIPTION
# Description

Summary of changes

cifar10 example not running out-of-the box, a few corresponding changes to make the LiRA work

- "cpu" or any device argument is not supported for the CifarInputHandler
- ReportHandler.save() is not sending the correct config format to the MIAResult.save() method. model_dump() returns a dict which is sent to MIAResult.save(), but the code expects a AuditConfig.


