### PR TITLE
Removed initialized flag

### DIFF
--- a/leakpro/attacks/mia_attacks/abstract_mia.py
+++ b/leakpro/attacks/mia_attacks/abstract_mia.py
@@ -57,7 +57,6 @@ class AbstractMIA(AbstractAttack):
         AbstractMIA.population = handler.population
         AbstractMIA.population_size = handler.population_size
         AbstractMIA.target_model = PytorchModel(handler.target_model, handler.get_criterion())
-
         AbstractMIA.audit_dataset = {
             # Assuming train_indices and test_indices are arrays of indices, not the actual data
             "data": np.concatenate((handler.train_indices, handler.test_indices)),


### PR DESCRIPTION
# Description

Summary of changes

* Removed "_initialized" flag from AbstractMIA. Should not impact current leakpro workflow, but allows for running multiple target models in a single session without using incorrect population, audit_data, in_members and out_members. If someone tries to run mulitple target models in a single session, they will use the first target models audit data and so forth

## Resolved Issues

- fixes #350

## How Has This Been Tested?
Ran audit.yaml file with more than one attack to check that it doesn't break current leakpro
