### PR TITLE
Add "How to run" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,34 @@ Our [example portfolio](https://github.com/aidotse/LeakPro/tree/readme/examples)
 2. **Install with pip**
 `pip install -e .[dev]`
 
+## How to run
+
+LeakPro runs privacy attacks against a **target model** that you have already trained. You provide the model, your dataset, and a small handler class — LeakPro takes care of the rest, including training shadow models, executing attacks, and producing a PDF report.
+
+A good starting point is the [CIFAR-10 example](https://github.com/aidotse/LeakPro/tree/main/examples/mia/cifar), which includes a ready-to-run notebook, a handler, and an [`audit.yaml`](https://github.com/aidotse/LeakPro/blob/main/examples/mia/cifar/audit.yaml). To run a different attack or tune parameters, edit the `attack_list` in `audit.yaml`:
+
+```yaml
+audit:
+  random_seed: 1234
+  attack_type: "mia"
+  data_modality: "image"
+  output_dir: "./leakpro_output"
+  attack_list:
+    - attack: lira
+      num_shadow_models: 4
+
+target:
+  module_path: "./target_model_class.py"
+  model_class: "MyModel"
+  target_folder: "./target"
+  data_path: "./data/dataset.pkl"
+```
+
+For full documentation see the **[LeakPro Wiki](https://github.com/aidotse/LeakPro/wiki)**:
+- [Attack Modules overview](https://github.com/aidotse/LeakPro/wiki/Attack-Modules)
+- [Membership Inference Attacks — implemented attacks & papers](https://github.com/aidotse/LeakPro/wiki/Membership-Inference-Attacks)
+- [Running MIA Attacks — audit.yaml config reference for all MIA attacks](https://github.com/aidotse/LeakPro/wiki/Running-MIA-Attacks)
+
 ## To Contribute
 0. **Ensure local repo is up-to-date:**
 `git fetch origin`


### PR DESCRIPTION
## Summary
- Adds a new "How to run" section to the README, placed between "To install" and "To Contribute"
- Explains that LeakPro runs against a pre-trained target model
- References the CIFAR-10 example as a concrete starting point with a minimal `audit.yaml` snippet
- Links to the LeakPro Wiki for full documentation:
  - Attack Modules overview
  - MIA implemented attacks & papers
  - Running MIA Attacks — config reference for all MIA attacks
  - Wiki paged added for attacks params: https://github.com/aidotse/LeakPro/wiki/Running-MIA-Attacks

## Motivation
The README had installation and contribution instructions but no guidance on how to actually run an attack. New users had no clear entry point.

## Fixed Issues:
https://github.com/aidotse/LeakPro/issues/244 