### PR TITLE
MIA: get_label bug

### DIFF
--- a/leakpro/input_handler/mia_handler.py
+++ b/leakpro/input_handler/mia_handler.py
@@ -213,7 +213,7 @@ class MIAHandler:
 
     def get_labels(self:Self, dataset_indices: np.ndarray) -> np.ndarray:
         """Get the labels for given indices in the population."""
-        dataloader = self.get_dataloader(dataset_indices)
+        dataloader = self.get_dataloader(dataset_indices, shuffle=False)
         # Initialize an empty list to store the labels
         all_labels = []
 

--- a/leakpro/tests/input_handler/test_image_handler.py
+++ b/leakpro/tests/input_handler/test_image_handler.py
@@ -114,8 +114,8 @@ def test_get_labels(image_handler:ImageInputHandler) -> None:
     """Test the get_labels method."""
     parameters = get_image_handler_config()
     labels = image_handler.get_labels(np.arange(parameters.data_points))
-    assert len(labels) == parameters.test_data_points
-    assert all(labels < parameters.num_classes)
-    assert all(labels >= 0)
-    assert labels.dtype in (int8, int16, int32, int64)
+    assert len(labels) == parameters.data_points
+    assert np.all(labels < parameters.num_classes)
+    assert np.all(labels >= 0)
+    assert np.issubdtype(labels.dtype, np.integer)
     assert np.array_equal(labels, image_handler.population.targets)

--- a/leakpro/tests/input_handler/test_image_handler.py
+++ b/leakpro/tests/input_handler/test_image_handler.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 
 import numpy as np
-from torch import equal
+from torch import equal, all, int8, int16, int32, int64
 from torch.utils.data import SequentialSampler
 
 from leakpro.tests.constants import get_image_handler_config
@@ -85,32 +85,37 @@ def test_cifar10_input_handler(image_handler:ImageInputHandler) -> None:
     weights_changed = [equal(before_weights[key], after_weights[key]) for key in before_weights]
     assert any(weights_changed) is False
 
-    def test_dataloader(image_handler:ImageInputHandler) -> None:
-        """Test the dataloader."""
-        test_loader = image_handler.get_dataloader(image_handler.test_indices, shuffle=False)
-        assert test_loader is not None
-        assert len(test_loader.dataset) == parameters.test_data_points
-        assert test_loader.batch_size == parameters.batch_size
-        # Check that shuffle = false in dataloader
-        assert isinstance(test_loader.sampler, SequentialSampler)
-        
-        population_data = image_handler.population.data
-        population_labels = image_handler.population.targets
-        bs = parameters.batch_size
-        for i, (data, label) in enumerate(test_loader):
-            assert data == population_data[image_handler.test_indices[i * bs:(i + 1) * bs]]
-            assert label == population_labels[image_handler.test_indices[i * bs:(i + 1) * bs]]
-            assert data.shape == parameters.img_size
-            assert label.shape == (parameters.batch_size,)
-            assert np.all(label < parameters.num_classes)
-            assert np.all(label >= 0)
-            assert np.issubdtype(label.dtype, np.integer)
+def test_dataloader(image_handler:ImageInputHandler) -> None:
+    """Test the dataloader."""
+    parameters = get_image_handler_config()
+    test_loader = image_handler.get_dataloader(image_handler.test_indices, shuffle=False)
+    assert test_loader is not None
+    assert len(test_loader.dataset) == parameters.test_data_points
+    assert test_loader.batch_size == parameters.batch_size
+    # Check that shuffle = false in dataloader
+    assert isinstance(test_loader.sampler, SequentialSampler)
+    
+    population_data = image_handler.population.data
+    population_labels = image_handler.population.targets
+    bs = parameters.batch_size
+    for i, (data, label) in enumerate(test_loader):
+        assert np.array_equal(data, population_data[image_handler.test_indices[i * bs:(i + 1) * bs]])
+        assert np.array_equal(label, population_labels[image_handler.test_indices[i * bs:(i + 1) * bs]])
+        assert all(label < parameters.num_classes)
+        assert all(label >= 0)
+        assert label.dtype in (int8, int16, int32, int64)
+    
+    test_loader2 = image_handler.get_dataloader(image_handler.test_indices, shuffle=True)
+    assert not isinstance(test_loader2.sampler, SequentialSampler)
+
+
             
-    def test_get_labels(image_handler:ImageInputHandler) -> None:
-        """Test the get_labels method."""
-        labels = image_handler.get_labels(image_handler.test_indices)
-        assert len(labels) == parameters.test_data_points
-        assert np.all(labels < parameters.num_classes)
-        assert np.all(labels >= 0)
-        assert np.issubdtype(labels.dtype, np.integer)
-        assert np.array_equal(labels, image_handler.population.targets[image_handler.test_indices])
+def test_get_labels(image_handler:ImageInputHandler) -> None:
+    """Test the get_labels method."""
+    parameters = get_image_handler_config()
+    labels = image_handler.get_labels(np.arange(parameters.data_points))
+    assert len(labels) == parameters.test_data_points
+    assert all(labels < parameters.num_classes)
+    assert all(labels >= 0)
+    assert labels.dtype in (int8, int16, int32, int64)
+    assert np.array_equal(labels, image_handler.population.targets)


### PR DESCRIPTION
# Description

Summary of changes

* the get_label method in MIA handler sampled labels from a dataloader with "shuffle" activated. This created a mismatch.

## Resolved Issues

- [ ] fixes #315 

## How Has This Been Tested?
- Unit tests added
- RMIA yields good results again.
