### PR TITLE
Fix gradient formatting and flattening in GIA attack

### DIFF
--- a/leakpro/attacks/gia_attacks/abstract_gia.py
+++ b/leakpro/attacks/gia_attacks/abstract_gia.py
@@ -14,7 +14,7 @@ from leakpro.attacks.attack_base import AbstractAttack
 from leakpro.attacks.utils.hyperparameter_tuning.optuna import optuna_optimal_hyperparameters
 from leakpro.fl_utils.model_utils import MedianPool2d
 from leakpro.fl_utils.similarity_measurements import dataloaders_psnr, dataloaders_ssim_ignite
-from leakpro.reporting.attack_result import GIAResults
+from leakpro.reporting.gia_result import GIAResults
 from leakpro.schemas import OptunaConfig
 from leakpro.utils.import_helper import Self
 from leakpro.utils.logger import logger

--- a/leakpro/attacks/gia_attacks/huang.py
+++ b/leakpro/attacks/gia_attacks/huang.py
@@ -18,7 +18,7 @@ from leakpro.fl_utils.gia_optimizers import MetaSGD
 from leakpro.fl_utils.gia_train import train
 from leakpro.fl_utils.model_utils import BNFeatureHook
 from leakpro.fl_utils.similarity_measurements import cosine_similarity_weights, l2_norm, total_variation
-from leakpro.reporting.attack_result import GIAResults
+from leakpro.reporting.gia_result import GIAResults
 from leakpro.utils.import_helper import Callable, Self
 from leakpro.utils.logger import logger
 

--- a/leakpro/run.py
+++ b/leakpro/run.py
@@ -25,14 +25,21 @@ def run_huang(model: Module, client_data: DataLoader, train_fn: Callable,
     return result_object
 
 def run_inverting(model: Module, client_data: DataLoader, train_fn: Callable,
-                data_mean:Tensor, data_std: Tensor, config: dict, experiment_name: str = "InvertingGradients",
-                path:str = "./leakpro_output/results", save:bool = True) -> None:
+                  data_mean: Tensor, data_std: Tensor, config: dict,
+                  experiment_name: str = "InvertingGradients",
+                  path: str = "./leakpro_output/results", save: bool = True) -> None:
     """Run InvertingGradients."""
     attack = InvertingGradients(model, client_data, train_fn, data_mean, data_std, config)
-    result = attack.run_attack()
-    if save:
+    
+    # Consume the generator fully and get the last yielded result
+    result = None
+    for res in attack.run_attack():
+        result = res
+    
+    if save and result is not None:
         result.save(name=experiment_name, path=path, config=config)
     return result
+
 
 def run_inverting_audit(model: Module, dataset: Dataset,
                         train_fn: Callable, data_mean: torch.Tensor, data_std: torch.Tensor


### PR DESCRIPTION
# Description

Summary of changes

* Fixed error when client_gradient contains floats or tuples by safely converting them to tensors.
* Added flatten_client_gradient() to handle mixed gradient formats before indexing.
* Fixed the imports. 

## Resolved Issues

 * Fixed AttributeError and IndexError during gradient processing

## How Has This Been Tested?
Tested with:
python examples/gia/inverting_cifar10_1_image/main.py
Attack ran for multiple iterations without errors.

## Related Pull Requests 
none

- #PR
