### PR TITLE
Add end-to-end Streamlit privacy auditor UI (MVP)

### DIFF
--- a/leakpro/ui/__init__.py
+++ b/leakpro/ui/__init__.py
@@ -1,0 +1,1 @@
+"""LeakPro Streamlit UI package."""

--- a/leakpro/ui/components/__init__.py
+++ b/leakpro/ui/components/__init__.py
@@ -1,0 +1,1 @@
+"""UI components for the LeakPro auditor dashboard."""

--- a/leakpro/ui/components/audit.py
+++ b/leakpro/ui/components/audit.py
@@ -1,0 +1,72 @@
+"""Stage 3 — Run MIA attacks with live log streaming."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def render_audit() -> None:
+    """Render the attack execution stage."""
+    from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
+
+    st.title("🔍  Stage 3 — Run Attacks")
+    dpsgd = st.session_state.get("dpsgd_enabled", False)
+
+    ac = st.session_state.get("audit_config", {})
+    attack_list = ac.get("audit", {}).get("attack_list", [])
+    attack_names = [a["attack"] for a in attack_list]
+
+    st.caption(
+        f"{'DP-SGD model' if dpsgd else 'Standard model'} — "
+        f"attacks: {', '.join(attack_names) if attack_names else 'none selected'}"
+    )
+
+    runner = LeakProRunner()
+
+    if "audit_results" not in st.session_state:
+        st.markdown(
+            """
+            Click **Run Attacks** to execute the selected membership inference attacks
+            against the trained target model. Log output will stream below.
+            """
+        )
+        if st.button("Run Attacks", type="primary"):
+            log_placeholder = st.empty()
+            with st.spinner("Running attacks… this may take a while."):
+                try:
+                    results = runner.run_audit(dpsgd=dpsgd, log_container=log_placeholder)
+                    st.session_state.audit_results = results
+                    st.rerun()
+                except Exception as e:  # noqa: BLE001
+                    st.error(f"Audit failed: {e}")
+    else:
+        results = st.session_state.audit_results
+        st.success(f"Audit complete — {len(results)} attack result(s) available.")
+
+        # Quick summary table
+        rows = []
+        for r in results:
+            auc = f"{r.roc_auc:.4f}" if r.roc_auc is not None else "N/A"
+            tpr_01 = "N/A"
+            if r.fixed_fpr_table:
+                tpr_01 = f"{r.fixed_fpr_table.get('TPR@0.1%FPR', 0):.4f}"
+            rows.append({"Attack": r.result_name, "AUC": auc, "TPR@0.1%FPR": tpr_01})
+
+        import pandas as pd  # noqa: PLC0415
+        st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+
+    # ------------------------------------------------------------------ #
+    # Navigation
+    # ------------------------------------------------------------------ #
+    st.markdown("---")
+    col_back, _, col_fwd = st.columns([1, 3, 1])
+    with col_back:
+        if st.button("← Re-train", use_container_width=True):
+            st.session_state.pop("audit_results", None)
+            st.session_state.stage = 2
+            st.rerun()
+    with col_fwd:
+        if "audit_results" in st.session_state:
+            if st.button("Explore Results →", type="primary", use_container_width=True):
+                st.session_state.stage = 4
+                st.rerun()

--- a/leakpro/ui/components/audit.py
+++ b/leakpro/ui/components/audit.py
@@ -66,7 +66,8 @@ def render_audit() -> None:
             st.session_state.stage = 2
             st.rerun()
     with col_fwd:
-        if st.session_state.get("audit_results"):
-            if st.button("Explore Results →", type="primary", use_container_width=True):
-                st.session_state.stage = 4
-                st.rerun()
+        if st.session_state.get("audit_results") and st.button(
+            "Explore Results →", type="primary", use_container_width=True
+        ):
+            st.session_state.stage = 4
+            st.rerun()

--- a/leakpro/ui/components/audit.py
+++ b/leakpro/ui/components/audit.py
@@ -14,9 +14,12 @@ def render_audit() -> None:
     models: list[dict] = st.session_state.get("models", [])
     trained_models = [m for m in models if m.get("train_result_dict")]
 
-    ac = st.session_state.get("audit_config", {})
-    attack_names = [a["attack"] for a in ac.get("audit", {}).get("attack_list", [])]
-    st.caption(f"Attacks: {', '.join(attack_names) if attack_names else 'none selected'}")
+    # Collect all unique attack names across all models
+    all_attacks: set[str] = set()
+    for m in models:
+        for a in (m.get("attack_list") or []):
+            all_attacks.add(a["attack"])
+    st.caption(f"Attacks (across all models): {', '.join(sorted(all_attacks)) if all_attacks else 'none selected'}")
 
     if not trained_models:
         st.warning("No trained models found. Go back to Stage 2 and train your models first.")
@@ -65,6 +68,7 @@ def _run_audit_loop(runner: object, trained_models: list[dict], all_models: list
             try:
                 results = runner.run_audit(  # type: ignore[attr-defined]
                     target_folder=model["target_folder"],
+                    attack_list=model.get("attack_list"),
                     dpsgd=model["dpsgd_enabled"],
                     log_container=log_ph,
                 )

--- a/leakpro/ui/components/audit.py
+++ b/leakpro/ui/components/audit.py
@@ -23,7 +23,7 @@ def render_audit() -> None:
 
     runner = LeakProRunner()
 
-    if "audit_results" not in st.session_state:
+    if not st.session_state.get("audit_results"):
         st.markdown(
             """
             Click **Run Attacks** to execute the selected membership inference attacks
@@ -66,7 +66,7 @@ def render_audit() -> None:
             st.session_state.stage = 2
             st.rerun()
     with col_fwd:
-        if "audit_results" in st.session_state:
+        if st.session_state.get("audit_results"):
             if st.button("Explore Results →", type="primary", use_container_width=True):
                 st.session_state.stage = 4
                 st.rerun()

--- a/leakpro/ui/components/audit.py
+++ b/leakpro/ui/components/audit.py
@@ -1,4 +1,4 @@
-"""Stage 3 — Run MIA attacks with live log streaming."""
+"""Stage 3 — Run MIA attacks on all trained models with live log streaming."""
 
 from __future__ import annotations
 
@@ -10,64 +10,87 @@ def render_audit() -> None:
     from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
 
     st.title("🔍  Stage 3 — Run Attacks")
-    dpsgd = st.session_state.get("dpsgd_enabled", False)
+
+    models: list[dict] = st.session_state.get("models", [])
+    trained_models = [m for m in models if m.get("train_result_dict")]
 
     ac = st.session_state.get("audit_config", {})
-    attack_list = ac.get("audit", {}).get("attack_list", [])
-    attack_names = [a["attack"] for a in attack_list]
+    attack_names = [a["attack"] for a in ac.get("audit", {}).get("attack_list", [])]
+    st.caption(f"Attacks: {', '.join(attack_names) if attack_names else 'none selected'}")
 
-    st.caption(
-        f"{'DP-SGD model' if dpsgd else 'Standard model'} — "
-        f"attacks: {', '.join(attack_names) if attack_names else 'none selected'}"
-    )
+    if not trained_models:
+        st.warning("No trained models found. Go back to Stage 2 and train your models first.")
+        if st.button("← Go to Stage 2"):
+            st.session_state.stage = 2
+            st.rerun()
+        return
 
     runner = LeakProRunner()
+    all_audited = all(m.get("audit_results") for m in trained_models)
 
-    if not st.session_state.get("audit_results"):
+    if not all_audited:
+        pending = [m for m in trained_models if not m.get("audit_results")]
+        st.caption(f"{len(pending)} model(s) still need auditing.")
         st.markdown(
-            """
-            Click **Run Attacks** to execute the selected membership inference attacks
-            against the trained target model. Log output will stream below.
-            """
+            "Click **Run Attacks** to execute the selected membership inference attacks "
+            "against each trained model. Log output will stream below."
         )
         if st.button("Run Attacks", type="primary"):
-            log_placeholder = st.empty()
-            with st.spinner("Running attacks… this may take a while."):
-                try:
-                    results = runner.run_audit(dpsgd=dpsgd, log_container=log_placeholder)
-                    st.session_state.audit_results = results
-                    st.rerun()
-                except Exception as e:  # noqa: BLE001
-                    st.error(f"Audit failed: {e}")
+            _run_audit_loop(runner, trained_models, models)
     else:
-        results = st.session_state.audit_results
-        st.success(f"Audit complete — {len(results)} attack result(s) available.")
+        st.success(f"All {len(trained_models)} model(s) audited.")
+        _render_audit_summary(trained_models)
 
-        # Quick summary table
-        rows = []
-        for r in results:
-            auc = f"{r.roc_auc:.4f}" if r.roc_auc is not None else "N/A"
-            tpr_01 = "N/A"
-            if r.fixed_fpr_table:
-                tpr_01 = f"{r.fixed_fpr_table.get('TPR@0.1%FPR', 0):.4f}"
-            rows.append({"Attack": r.result_name, "AUC": auc, "TPR@0.1%FPR": tpr_01})
-
-        import pandas as pd  # noqa: PLC0415
-        st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
-
-    # ------------------------------------------------------------------ #
-    # Navigation
-    # ------------------------------------------------------------------ #
     st.markdown("---")
     col_back, _, col_fwd = st.columns([1, 3, 1])
     with col_back:
         if st.button("← Re-train", use_container_width=True):
-            st.session_state.pop("audit_results", None)
+            for m in models:
+                m["audit_results"] = None
             st.session_state.stage = 2
             st.rerun()
     with col_fwd:
-        if st.session_state.get("audit_results") and st.button(
-            "Explore Results →", type="primary", use_container_width=True
-        ):
+        if all_audited and st.button("Explore Results →", type="primary", use_container_width=True):
             st.session_state.stage = 4
             st.rerun()
+
+
+def _run_audit_loop(runner: object, trained_models: list[dict], all_models: list[dict]) -> None:
+    """Run audits sequentially for all untrained models and trigger a rerun."""
+    for model in trained_models:
+        if model.get("audit_results"):
+            continue
+        with st.spinner(f"Auditing **{model['name']}**…"):
+            log_ph = st.empty()
+            try:
+                results = runner.run_audit(  # type: ignore[attr-defined]
+                    target_folder=model["target_folder"],
+                    dpsgd=model["dpsgd_enabled"],
+                    log_container=log_ph,
+                )
+                model["audit_results"] = results
+                st.success(f"✅ {model['name']} — {len(results)} attack(s) done.")
+            except Exception as e:  # noqa: BLE001
+                st.error(f"Audit failed for **{model['name']}**: {e}")
+    st.session_state.models = all_models
+    st.rerun()
+
+
+def _render_audit_summary(models: list[dict]) -> None:
+    """Render a quick per-model AUC summary table after auditing."""
+    import pandas as pd  # noqa: PLC0415
+
+    rows = []
+    for m in models:
+        for r in (m.get("audit_results") or []):
+            auc = f"{r.roc_auc:.4f}" if r.roc_auc is not None else "N/A"
+            tpr_01 = "N/A"
+            if r.fixed_fpr_table:
+                tpr_01 = f"{r.fixed_fpr_table.get('TPR@0.1%FPR', 0):.4f}"
+            rows.append({
+                "Model": m["name"],
+                "Attack": r.result_name,
+                "AUC": auc,
+                "TPR@0.1%FPR": tpr_01,
+            })
+    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)

--- a/leakpro/ui/components/configure.py
+++ b/leakpro/ui/components/configure.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-import copy
-
 import streamlit as st
-import yaml
-
 
 _AVAILABLE_ATTACKS = [
     ("rmia",  "RMIA — Relative Membership Inference Attack"),
@@ -15,6 +11,13 @@ _AVAILABLE_ATTACKS = [
     ("ramia", "RaMIA — Randomised Augmentation MIA"),
     ("qmia",  "QMIA — Quantile-based MIA"),
 ]
+
+_DEFAULT_DPSGD_PARAMS: dict = {
+    "target_epsilon": 3.5,
+    "target_delta": 1e-5,
+    "max_grad_norm": 1.2,
+    "virtual_batch_size": 16,
+}
 
 
 def render_configure() -> None:
@@ -26,28 +29,52 @@ def render_configure() -> None:
 
     runner = LeakProRunner()
 
-    # Load defaults if not yet in session state (or reset to None by dashboard)
     if not st.session_state.get("train_config"):
         st.session_state.train_config = runner.default_train_config()
     if not st.session_state.get("audit_config"):
         st.session_state.audit_config = runner.default_audit_config()
     if "dpsgd_enabled" not in st.session_state:
         st.session_state.dpsgd_enabled = False
-    if "dpsgd_params" not in st.session_state:
-        st.session_state.dpsgd_params = {
-            "target_epsilon": 3.5,
-            "target_delta": 1e-5,
-            "max_grad_norm": 1.2,
-            "virtual_batch_size": 16,
-        }
+    if not st.session_state.get("dpsgd_params"):
+        st.session_state.dpsgd_params = dict(_DEFAULT_DPSGD_PARAMS)
 
     tc = st.session_state.train_config
     ac = st.session_state.audit_config
 
-    # ------------------------------------------------------------------ #
-    # Training parameters
-    # ------------------------------------------------------------------ #
     st.subheader("Training parameters")
+    _render_training_params(tc)
+    st.markdown("---")
+
+    st.subheader("Attacks to run")
+    st.caption("Select which membership inference attacks to include in the audit.")
+    selected_attacks = _render_attack_selection(ac)
+    if not selected_attacks:
+        st.warning("Select at least one attack.")
+    ac.setdefault("audit", {})["attack_list"] = selected_attacks
+    st.markdown("---")
+
+    st.subheader("Differential Privacy (DP-SGD)")
+    _render_dpsgd_section()
+    st.markdown("---")
+
+    col_back, _, col_fwd = st.columns([1, 3, 1])
+    with col_back:
+        if st.button("← Back", use_container_width=True):
+            st.session_state.stage = 0
+            st.rerun()
+    with col_fwd:
+        if st.button(
+            "Start Audit →", type="primary",
+            use_container_width=True, disabled=(len(selected_attacks) == 0),
+        ):
+            st.session_state.train_config = tc
+            st.session_state.audit_config = ac
+            st.session_state.stage = 2
+            st.rerun()
+
+
+def _render_training_params(tc: dict) -> None:
+    """Render training hyper-parameter inputs and mutate tc in place."""
     col1, col2, col3 = st.columns(3)
     with col1:
         tc["train"]["epochs"] = st.number_input(
@@ -59,16 +86,16 @@ def render_configure() -> None:
     with col2:
         tc["train"]["learning_rate"] = st.number_input(
             "Learning rate", min_value=1e-5, max_value=1.0,
-            value=float(tc["train"]["learning_rate"]), format="%.5f"
+            value=float(tc["train"]["learning_rate"]), format="%.5f",
         )
         tc["train"]["weight_decay"] = st.number_input(
             "Weight decay", min_value=0.0, max_value=0.1,
-            value=float(tc["train"]["weight_decay"]), format="%.6f"
+            value=float(tc["train"]["weight_decay"]), format="%.6f",
         )
     with col3:
         tc["data"]["dataset"] = st.selectbox(
             "Dataset", ["cifar10", "cifar100"],
-            index=0 if tc["data"]["dataset"] == "cifar10" else 1
+            index=0 if tc["data"]["dataset"] == "cifar10" else 1,
         )
         tc["data"]["f_train"] = st.slider(
             "Train fraction", 0.1, 0.9, float(tc["data"]["f_train"]), 0.05
@@ -77,96 +104,54 @@ def render_configure() -> None:
             "Random seed", value=int(tc["run"].get("random_seed", 1236))
         )
 
-    st.markdown("---")
 
-    # ------------------------------------------------------------------ #
-    # Attack selection
-    # ------------------------------------------------------------------ #
-    st.subheader("Attacks to run")
-    st.caption("Select which membership inference attacks to include in the audit.")
-
-    # Build a set of currently configured attacks
-    current_attacks = {entry["attack"] for entry in ac.get("audit", {}).get("attack_list", [])}
-
-    selected_attacks: list[dict] = []
+def _render_attack_selection(ac: dict) -> list[dict]:
+    """Render the attack checkboxes and return the list of selected attack dicts."""
+    current = {e["attack"] for e in ac.get("audit", {}).get("attack_list", [])}
+    selected: list[dict] = []
     cols = st.columns(len(_AVAILABLE_ATTACKS))
     for col, (attack_id, label) in zip(cols, _AVAILABLE_ATTACKS):
         with col:
-            checked = st.checkbox(label.split(" — ")[0], value=(attack_id in current_attacks))
-            if checked:
-                selected_attacks.append({"attack": attack_id})
+            if st.checkbox(label.split(" — ")[0], value=(attack_id in current)):
+                selected.append({"attack": attack_id})
+    return selected
 
-    if not selected_attacks:
-        st.warning("Select at least one attack.")
 
-    # Update audit config with selected attacks
-    if "audit" not in ac:
-        ac["audit"] = {}
-    ac["audit"]["attack_list"] = selected_attacks
-
-    st.markdown("---")
-
-    # ------------------------------------------------------------------ #
-    # DP-SGD toggle
-    # ------------------------------------------------------------------ #
-    st.subheader("Differential Privacy (DP-SGD)")
+def _render_dpsgd_section() -> None:
+    """Render the DP-SGD toggle and parameter sliders."""
     dp = st.session_state.dpsgd_params
 
     st.session_state.dpsgd_enabled = st.toggle(
         "Enable DP-SGD training",
         value=st.session_state.dpsgd_enabled,
-        help="Train the target model with differential privacy using Opacus. "
-             "Reduces privacy leakage at the cost of some model accuracy.",
+        help="Train the target model with differential privacy using Opacus.",
     )
 
-    if st.session_state.dpsgd_enabled:
-        st.info(
-            "Lower ε = stronger privacy guarantee, but lower model accuracy. "
-            "Typical range: ε ∈ [1, 10], δ = 1e-5."
-        )
-        col_dp1, col_dp2, col_dp3 = st.columns(3)
-        with col_dp1:
-            dp["target_epsilon"] = st.slider(
-                "Target ε (epsilon)", 0.5, 20.0, float(dp["target_epsilon"]), 0.5,
-                help="Privacy budget. Lower means more private."
-            )
-        with col_dp2:
-            dp["max_grad_norm"] = st.slider(
-                "Max gradient norm", 0.1, 5.0, float(dp["max_grad_norm"]), 0.1,
-                help="Gradient clipping threshold."
-            )
-        with col_dp3:
-            dp["virtual_batch_size"] = st.number_input(
-                "Virtual batch size", min_value=4, max_value=256,
-                value=int(dp["virtual_batch_size"]),
-                help="Physical batch size processed per step (memory optimisation)."
-            )
-        dp["target_delta"] = float(
-            st.number_input(
-                "Target δ (delta)", min_value=1e-8, max_value=1e-3,
-                value=float(dp["target_delta"]), format="%.2e"
-            )
-        )
-        st.session_state.dpsgd_params = dp
-    else:
+    if not st.session_state.dpsgd_enabled:
         st.caption("Standard SGD/Adam training — no differential privacy applied.")
+        return
 
-    st.markdown("---")
-
-    # ------------------------------------------------------------------ #
-    # Navigation
-    # ------------------------------------------------------------------ #
-    col_back, _, col_fwd = st.columns([1, 3, 1])
-    with col_back:
-        if st.button("← Back", use_container_width=True):
-            st.session_state.stage = 0
-            st.rerun()
-    with col_fwd:
-        disabled = len(selected_attacks) == 0
-        if st.button(
-            "Start Audit →", type="primary", use_container_width=True, disabled=disabled
-        ):
-            st.session_state.train_config = tc
-            st.session_state.audit_config = ac
-            st.session_state.stage = 2
-            st.rerun()
+    st.info("Lower ε = stronger privacy guarantee, but lower model accuracy. Typical range: ε ∈ [1, 10], δ = 1e-5.")
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        dp["target_epsilon"] = st.slider(
+            "Target ε (epsilon)", 0.5, 20.0, float(dp["target_epsilon"]), 0.5,
+            help="Privacy budget. Lower means more private.",
+        )
+    with col2:
+        dp["max_grad_norm"] = st.slider(
+            "Max gradient norm", 0.1, 5.0, float(dp["max_grad_norm"]), 0.1,
+            help="Gradient clipping threshold.",
+        )
+    with col3:
+        dp["virtual_batch_size"] = st.number_input(
+            "Virtual batch size", min_value=4, max_value=256, value=int(dp["virtual_batch_size"]),
+            help="Physical batch size per step (memory optimisation).",
+        )
+    dp["target_delta"] = float(
+        st.number_input(
+            "Target δ (delta)", min_value=1e-8, max_value=1e-3,
+            value=float(dp["target_delta"]), format="%.2e",
+        )
+    )
+    st.session_state.dpsgd_params = dp

--- a/leakpro/ui/components/configure.py
+++ b/leakpro/ui/components/configure.py
@@ -26,10 +26,10 @@ def render_configure() -> None:
 
     runner = LeakProRunner()
 
-    # Load defaults if not yet in session state
-    if "train_config" not in st.session_state:
+    # Load defaults if not yet in session state (or reset to None by dashboard)
+    if not st.session_state.get("train_config"):
         st.session_state.train_config = runner.default_train_config()
-    if "audit_config" not in st.session_state:
+    if not st.session_state.get("audit_config"):
         st.session_state.audit_config = runner.default_audit_config()
     if "dpsgd_enabled" not in st.session_state:
         st.session_state.dpsgd_enabled = False

--- a/leakpro/ui/components/configure.py
+++ b/leakpro/ui/components/configure.py
@@ -1,4 +1,4 @@
-"""Stage 1 — Configure training parameters, select attacks, and optionally enable DP-SGD."""
+"""Stage 1 — Configure training parameters, select attacks, and define models."""
 
 from __future__ import annotations
 
@@ -19,13 +19,27 @@ _DEFAULT_DPSGD_PARAMS: dict = {
     "virtual_batch_size": 16,
 }
 
+_MAX_MODELS = 5
+
+
+def _default_model(name: str) -> dict:
+    """Return a fresh model spec dict with default values."""
+    return {
+        "name": name,
+        "dpsgd_enabled": False,
+        "dpsgd_params": None,
+        "target_folder": "",   # assigned on proceed
+        "train_result_dict": None,
+        "audit_results": None,
+    }
+
 
 def render_configure() -> None:
     """Render the configuration stage."""
     from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
 
     st.title("⚙️  Stage 1 — Configure")
-    st.caption("Adjust training and audit parameters, then click **Start Audit** to proceed.")
+    st.caption("Adjust training and audit parameters, define your models, then click **Start Audit**.")
 
     runner = LeakProRunner()
 
@@ -33,17 +47,15 @@ def render_configure() -> None:
         st.session_state.train_config = runner.default_train_config()
     if not st.session_state.get("audit_config"):
         st.session_state.audit_config = runner.default_audit_config()
-    if "dpsgd_enabled" not in st.session_state:
-        st.session_state.dpsgd_enabled = False
-    if not st.session_state.get("dpsgd_params"):
-        st.session_state.dpsgd_params = dict(_DEFAULT_DPSGD_PARAMS)
+    if not st.session_state.get("models"):
+        st.session_state.models = [_default_model("Standard")]
 
     tc = st.session_state.train_config
     ac = st.session_state.audit_config
     reaudit = st.session_state.get("reaudit_mode", False)
 
     if reaudit:
-        st.info("Re-audit mode — the trained model will be reused. Only attack selection and parameters can be changed.")
+        st.info("Re-audit mode — trained models will be reused. Only attack selection can be changed.")
     else:
         st.subheader("Training parameters")
         _render_training_params(tc)
@@ -58,8 +70,12 @@ def render_configure() -> None:
     st.markdown("---")
 
     if not reaudit:
-        st.subheader("Differential Privacy (DP-SGD)")
-        _render_dpsgd_section()
+        st.subheader("Model Definitions")
+        st.caption(
+            "Define one or more target models. Each model is trained independently "
+            "and audited with the attacks above. Add a DP-SGD model to compare privacy-accuracy trade-offs."
+        )
+        _render_model_definitions()
         st.markdown("---")
 
     col_back, _, col_fwd = st.columns([1, 3, 1])
@@ -71,14 +87,92 @@ def render_configure() -> None:
     with col_fwd:
         next_stage = 3 if reaudit else 2
         label = "Run Attacks →" if reaudit else "Start Audit →"
+        models_ok = len(st.session_state.get("models", [])) > 0
         if st.button(
             label, type="primary",
-            use_container_width=True, disabled=(len(selected_attacks) == 0),
+            use_container_width=True,
+            disabled=(len(selected_attacks) == 0 or not models_ok),
         ):
             st.session_state.train_config = tc
             st.session_state.audit_config = ac
+            _assign_target_folders()
             st.session_state.stage = next_stage
             st.rerun()
+
+
+def _assign_target_folders() -> None:
+    """Set unique target_folder names for each model based on type."""
+    std_count = dp_count = 0
+    for m in st.session_state.models:
+        if m["dpsgd_enabled"]:
+            m["target_folder"] = f"target_dpsgd_{dp_count}"
+            dp_count += 1
+        else:
+            m["target_folder"] = f"target_model_{std_count}"
+            std_count += 1
+
+
+def _render_model_definitions() -> None:
+    """Render the list of model cards with add/remove controls."""
+    models: list[dict] = st.session_state.models
+    to_remove: int | None = None
+
+    for i, model in enumerate(models):
+        with st.expander(f"Model {i + 1}: **{model['name']}**", expanded=True):
+            _render_model_card(model, i, len(models))
+            if len(models) > 1 and st.button("Remove this model", key=f"m_remove_{i}", type="secondary"):
+                to_remove = i
+
+    if to_remove is not None:
+        models.pop(to_remove)
+        st.session_state.models = models
+        st.rerun()
+
+    if len(models) < _MAX_MODELS:
+        if st.button("+ Add Model", use_container_width=False):
+            models.append(_default_model(f"Model {len(models) + 1}"))
+            st.session_state.models = models
+            st.rerun()
+    else:
+        st.caption(f"Maximum of {_MAX_MODELS} models reached.")
+
+
+def _render_model_card(model: dict, i: int, total: int) -> None:  # noqa: ARG001
+    """Render the controls for a single model definition card."""
+    model["name"] = st.text_input("Model name", model["name"], key=f"m_name_{i}")
+
+    model["dpsgd_enabled"] = st.toggle(
+        "Enable DP-SGD training",
+        value=model["dpsgd_enabled"],
+        key=f"m_dpsgd_{i}",
+        help="Train with differential privacy (Opacus). Lower ε = stronger privacy, lower accuracy.",
+    )
+
+    if model["dpsgd_enabled"]:
+        if model["dpsgd_params"] is None:
+            model["dpsgd_params"] = dict(_DEFAULT_DPSGD_PARAMS)
+        dp = model["dpsgd_params"]
+        st.info("Lower ε = stronger privacy guarantee, but lower accuracy. Typical range: ε ∈ [1, 10].")
+        c1, c2, c3 = st.columns(3)
+        dp["target_epsilon"] = c1.slider(
+            "Target ε", 0.5, 20.0, float(dp["target_epsilon"]), 0.5, key=f"m_eps_{i}",
+            help="Privacy budget.",
+        )
+        dp["max_grad_norm"] = c2.slider(
+            "Max grad norm", 0.1, 5.0, float(dp["max_grad_norm"]), 0.1, key=f"m_clip_{i}",
+            help="Gradient clipping threshold (C).",
+        )
+        dp["virtual_batch_size"] = c3.number_input(
+            "Virtual batch size", min_value=4, max_value=256,
+            value=int(dp["virtual_batch_size"]), key=f"m_vbs_{i}",
+        )
+        dp["target_delta"] = float(st.number_input(
+            "Target δ", min_value=1e-8, max_value=1e-3,
+            value=float(dp["target_delta"]), format="%.2e", key=f"m_delta_{i}",
+        ))
+    else:
+        model["dpsgd_params"] = None
+        st.caption("Standard SGD/Adam training — no differential privacy applied.")
 
 
 def _render_training_params(tc: dict) -> None:
@@ -116,14 +210,12 @@ def _render_training_params(tc: dict) -> None:
 def _render_attack_selection(ac: dict) -> list[dict]:
     """Render attack checkboxes + per-attack parameter expanders."""
     current_list = ac.get("audit", {}).get("attack_list", [])
-    # Build a lookup of existing params keyed by attack id (last entry wins for duplicates)
     current_params: dict[str, dict] = {}
     for entry in current_list:
         current_params[entry["attack"]] = entry
 
     selected: list[dict] = []
 
-    # ── checkboxes ──────────────────────────────────────────────────────────
     cols = st.columns(len(_AVAILABLE_ATTACKS))
     enabled: dict[str, bool] = {}
     for col, (attack_id, label) in zip(cols, _AVAILABLE_ATTACKS):
@@ -133,7 +225,6 @@ def _render_attack_selection(ac: dict) -> list[dict]:
                 value=(attack_id in current_params),
             )
 
-    # ── per-attack parameter expanders ──────────────────────────────────────
     for attack_id, label in _AVAILABLE_ATTACKS:
         if not enabled[attack_id]:
             continue
@@ -154,10 +245,9 @@ def _render_attack_selection(ac: dict) -> list[dict]:
                     key=f"{attack_id}_frac",
                 )
                 entry["online"] = c3.checkbox(
-                    "Online mode",
-                    value=bool(prev.get("online", False)),
+                    "Online mode", value=bool(prev.get("online", False)),
                     key=f"{attack_id}_online",
-                    help="Online RMIA/BASE trains one shadow model per audit point — much slower but more accurate.",
+                    help="Online mode trains one shadow model per audit point — slower but more accurate.",
                 )
 
             elif attack_id == "lira":
@@ -168,78 +258,31 @@ def _render_attack_selection(ac: dict) -> list[dict]:
                     key="lira_nshadow",
                 )
                 entry["online"] = c2.checkbox(
-                    "Online mode", value=bool(prev.get("online", False)),
-                    key="lira_online",
+                    "Online mode", value=bool(prev.get("online", False)), key="lira_online",
                 )
 
             elif attack_id == "ramia":
                 c1, c2, c3 = st.columns(3)
                 entry["num_transforms"] = c1.number_input(
                     "Num transforms", min_value=0, max_value=32,
-                    value=int(prev.get("num_transforms", 1)),
-                    key="ramia_ntrans",
+                    value=int(prev.get("num_transforms", 1)), key="ramia_ntrans",
                 )
                 entry["n_ops"] = c2.number_input(
                     "Ops per transform", min_value=0, max_value=8,
-                    value=int(prev.get("n_ops", 1)),
-                    key="ramia_nops",
+                    value=int(prev.get("n_ops", 1)), key="ramia_nops",
                 )
                 entry["augment_strength"] = c3.selectbox(
-                    "Augment strength",
-                    ["easy", "medium", "strong"],
-                    index=["easy", "medium", "strong"].index(
-                        prev.get("augment_strength", "strong")
-                    ),
+                    "Augment strength", ["easy", "medium", "strong"],
+                    index=["easy", "medium", "strong"].index(prev.get("augment_strength", "strong")),
                     key="ramia_strength",
                 )
 
             elif attack_id == "qmia":
                 entry["num_shadow_models"] = st.number_input(
                     "Shadow models", min_value=1, max_value=32,
-                    value=int(prev.get("num_shadow_models", 4)),
-                    key="qmia_nshadow",
+                    value=int(prev.get("num_shadow_models", 4)), key="qmia_nshadow",
                 )
 
         selected.append(entry)
 
     return selected
-
-
-def _render_dpsgd_section() -> None:
-    """Render the DP-SGD toggle and parameter sliders."""
-    dp = st.session_state.dpsgd_params
-
-    st.session_state.dpsgd_enabled = st.toggle(
-        "Enable DP-SGD training",
-        value=st.session_state.dpsgd_enabled,
-        help="Train the target model with differential privacy using Opacus.",
-    )
-
-    if not st.session_state.dpsgd_enabled:
-        st.caption("Standard SGD/Adam training — no differential privacy applied.")
-        return
-
-    st.info("Lower ε = stronger privacy guarantee, but lower model accuracy. Typical range: ε ∈ [1, 10], δ = 1e-5.")
-    col1, col2, col3 = st.columns(3)
-    with col1:
-        dp["target_epsilon"] = st.slider(
-            "Target ε (epsilon)", 0.5, 20.0, float(dp["target_epsilon"]), 0.5,
-            help="Privacy budget. Lower means more private.",
-        )
-    with col2:
-        dp["max_grad_norm"] = st.slider(
-            "Max gradient norm", 0.1, 5.0, float(dp["max_grad_norm"]), 0.1,
-            help="Gradient clipping threshold.",
-        )
-    with col3:
-        dp["virtual_batch_size"] = st.number_input(
-            "Virtual batch size", min_value=4, max_value=256, value=int(dp["virtual_batch_size"]),
-            help="Physical batch size per step (memory optimisation).",
-        )
-    dp["target_delta"] = float(
-        st.number_input(
-            "Target δ (delta)", min_value=1e-8, max_value=1e-3,
-            value=float(dp["target_delta"]), format="%.2e",
-        )
-    )
-    st.session_state.dpsgd_params = dp

--- a/leakpro/ui/components/configure.py
+++ b/leakpro/ui/components/configure.py
@@ -1,6 +1,8 @@
-"""Stage 1 — Configure training parameters, select attacks, and define models."""
+"""Stage 1 — Per-model configuration: training parameters, attacks, and DP-SGD settings."""
 
 from __future__ import annotations
+
+import copy
 
 import streamlit as st
 
@@ -22,13 +24,15 @@ _DEFAULT_DPSGD_PARAMS: dict = {
 _MAX_MODELS = 5
 
 
-def _default_model(name: str) -> dict:
+def _default_model(name: str, train_config: dict) -> dict:
     """Return a fresh model spec dict with default values."""
     return {
         "name": name,
         "dpsgd_enabled": False,
         "dpsgd_params": None,
-        "target_folder": "",   # assigned on proceed
+        "target_folder": "",
+        "train_config": copy.deepcopy(train_config),
+        "attack_list": [],
         "train_result_dict": None,
         "audit_results": None,
     }
@@ -39,45 +43,49 @@ def render_configure() -> None:
     from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
 
     st.title("⚙️  Stage 1 — Configure")
-    st.caption("Adjust training and audit parameters, define your models, then click **Start Audit**.")
 
     runner = LeakProRunner()
+    default_tc = runner.default_train_config()
 
-    if not st.session_state.get("train_config"):
-        st.session_state.train_config = runner.default_train_config()
-    if not st.session_state.get("audit_config"):
-        st.session_state.audit_config = runner.default_audit_config()
-    if not st.session_state.get("models"):
-        st.session_state.models = [_default_model("Standard")]
-
-    tc = st.session_state.train_config
-    ac = st.session_state.audit_config
     reaudit = st.session_state.get("reaudit_mode", False)
 
     if reaudit:
         st.info("Re-audit mode — trained models will be reused. Only attack selection can be changed.")
+        _render_reaudit(default_tc)
+        return
+
+    config_phase = st.session_state.get("config_phase", 1)
+
+    if config_phase == 1:
+        _render_phase1(default_tc)
     else:
-        st.subheader("Training parameters")
-        _render_training_params(tc)
-        st.markdown("---")
+        _render_phase2(default_tc)
 
-    st.subheader("Attacks to run")
-    st.caption("Select which membership inference attacks to include in the audit.")
-    selected_attacks = _render_attack_selection(ac)
-    if not selected_attacks:
-        st.warning("Select at least one attack.")
-    ac.setdefault("audit", {})["attack_list"] = selected_attacks
+
+# ---------------------------------------------------------------------------
+# Phase 1 — model count selector
+# ---------------------------------------------------------------------------
+
+def _render_phase1(default_tc: dict) -> None:
+    """Render the model count selection screen."""
+    st.caption("First, decide how many models to train and compare in this audit.")
+
     st.markdown("---")
+    st.subheader("How many models?")
+    st.caption(
+        "Each model is trained independently and audited with its own attacks. "
+        "Add a DP-SGD model alongside a standard one to compare privacy-accuracy trade-offs."
+    )
 
-    if not reaudit:
-        st.subheader("Model Definitions")
-        st.caption(
-            "Define one or more target models. Each model is trained independently "
-            "and audited with the attacks above. Add a DP-SGD model to compare privacy-accuracy trade-offs."
-        )
-        _render_model_definitions()
-        st.markdown("---")
+    current_count = len(st.session_state.get("models") or [])
+    default_count = current_count if 1 <= current_count <= _MAX_MODELS else 1
 
+    model_count = st.number_input(
+        "Number of models", min_value=1, max_value=_MAX_MODELS,
+        value=default_count, step=1,
+    )
+
+    st.markdown("---")
     col_back, _, col_fwd = st.columns([1, 3, 1])
     with col_back:
         if st.button("← Back", use_container_width=True):
@@ -85,62 +93,106 @@ def render_configure() -> None:
             st.session_state.stage = 0
             st.rerun()
     with col_fwd:
-        next_stage = 3 if reaudit else 2
-        label = "Run Attacks →" if reaudit else "Start Audit →"
-        models_ok = len(st.session_state.get("models", [])) > 0
-        if st.button(
-            label, type="primary",
-            use_container_width=True,
-            disabled=(len(selected_attacks) == 0 or not models_ok),
-        ):
-            st.session_state.train_config = tc
-            st.session_state.audit_config = ac
-            _assign_target_folders()
-            st.session_state.stage = next_stage
+        if st.button("Configure Models →", type="primary", use_container_width=True):
+            _init_models(int(model_count), default_tc)
+            st.session_state.config_phase = 2
             st.rerun()
 
 
-def _assign_target_folders() -> None:
-    """Set unique target_folder names for each model based on type."""
-    std_count = dp_count = 0
-    for m in st.session_state.models:
-        if m["dpsgd_enabled"]:
-            m["target_folder"] = f"target_dpsgd_{dp_count}"
-            dp_count += 1
+def _init_models(count: int, default_tc: dict) -> None:
+    """Initialise the models list to `count` entries, preserving existing configs."""
+    existing = st.session_state.get("models") or []
+    models: list[dict] = []
+    for i in range(count):
+        if i < len(existing):
+            # Backfill new keys for models created before this redesign
+            m = existing[i]
+            if "train_config" not in m:
+                m["train_config"] = copy.deepcopy(default_tc)
+            if "attack_list" not in m:
+                m["attack_list"] = []
+            models.append(m)
         else:
-            m["target_folder"] = f"target_model_{std_count}"
-            std_count += 1
+            name = "Standard" if i == 0 else f"Model {i + 1}"
+            models.append(_default_model(name, default_tc))
+    st.session_state.models = models
 
 
-def _render_model_definitions() -> None:
-    """Render the list of model cards with add/remove controls."""
-    models: list[dict] = st.session_state.models
-    to_remove: int | None = None
+# ---------------------------------------------------------------------------
+# Phase 2 — per-model tabs
+# ---------------------------------------------------------------------------
 
-    for i, model in enumerate(models):
-        with st.expander(f"Model {i + 1}: **{model['name']}**", expanded=True):
-            _render_model_card(model, i, len(models))
-            if len(models) > 1 and st.button("Remove this model", key=f"m_remove_{i}", type="secondary"):
-                to_remove = i
+def _render_phase2(default_tc: dict) -> None:  # noqa: ARG001
+    """Render per-model configuration tabs."""
+    models: list[dict] = st.session_state.get("models") or []
+    if not models:
+        st.warning("No models found. Please go back.")
+        return
 
-    if to_remove is not None:
-        models.pop(to_remove)
-        st.session_state.models = models
-        st.rerun()
+    st.caption(
+        f"Configure each of your {len(models)} model(s) independently — "
+        "training parameters, attacks, and DP-SGD settings."
+    )
 
-    if len(models) < _MAX_MODELS:
-        if st.button("+ Add Model", use_container_width=False):
-            models.append(_default_model(f"Model {len(models) + 1}"))
-            st.session_state.models = models
+    tab_labels = [f"{i + 1}. {m['name']}" for i, m in enumerate(models)]
+    tabs = st.tabs(tab_labels)
+
+    all_valid = True
+    for tab, model, i in zip(tabs, models, range(len(models))):
+        with tab:
+            _render_model_tab(model, i)
+            if not model.get("attack_list"):
+                all_valid = False
+
+    if not all_valid:
+        st.warning("Each model must have at least one attack selected.")
+
+    st.markdown("---")
+    col_back, _, col_fwd = st.columns([1, 3, 1])
+    with col_back:
+        if st.button("← Change model count", use_container_width=True):
+            st.session_state.config_phase = 1
             st.rerun()
-    else:
-        st.caption(f"Maximum of {_MAX_MODELS} models reached.")
+    with col_fwd:
+        if st.button(
+            "Start Audit →", type="primary", use_container_width=True,
+            disabled=not all_valid,
+        ):
+            _assign_target_folders()
+            st.session_state.models = models
+            st.session_state.stage = 2
+            st.rerun()
 
 
-def _render_model_card(model: dict, i: int, total: int) -> None:  # noqa: ARG001
-    """Render the controls for a single model definition card."""
+def _render_model_tab(model: dict, i: int) -> None:
+    """Render the full configuration for one model inside its tab."""
+    # --- Name ---
     model["name"] = st.text_input("Model name", model["name"], key=f"m_name_{i}")
 
+    st.markdown("---")
+
+    # --- Training parameters ---
+    st.subheader("Training parameters")
+    _render_training_params(model["train_config"], i)
+
+    st.markdown("---")
+
+    # --- Attack selection ---
+    st.subheader("Attacks to run")
+    st.caption("Select which membership inference attacks to include for this model.")
+    model["attack_list"] = _render_attack_selection(model.get("attack_list", []), prefix=f"m{i}")
+    if not model["attack_list"]:
+        st.warning("Select at least one attack.")
+
+    st.markdown("---")
+
+    # --- DP-SGD ---
+    st.subheader("Differential Privacy (DP-SGD)")
+    _render_dpsgd_section(model, i)
+
+
+def _render_dpsgd_section(model: dict, i: int) -> None:
+    """Render DP-SGD toggle and parameter sliders for one model."""
     model["dpsgd_enabled"] = st.toggle(
         "Enable DP-SGD training",
         value=model["dpsgd_enabled"],
@@ -175,44 +227,106 @@ def _render_model_card(model: dict, i: int, total: int) -> None:  # noqa: ARG001
         st.caption("Standard SGD/Adam training — no differential privacy applied.")
 
 
-def _render_training_params(tc: dict) -> None:
+# ---------------------------------------------------------------------------
+# Re-audit mode (attack-only reconfiguration)
+# ---------------------------------------------------------------------------
+
+def _render_reaudit(default_tc: dict) -> None:  # noqa: ARG001
+    """Render re-audit mode: only attack lists can be changed per model."""
+    models: list[dict] = st.session_state.get("models") or []
+    if not models:
+        st.warning("No trained models found in session.")
+        return
+
+    tab_labels = [f"{i + 1}. {m['name']}" for i, m in enumerate(models)]
+    tabs = st.tabs(tab_labels)
+
+    all_valid = True
+    for tab, model, i in zip(tabs, models, range(len(models))):
+        with tab:
+            st.caption(f"Model: **{model['name']}** — select attacks to re-run.")
+            model["attack_list"] = _render_attack_selection(
+                model.get("attack_list", []), prefix=f"ra{i}"
+            )
+            if not model.get("attack_list"):
+                st.warning("Select at least one attack.")
+                all_valid = False
+
+    st.markdown("---")
+    col_back, _, col_fwd = st.columns([1, 3, 1])
+    with col_back:
+        if st.button("← Back", use_container_width=True):
+            st.session_state.pop("reaudit_mode", None)
+            st.session_state.stage = 0
+            st.rerun()
+    with col_fwd:
+        if st.button(
+            "Run Attacks →", type="primary", use_container_width=True, disabled=not all_valid,
+        ):
+            st.session_state.models = models
+            st.session_state.pop("reaudit_mode", None)
+            st.session_state.stage = 3
+            st.rerun()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _assign_target_folders() -> None:
+    """Set unique target_folder names for each model based on type."""
+    std_count = dp_count = 0
+    for m in st.session_state.models:
+        if m["dpsgd_enabled"]:
+            m["target_folder"] = f"target_dpsgd_{dp_count}"
+            dp_count += 1
+        else:
+            m["target_folder"] = f"target_model_{std_count}"
+            std_count += 1
+
+
+def _render_training_params(tc: dict, model_idx: int) -> None:
     """Render training hyper-parameter inputs and mutate tc in place."""
     col1, col2, col3 = st.columns(3)
     with col1:
         tc["train"]["epochs"] = st.number_input(
-            "Epochs", min_value=1, max_value=500, value=tc["train"]["epochs"]
+            "Epochs", min_value=1, max_value=500, value=tc["train"]["epochs"],
+            key=f"tc_epochs_{model_idx}",
         )
         tc["train"]["batch_size"] = st.number_input(
-            "Batch size", min_value=8, max_value=2048, step=8, value=tc["train"]["batch_size"]
+            "Batch size", min_value=8, max_value=2048, step=8, value=tc["train"]["batch_size"],
+            key=f"tc_batch_{model_idx}",
         )
     with col2:
         tc["train"]["learning_rate"] = st.number_input(
             "Learning rate", min_value=1e-5, max_value=1.0,
             value=float(tc["train"]["learning_rate"]), format="%.5f",
+            key=f"tc_lr_{model_idx}",
         )
         tc["train"]["weight_decay"] = st.number_input(
             "Weight decay", min_value=0.0, max_value=0.1,
             value=float(tc["train"]["weight_decay"]), format="%.6f",
+            key=f"tc_wd_{model_idx}",
         )
     with col3:
         tc["data"]["dataset"] = st.selectbox(
             "Dataset", ["cifar10", "cifar100"],
             index=0 if tc["data"]["dataset"] == "cifar10" else 1,
+            key=f"tc_ds_{model_idx}",
         )
         tc["data"]["f_train"] = st.slider(
-            "Train fraction", 0.1, 0.9, float(tc["data"]["f_train"]), 0.05
+            "Train fraction", 0.1, 0.9, float(tc["data"]["f_train"]), 0.05,
+            key=f"tc_ftrain_{model_idx}",
         )
         tc["run"]["random_seed"] = st.number_input(
-            "Random seed", value=int(tc["run"].get("random_seed", 1236))
+            "Random seed", value=int(tc["run"].get("random_seed", 1236)),
+            key=f"tc_seed_{model_idx}",
         )
 
 
-def _render_attack_selection(ac: dict) -> list[dict]:
+def _render_attack_selection(current_list: list, prefix: str = "") -> list[dict]:
     """Render attack checkboxes + per-attack parameter expanders."""
-    current_list = ac.get("audit", {}).get("attack_list", [])
-    current_params: dict[str, dict] = {}
-    for entry in current_list:
-        current_params[entry["attack"]] = entry
+    current_params: dict[str, dict] = {entry["attack"]: entry for entry in current_list}
 
     selected: list[dict] = []
 
@@ -223,6 +337,7 @@ def _render_attack_selection(ac: dict) -> list[dict]:
             enabled[attack_id] = st.checkbox(
                 label.split(" — ")[0],
                 value=(attack_id in current_params),
+                key=f"{prefix}_{attack_id}_cb",
             )
 
     for attack_id, label in _AVAILABLE_ATTACKS:
@@ -237,16 +352,16 @@ def _render_attack_selection(ac: dict) -> list[dict]:
                 entry["num_shadow_models"] = c1.number_input(
                     "Shadow models", min_value=1, max_value=32,
                     value=int(prev.get("num_shadow_models", 2)),
-                    key=f"{attack_id}_nshadow",
+                    key=f"{prefix}_{attack_id}_nshadow",
                 )
                 entry["training_data_fraction"] = c2.slider(
                     "Train data fraction", 0.1, 1.0,
                     float(prev.get("training_data_fraction", 0.5)), 0.05,
-                    key=f"{attack_id}_frac",
+                    key=f"{prefix}_{attack_id}_frac",
                 )
                 entry["online"] = c3.checkbox(
                     "Online mode", value=bool(prev.get("online", False)),
-                    key=f"{attack_id}_online",
+                    key=f"{prefix}_{attack_id}_online",
                     help="Online mode trains one shadow model per audit point — slower but more accurate.",
                 )
 
@@ -255,32 +370,38 @@ def _render_attack_selection(ac: dict) -> list[dict]:
                 entry["num_shadow_models"] = c1.number_input(
                     "Shadow models", min_value=1, max_value=64,
                     value=int(prev.get("num_shadow_models", 4)),
-                    key="lira_nshadow",
+                    key=f"{prefix}_{attack_id}_nshadow",
                 )
                 entry["online"] = c2.checkbox(
-                    "Online mode", value=bool(prev.get("online", False)), key="lira_online",
+                    "Online mode", value=bool(prev.get("online", False)),
+                    key=f"{prefix}_{attack_id}_online",
                 )
 
             elif attack_id == "ramia":
                 c1, c2, c3 = st.columns(3)
                 entry["num_transforms"] = c1.number_input(
                     "Num transforms", min_value=0, max_value=32,
-                    value=int(prev.get("num_transforms", 1)), key="ramia_ntrans",
+                    value=int(prev.get("num_transforms", 1)),
+                    key=f"{prefix}_{attack_id}_ntrans",
                 )
                 entry["n_ops"] = c2.number_input(
                     "Ops per transform", min_value=0, max_value=8,
-                    value=int(prev.get("n_ops", 1)), key="ramia_nops",
+                    value=int(prev.get("n_ops", 1)),
+                    key=f"{prefix}_{attack_id}_nops",
                 )
                 entry["augment_strength"] = c3.selectbox(
                     "Augment strength", ["easy", "medium", "strong"],
-                    index=["easy", "medium", "strong"].index(prev.get("augment_strength", "strong")),
-                    key="ramia_strength",
+                    index=["easy", "medium", "strong"].index(
+                        prev.get("augment_strength", "strong")
+                    ),
+                    key=f"{prefix}_{attack_id}_strength",
                 )
 
             elif attack_id == "qmia":
                 entry["num_shadow_models"] = st.number_input(
                     "Shadow models", min_value=1, max_value=32,
-                    value=int(prev.get("num_shadow_models", 4)), key="qmia_nshadow",
+                    value=int(prev.get("num_shadow_models", 4)),
+                    key=f"{prefix}_{attack_id}_nshadow",
                 )
 
         selected.append(entry)

--- a/leakpro/ui/components/configure.py
+++ b/leakpro/ui/components/configure.py
@@ -1,0 +1,172 @@
+"""Stage 1 — Configure training parameters, select attacks, and optionally enable DP-SGD."""
+
+from __future__ import annotations
+
+import copy
+
+import streamlit as st
+import yaml
+
+
+_AVAILABLE_ATTACKS = [
+    ("rmia",  "RMIA — Relative Membership Inference Attack"),
+    ("base",  "Base — Shadow-model baseline"),
+    ("lira",  "LiRA — Likelihood Ratio Attack"),
+    ("ramia", "RaMIA — Randomised Augmentation MIA"),
+    ("qmia",  "QMIA — Quantile-based MIA"),
+]
+
+
+def render_configure() -> None:
+    """Render the configuration stage."""
+    from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
+
+    st.title("⚙️  Stage 1 — Configure")
+    st.caption("Adjust training and audit parameters, then click **Start Audit** to proceed.")
+
+    runner = LeakProRunner()
+
+    # Load defaults if not yet in session state
+    if "train_config" not in st.session_state:
+        st.session_state.train_config = runner.default_train_config()
+    if "audit_config" not in st.session_state:
+        st.session_state.audit_config = runner.default_audit_config()
+    if "dpsgd_enabled" not in st.session_state:
+        st.session_state.dpsgd_enabled = False
+    if "dpsgd_params" not in st.session_state:
+        st.session_state.dpsgd_params = {
+            "target_epsilon": 3.5,
+            "target_delta": 1e-5,
+            "max_grad_norm": 1.2,
+            "virtual_batch_size": 16,
+        }
+
+    tc = st.session_state.train_config
+    ac = st.session_state.audit_config
+
+    # ------------------------------------------------------------------ #
+    # Training parameters
+    # ------------------------------------------------------------------ #
+    st.subheader("Training parameters")
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        tc["train"]["epochs"] = st.number_input(
+            "Epochs", min_value=1, max_value=500, value=tc["train"]["epochs"]
+        )
+        tc["train"]["batch_size"] = st.number_input(
+            "Batch size", min_value=8, max_value=2048, step=8, value=tc["train"]["batch_size"]
+        )
+    with col2:
+        tc["train"]["learning_rate"] = st.number_input(
+            "Learning rate", min_value=1e-5, max_value=1.0,
+            value=float(tc["train"]["learning_rate"]), format="%.5f"
+        )
+        tc["train"]["weight_decay"] = st.number_input(
+            "Weight decay", min_value=0.0, max_value=0.1,
+            value=float(tc["train"]["weight_decay"]), format="%.6f"
+        )
+    with col3:
+        tc["data"]["dataset"] = st.selectbox(
+            "Dataset", ["cifar10", "cifar100"],
+            index=0 if tc["data"]["dataset"] == "cifar10" else 1
+        )
+        tc["data"]["f_train"] = st.slider(
+            "Train fraction", 0.1, 0.9, float(tc["data"]["f_train"]), 0.05
+        )
+        tc["run"]["random_seed"] = st.number_input(
+            "Random seed", value=int(tc["run"].get("random_seed", 1236))
+        )
+
+    st.markdown("---")
+
+    # ------------------------------------------------------------------ #
+    # Attack selection
+    # ------------------------------------------------------------------ #
+    st.subheader("Attacks to run")
+    st.caption("Select which membership inference attacks to include in the audit.")
+
+    # Build a set of currently configured attacks
+    current_attacks = {entry["attack"] for entry in ac.get("audit", {}).get("attack_list", [])}
+
+    selected_attacks: list[dict] = []
+    cols = st.columns(len(_AVAILABLE_ATTACKS))
+    for col, (attack_id, label) in zip(cols, _AVAILABLE_ATTACKS):
+        with col:
+            checked = st.checkbox(label.split(" — ")[0], value=(attack_id in current_attacks))
+            if checked:
+                selected_attacks.append({"attack": attack_id})
+
+    if not selected_attacks:
+        st.warning("Select at least one attack.")
+
+    # Update audit config with selected attacks
+    if "audit" not in ac:
+        ac["audit"] = {}
+    ac["audit"]["attack_list"] = selected_attacks
+
+    st.markdown("---")
+
+    # ------------------------------------------------------------------ #
+    # DP-SGD toggle
+    # ------------------------------------------------------------------ #
+    st.subheader("Differential Privacy (DP-SGD)")
+    dp = st.session_state.dpsgd_params
+
+    st.session_state.dpsgd_enabled = st.toggle(
+        "Enable DP-SGD training",
+        value=st.session_state.dpsgd_enabled,
+        help="Train the target model with differential privacy using Opacus. "
+             "Reduces privacy leakage at the cost of some model accuracy.",
+    )
+
+    if st.session_state.dpsgd_enabled:
+        st.info(
+            "Lower ε = stronger privacy guarantee, but lower model accuracy. "
+            "Typical range: ε ∈ [1, 10], δ = 1e-5."
+        )
+        col_dp1, col_dp2, col_dp3 = st.columns(3)
+        with col_dp1:
+            dp["target_epsilon"] = st.slider(
+                "Target ε (epsilon)", 0.5, 20.0, float(dp["target_epsilon"]), 0.5,
+                help="Privacy budget. Lower means more private."
+            )
+        with col_dp2:
+            dp["max_grad_norm"] = st.slider(
+                "Max gradient norm", 0.1, 5.0, float(dp["max_grad_norm"]), 0.1,
+                help="Gradient clipping threshold."
+            )
+        with col_dp3:
+            dp["virtual_batch_size"] = st.number_input(
+                "Virtual batch size", min_value=4, max_value=256,
+                value=int(dp["virtual_batch_size"]),
+                help="Physical batch size processed per step (memory optimisation)."
+            )
+        dp["target_delta"] = float(
+            st.number_input(
+                "Target δ (delta)", min_value=1e-8, max_value=1e-3,
+                value=float(dp["target_delta"]), format="%.2e"
+            )
+        )
+        st.session_state.dpsgd_params = dp
+    else:
+        st.caption("Standard SGD/Adam training — no differential privacy applied.")
+
+    st.markdown("---")
+
+    # ------------------------------------------------------------------ #
+    # Navigation
+    # ------------------------------------------------------------------ #
+    col_back, _, col_fwd = st.columns([1, 3, 1])
+    with col_back:
+        if st.button("← Back", use_container_width=True):
+            st.session_state.stage = 0
+            st.rerun()
+    with col_fwd:
+        disabled = len(selected_attacks) == 0
+        if st.button(
+            "Start Audit →", type="primary", use_container_width=True, disabled=disabled
+        ):
+            st.session_state.train_config = tc
+            st.session_state.audit_config = ac
+            st.session_state.stage = 2
+            st.rerun()

--- a/leakpro/ui/components/configure.py
+++ b/leakpro/ui/components/configure.py
@@ -40,10 +40,14 @@ def render_configure() -> None:
 
     tc = st.session_state.train_config
     ac = st.session_state.audit_config
+    reaudit = st.session_state.get("reaudit_mode", False)
 
-    st.subheader("Training parameters")
-    _render_training_params(tc)
-    st.markdown("---")
+    if reaudit:
+        st.info("Re-audit mode — the trained model will be reused. Only attack selection and parameters can be changed.")
+    else:
+        st.subheader("Training parameters")
+        _render_training_params(tc)
+        st.markdown("---")
 
     st.subheader("Attacks to run")
     st.caption("Select which membership inference attacks to include in the audit.")
@@ -53,23 +57,27 @@ def render_configure() -> None:
     ac.setdefault("audit", {})["attack_list"] = selected_attacks
     st.markdown("---")
 
-    st.subheader("Differential Privacy (DP-SGD)")
-    _render_dpsgd_section()
-    st.markdown("---")
+    if not reaudit:
+        st.subheader("Differential Privacy (DP-SGD)")
+        _render_dpsgd_section()
+        st.markdown("---")
 
     col_back, _, col_fwd = st.columns([1, 3, 1])
     with col_back:
         if st.button("← Back", use_container_width=True):
+            st.session_state.pop("reaudit_mode", None)
             st.session_state.stage = 0
             st.rerun()
     with col_fwd:
+        next_stage = 3 if reaudit else 2
+        label = "Run Attacks →" if reaudit else "Start Audit →"
         if st.button(
-            "Start Audit →", type="primary",
+            label, type="primary",
             use_container_width=True, disabled=(len(selected_attacks) == 0),
         ):
             st.session_state.train_config = tc
             st.session_state.audit_config = ac
-            st.session_state.stage = 2
+            st.session_state.stage = next_stage
             st.rerun()
 
 
@@ -106,14 +114,94 @@ def _render_training_params(tc: dict) -> None:
 
 
 def _render_attack_selection(ac: dict) -> list[dict]:
-    """Render the attack checkboxes and return the list of selected attack dicts."""
-    current = {e["attack"] for e in ac.get("audit", {}).get("attack_list", [])}
+    """Render attack checkboxes + per-attack parameter expanders."""
+    current_list = ac.get("audit", {}).get("attack_list", [])
+    # Build a lookup of existing params keyed by attack id (last entry wins for duplicates)
+    current_params: dict[str, dict] = {}
+    for entry in current_list:
+        current_params[entry["attack"]] = entry
+
     selected: list[dict] = []
+
+    # ── checkboxes ──────────────────────────────────────────────────────────
     cols = st.columns(len(_AVAILABLE_ATTACKS))
+    enabled: dict[str, bool] = {}
     for col, (attack_id, label) in zip(cols, _AVAILABLE_ATTACKS):
         with col:
-            if st.checkbox(label.split(" — ")[0], value=(attack_id in current)):
-                selected.append({"attack": attack_id})
+            enabled[attack_id] = st.checkbox(
+                label.split(" — ")[0],
+                value=(attack_id in current_params),
+            )
+
+    # ── per-attack parameter expanders ──────────────────────────────────────
+    for attack_id, label in _AVAILABLE_ATTACKS:
+        if not enabled[attack_id]:
+            continue
+        prev = current_params.get(attack_id, {})
+        entry: dict = {"attack": attack_id}
+
+        with st.expander(f"⚙ {label.split(' — ')[0]} parameters", expanded=False):
+            if attack_id in ("rmia", "base"):
+                c1, c2, c3 = st.columns(3)
+                entry["num_shadow_models"] = c1.number_input(
+                    "Shadow models", min_value=1, max_value=32,
+                    value=int(prev.get("num_shadow_models", 2)),
+                    key=f"{attack_id}_nshadow",
+                )
+                entry["training_data_fraction"] = c2.slider(
+                    "Train data fraction", 0.1, 1.0,
+                    float(prev.get("training_data_fraction", 0.5)), 0.05,
+                    key=f"{attack_id}_frac",
+                )
+                entry["online"] = c3.checkbox(
+                    "Online mode",
+                    value=bool(prev.get("online", False)),
+                    key=f"{attack_id}_online",
+                    help="Online RMIA/BASE trains one shadow model per audit point — much slower but more accurate.",
+                )
+
+            elif attack_id == "lira":
+                c1, c2 = st.columns(2)
+                entry["num_shadow_models"] = c1.number_input(
+                    "Shadow models", min_value=1, max_value=64,
+                    value=int(prev.get("num_shadow_models", 4)),
+                    key="lira_nshadow",
+                )
+                entry["online"] = c2.checkbox(
+                    "Online mode", value=bool(prev.get("online", False)),
+                    key="lira_online",
+                )
+
+            elif attack_id == "ramia":
+                c1, c2, c3 = st.columns(3)
+                entry["num_transforms"] = c1.number_input(
+                    "Num transforms", min_value=0, max_value=32,
+                    value=int(prev.get("num_transforms", 1)),
+                    key="ramia_ntrans",
+                )
+                entry["n_ops"] = c2.number_input(
+                    "Ops per transform", min_value=0, max_value=8,
+                    value=int(prev.get("n_ops", 1)),
+                    key="ramia_nops",
+                )
+                entry["augment_strength"] = c3.selectbox(
+                    "Augment strength",
+                    ["easy", "medium", "strong"],
+                    index=["easy", "medium", "strong"].index(
+                        prev.get("augment_strength", "strong")
+                    ),
+                    key="ramia_strength",
+                )
+
+            elif attack_id == "qmia":
+                entry["num_shadow_models"] = st.number_input(
+                    "Shadow models", min_value=1, max_value=32,
+                    value=int(prev.get("num_shadow_models", 4)),
+                    key="qmia_nshadow",
+                )
+
+        selected.append(entry)
+
     return selected
 
 

--- a/leakpro/ui/components/overview.py
+++ b/leakpro/ui/components/overview.py
@@ -69,7 +69,8 @@ def render_overview() -> None:
     with col_resume:
         st.markdown("### Resume previous run")
         if has_results:
-            st.caption(f"Previous results found in `{resume_dir.relative_to(Path.cwd()) if resume_dir.is_relative_to(Path.cwd()) else resume_dir}`.")
+            disp_path = resume_dir.relative_to(Path.cwd()) if resume_dir.is_relative_to(Path.cwd()) else resume_dir
+            st.caption(f"Previous results found in `{disp_path}`.")
             if st.button("Load Existing Results", use_container_width=True):
                 from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
                 results = LeakProRunner.load_audit_results_from_disk(str(resume_dir))

--- a/leakpro/ui/components/overview.py
+++ b/leakpro/ui/components/overview.py
@@ -1,0 +1,95 @@
+"""Stage 0 — Overview / landing page."""
+
+from pathlib import Path
+
+import streamlit as st
+
+_CIFAR_OUTPUT_DIR = Path(__file__).parent.parent.parent.parent / "examples" / "mia" / "cifar"
+
+
+def render_overview() -> None:
+    """Render the landing page with intro text, pipeline diagram, and entry buttons."""
+
+    st.title("LeakPro — Privacy Auditor")
+    st.markdown(
+        """
+        **What is this tool?**
+
+        LeakPro helps you measure how much private information your machine learning model leaks.
+        Even after training is finished, an attacker may be able to determine which data points
+        were used to train your model — a threat known as a **Membership Inference Attack (MIA)**.
+
+        This tool guides you through the full privacy audit journey:
+        """
+    )
+
+    # Pipeline diagram using columns
+    col1, col2, col3, col4, col5 = st.columns(5)
+    steps = [
+        ("⚙️", "Configure", "Set training parameters and select attacks"),
+        ("🏋️", "Train", "Train target model (standard or DP-SGD)"),
+        ("🔍", "Audit", "Run membership inference attacks"),
+        ("📊", "Explore", "Visualise leakage, sensitive records, and risk scores"),
+    ]
+    for col, (icon, title, desc) in zip([col2, col3, col4, col5], steps):
+        with col:
+            st.markdown(
+                f"""
+                <div style="text-align:center; padding:12px; border:1px solid #444;
+                            border-radius:8px; min-height:100px;">
+                    <div style="font-size:28px">{icon}</div>
+                    <strong>{title}</strong><br/>
+                    <small style="color:#aaa">{desc}</small>
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
+
+    st.markdown("---")
+
+    # Check for existing results to offer resume
+    resume_dir = _CIFAR_OUTPUT_DIR / "leakpro_output"
+    has_results = (resume_dir / "data_objects").exists() and any(
+        (resume_dir / "data_objects").glob("*.json")
+    )
+
+    col_start, col_resume = st.columns([1, 1])
+
+    with col_start:
+        st.markdown("### Start a new audit")
+        st.caption("Configure, train a model from scratch, and run attacks.")
+        if st.button("Start New Audit", type="primary", use_container_width=True):
+            # Reset any previous run state
+            for key in ["data_result", "train_result_dict", "audit_results",
+                        "dpsgd_enabled", "dpsgd_params", "train_config", "audit_config"]:
+                st.session_state.pop(key, None)
+            st.session_state.stage = 1
+            st.rerun()
+
+    with col_resume:
+        st.markdown("### Resume previous run")
+        if has_results:
+            st.caption(f"Previous results found in `{resume_dir.relative_to(Path.cwd()) if resume_dir.is_relative_to(Path.cwd()) else resume_dir}`.")
+            if st.button("Load Existing Results", use_container_width=True):
+                from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
+                results = LeakProRunner.load_audit_results_from_disk(str(resume_dir))
+                if results:
+                    st.session_state.audit_results = results
+                    st.session_state.stage = 4
+                    st.rerun()
+                else:
+                    st.error("Could not load results from disk.")
+        else:
+            st.caption("No previous results detected.")
+            st.button("Load Existing Results", disabled=True, use_container_width=True)
+
+    st.markdown("---")
+    st.markdown(
+        """
+        <small style="color:#888">
+        LeakPro is a privacy auditing framework by <a href="https://github.com/aidotse/LeakPro" target="_blank">AI Sweden</a>.
+        MVP targets CIFAR-10/100 with Membership Inference Attacks.
+        </small>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/leakpro/ui/components/overview.py
+++ b/leakpro/ui/components/overview.py
@@ -62,18 +62,32 @@ def render_overview() -> None:
         (resume_dir / "data_objects").glob("*.json")
     )
 
-    col_start, col_resume = st.columns([1, 1])
+    has_trained_model = bool(st.session_state.get("train_result_dict"))
+
+    col_start, col_reaudit, col_resume = st.columns([1, 1, 1])
 
     with col_start:
         st.markdown("### Start a new audit")
         st.caption("Configure, train a model from scratch, and run attacks.")
         if st.button("Start New Audit", type="primary", use_container_width=True):
-            # Reset any previous run state
             for key in ["data_result", "train_result_dict", "audit_results",
                         "dpsgd_enabled", "dpsgd_params", "train_config", "audit_config"]:
                 st.session_state.pop(key, None)
             st.session_state.stage = 1
             st.rerun()
+
+    with col_reaudit:
+        st.markdown("### Re-audit same model")
+        st.caption("Keep the trained model, change attacks or parameters.")
+        if has_trained_model:
+            if st.button("Re-audit (keep model)", use_container_width=True):
+                st.session_state.pop("audit_results", None)
+                st.session_state["reaudit_mode"] = True
+                st.session_state.stage = 1
+                st.rerun()
+        else:
+            st.caption("No trained model in session.")
+            st.button("Re-audit (keep model)", disabled=True, use_container_width=True)
 
     with col_resume:
         st.markdown("### Resume previous run")

--- a/leakpro/ui/components/overview.py
+++ b/leakpro/ui/components/overview.py
@@ -47,8 +47,17 @@ def render_overview() -> None:
 
     st.markdown("---")
 
-    # Check for existing results to offer resume
-    resume_dir = _CIFAR_OUTPUT_DIR / "leakpro_output"
+    # Check for existing results to offer resume.
+    # Derive output_dir from session audit config or the default audit.yaml.
+    audit_cfg = st.session_state.get("audit_config")
+    if audit_cfg is None:
+        try:
+            from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
+            audit_cfg = LeakProRunner.default_audit_config()
+        except Exception:
+            audit_cfg = {}
+    _output_dir_rel = audit_cfg.get("audit", {}).get("output_dir", "./leakpro_output")
+    resume_dir = (_CIFAR_OUTPUT_DIR / _output_dir_rel).resolve()
     has_results = (resume_dir / "data_objects").exists() and any(
         (resume_dir / "data_objects").glob("*.json")
     )

--- a/leakpro/ui/components/overview.py
+++ b/leakpro/ui/components/overview.py
@@ -62,14 +62,12 @@ def _render_pipeline_diagram() -> None:
 
 
 def _detect_existing_results() -> tuple:
-    """Return (resume_dir, has_results) based on session audit config."""
-    audit_cfg = st.session_state.get("audit_config")
-    if audit_cfg is None:
-        try:
-            from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
-            audit_cfg = LeakProRunner.default_audit_config()
-        except Exception:  # noqa: BLE001
-            audit_cfg = {}
+    """Return (resume_dir, has_results) based on default audit config."""
+    try:
+        from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
+        audit_cfg = LeakProRunner.default_audit_config()
+    except Exception:  # noqa: BLE001
+        audit_cfg = {}
     output_dir_rel = audit_cfg.get("audit", {}).get("output_dir", "./leakpro_output")
     resume_dir = (_CIFAR_OUTPUT_DIR / output_dir_rel).resolve()
     has_results = (resume_dir / "data_objects").exists() and any(
@@ -89,7 +87,7 @@ def _render_action_buttons(resume_dir: Path, has_results: bool) -> None:
         st.markdown("### Start a new audit")
         st.caption("Configure, train models from scratch, and run attacks.")
         if st.button("Start New Audit", type="primary", use_container_width=True):
-            for key in ["data_result", "train_config", "audit_config", "models"]:
+            for key in ["data_result", "models", "config_phase"]:
                 st.session_state.pop(key, None)
             st.session_state.stage = 1
             st.rerun()

--- a/leakpro/ui/components/overview.py
+++ b/leakpro/ui/components/overview.py
@@ -9,7 +9,6 @@ _CIFAR_OUTPUT_DIR = Path(__file__).parent.parent.parent.parent / "examples" / "m
 
 def render_overview() -> None:
     """Render the landing page with intro text, pipeline diagram, and entry buttons."""
-
     st.title("LeakPro — Privacy Auditor")
     st.markdown(
         """
@@ -22,9 +21,25 @@ def render_overview() -> None:
         This tool guides you through the full privacy audit journey:
         """
     )
+    _render_pipeline_diagram()
+    st.markdown("---")
+    resume_dir, has_results = _detect_existing_results()
+    _render_action_buttons(resume_dir, has_results)
+    st.markdown("---")
+    st.markdown(
+        """
+        <small style="color:#888">
+        LeakPro is a privacy auditing framework by <a href="https://github.com/aidotse/LeakPro" target="_blank">AI Sweden</a>.
+        MVP targets CIFAR-10/100 with Membership Inference Attacks.
+        </small>
+        """,
+        unsafe_allow_html=True,
+    )
 
-    # Pipeline diagram using columns
-    col1, col2, col3, col4, col5 = st.columns(5)
+
+def _render_pipeline_diagram() -> None:
+    """Render the 4-step pipeline overview cards."""
+    _, col2, col3, col4, col5 = st.columns(5)
     steps = [
         ("⚙️", "Configure", "Set training parameters and select attacks"),
         ("🏋️", "Train", "Train target model (standard or DP-SGD)"),
@@ -45,25 +60,27 @@ def render_overview() -> None:
                 unsafe_allow_html=True,
             )
 
-    st.markdown("---")
 
-    # Check for existing results to offer resume.
-    # Derive output_dir from session audit config or the default audit.yaml.
+def _detect_existing_results() -> tuple:
+    """Return (resume_dir, has_results) based on session audit config."""
     audit_cfg = st.session_state.get("audit_config")
     if audit_cfg is None:
         try:
             from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
             audit_cfg = LeakProRunner.default_audit_config()
-        except Exception:
+        except Exception:  # noqa: BLE001
             audit_cfg = {}
-    _output_dir_rel = audit_cfg.get("audit", {}).get("output_dir", "./leakpro_output")
-    resume_dir = (_CIFAR_OUTPUT_DIR / _output_dir_rel).resolve()
+    output_dir_rel = audit_cfg.get("audit", {}).get("output_dir", "./leakpro_output")
+    resume_dir = (_CIFAR_OUTPUT_DIR / output_dir_rel).resolve()
     has_results = (resume_dir / "data_objects").exists() and any(
         (resume_dir / "data_objects").glob("*.json")
     )
+    return resume_dir, has_results
 
+
+def _render_action_buttons(resume_dir: Path, has_results: bool) -> None:
+    """Render Start / Re-audit / Resume buttons."""
     has_trained_model = bool(st.session_state.get("train_result_dict"))
-
     col_start, col_reaudit, col_resume = st.columns([1, 1, 1])
 
     with col_start:
@@ -106,14 +123,3 @@ def render_overview() -> None:
         else:
             st.caption("No previous results detected.")
             st.button("Load Existing Results", disabled=True, use_container_width=True)
-
-    st.markdown("---")
-    st.markdown(
-        """
-        <small style="color:#888">
-        LeakPro is a privacy auditing framework by <a href="https://github.com/aidotse/LeakPro" target="_blank">AI Sweden</a>.
-        MVP targets CIFAR-10/100 with Membership Inference Attacks.
-        </small>
-        """,
-        unsafe_allow_html=True,
-    )

--- a/leakpro/ui/components/overview.py
+++ b/leakpro/ui/components/overview.py
@@ -80,31 +80,33 @@ def _detect_existing_results() -> tuple:
 
 def _render_action_buttons(resume_dir: Path, has_results: bool) -> None:
     """Render Start / Re-audit / Resume buttons."""
-    has_trained_model = bool(st.session_state.get("train_result_dict"))
+    has_trained_models = any(
+        m.get("train_result_dict") for m in st.session_state.get("models", [])
+    )
     col_start, col_reaudit, col_resume = st.columns([1, 1, 1])
 
     with col_start:
         st.markdown("### Start a new audit")
-        st.caption("Configure, train a model from scratch, and run attacks.")
+        st.caption("Configure, train models from scratch, and run attacks.")
         if st.button("Start New Audit", type="primary", use_container_width=True):
-            for key in ["data_result", "train_result_dict", "audit_results",
-                        "dpsgd_enabled", "dpsgd_params", "train_config", "audit_config"]:
+            for key in ["data_result", "train_config", "audit_config", "models"]:
                 st.session_state.pop(key, None)
             st.session_state.stage = 1
             st.rerun()
 
     with col_reaudit:
-        st.markdown("### Re-audit same model")
-        st.caption("Keep the trained model, change attacks or parameters.")
-        if has_trained_model:
-            if st.button("Re-audit (keep model)", use_container_width=True):
-                st.session_state.pop("audit_results", None)
+        st.markdown("### Re-audit same models")
+        st.caption("Keep trained models, change attacks or parameters.")
+        if has_trained_models:
+            if st.button("Re-audit (keep models)", use_container_width=True):
+                for m in st.session_state.get("models", []):
+                    m["audit_results"] = None
                 st.session_state["reaudit_mode"] = True
                 st.session_state.stage = 1
                 st.rerun()
         else:
-            st.caption("No trained model in session.")
-            st.button("Re-audit (keep model)", disabled=True, use_container_width=True)
+            st.caption("No trained models in session.")
+            st.button("Re-audit (keep models)", disabled=True, use_container_width=True)
 
     with col_resume:
         st.markdown("### Resume previous run")
@@ -115,7 +117,14 @@ def _render_action_buttons(resume_dir: Path, has_results: bool) -> None:
                 from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
                 results = LeakProRunner.load_audit_results_from_disk(str(resume_dir))
                 if results:
-                    st.session_state.audit_results = results
+                    st.session_state.models = [{
+                        "name": "Loaded",
+                        "dpsgd_enabled": False,
+                        "dpsgd_params": None,
+                        "target_folder": "",
+                        "train_result_dict": None,
+                        "audit_results": results,
+                    }]
                     st.session_state.stage = 4
                     st.rerun()
                 else:

--- a/leakpro/ui/components/results/__init__.py
+++ b/leakpro/ui/components/results/__init__.py
@@ -1,0 +1,1 @@
+"""Results visualisation components for Stage 4."""

--- a/leakpro/ui/components/results/histograms.py
+++ b/leakpro/ui/components/results/histograms.py
@@ -88,5 +88,9 @@ def render_histograms(results: list) -> None:
     c1.metric("TPR", f"{tpr:.4f}", help="True positive rate at this threshold.")
     c2.metric("FPR", f"{fpr:.4f}", help="False positive rate at this threshold.")
     c3.metric("Accuracy", f"{acc:.4f}")
-    c4.metric("TP / FN", f"{tp} / {fn}")
-    c5.metric("FP / TN", f"{fp} / {tn}")
+    with c4:
+        st.markdown("**TP / FN**")
+        st.markdown(f"{tp} / {fn}")
+    with c5:
+        st.markdown("**FP / TN**")
+        st.markdown(f"{fp} / {tn}")

--- a/leakpro/ui/components/results/histograms.py
+++ b/leakpro/ui/components/results/histograms.py
@@ -7,22 +7,34 @@ import plotly.graph_objects as go
 import streamlit as st
 
 
-def render_histograms(results: list) -> None:
-    """Render signal histogram plots for each attack result."""
-    hist_results = [r for r in results if r.signal_values is not None]
-
-    if not hist_results:
+def render_histograms(models: list) -> None:
+    """Render signal histogram plots with a model and attack selector."""
+    audited = [m for m in models if m.get("audit_results")]
+    if not audited:
         st.info("No signal-value data available for histogram visualisation.")
         return
 
+    if len(audited) > 1:
+        model_name = st.selectbox(
+            "Select model", [m["name"] for m in audited], key="hist_model_select"
+        )
+        model = next(m for m in audited if m["name"] == model_name)
+    else:
+        model = audited[0]
+
+    hist_results = [r for r in (model.get("audit_results") or []) if r.signal_values is not None]
+    if not hist_results:
+        st.info(f"No signal-value data available for **{model['name']}**.")
+        return
+
     st.caption(
-        "A larger separation between the **member** (blue) and **non-member** (red) "
+        f"Model: **{model['name']}** — "
+        "a larger separation between the **member** (blue) and **non-member** (red) "
         "distributions indicates stronger privacy leakage."
     )
 
-    # Attack picker
     attack_names = [r.result_name for r in hist_results]
-    selected_name = st.selectbox("Select attack", attack_names)
+    selected_name = st.selectbox("Select attack", attack_names, key="hist_attack_select")
     result = next(r for r in hist_results if r.result_name == selected_name)
 
     signal = np.asarray(result.signal_values).ravel()
@@ -30,7 +42,6 @@ def render_histograms(results: list) -> None:
     members = signal[labels == 1]
     non_members = signal[labels == 0]
 
-    # ---- Histogram ------------------------------------------------------
     fig = go.Figure()
     fig.add_trace(go.Histogram(
         x=members,
@@ -58,7 +69,6 @@ def render_histograms(results: list) -> None:
     )
     st.plotly_chart(fig, use_container_width=True)
 
-    # ---- Interactive threshold slider -----------------------------------
     st.markdown("##### Decision threshold explorer")
     st.caption("Move the threshold to see how TP/FP/TN/FN change.")
 
@@ -69,6 +79,7 @@ def render_histograms(results: list) -> None:
     threshold = st.slider(
         "Decision threshold", min_value=score_min, max_value=score_max,
         value=default_threshold, step=(score_max - score_min) / 200,
+        key="hist_threshold_slider",
     )
 
     preds = (signal >= threshold).astype(int)
@@ -88,9 +99,5 @@ def render_histograms(results: list) -> None:
     c1.metric("TPR", f"{tpr:.4f}", help="True positive rate at this threshold.")
     c2.metric("FPR", f"{fpr:.4f}", help="False positive rate at this threshold.")
     c3.metric("Accuracy", f"{acc:.4f}")
-    with c4:
-        st.markdown("**TP / FN**")
-        st.markdown(f"{tp} / {fn}")
-    with c5:
-        st.markdown("**FP / TN**")
-        st.markdown(f"{fp} / {tn}")
+    c4.metric("TP / FN", f"{tp} / {fn}")
+    c5.metric("FP / TN", f"{fp} / {tn}")

--- a/leakpro/ui/components/results/histograms.py
+++ b/leakpro/ui/components/results/histograms.py
@@ -52,9 +52,9 @@ def render_histograms(results: list) -> None:
         barmode="overlay",
         xaxis_title="Attack signal score",
         yaxis_title="Count",
-        legend=dict(orientation="h", yanchor="bottom", y=-0.3, xanchor="center", x=0.5),
+        legend={"orientation": "h", "yanchor": "bottom", "y": -0.3, "xanchor": "center", "x": 0.5},
         height=400,
-        margin=dict(t=20),
+        margin={"t": 20},
     )
     st.plotly_chart(fig, use_container_width=True)
 

--- a/leakpro/ui/components/results/histograms.py
+++ b/leakpro/ui/components/results/histograms.py
@@ -1,0 +1,92 @@
+"""Stage 4 — Signal Histograms tab: member vs non-member score distributions."""
+
+from __future__ import annotations
+
+import numpy as np
+import plotly.graph_objects as go
+import streamlit as st
+
+
+def render_histograms(results: list) -> None:
+    """Render signal histogram plots for each attack result."""
+    hist_results = [r for r in results if r.signal_values is not None]
+
+    if not hist_results:
+        st.info("No signal-value data available for histogram visualisation.")
+        return
+
+    st.caption(
+        "A larger separation between the **member** (blue) and **non-member** (red) "
+        "distributions indicates stronger privacy leakage."
+    )
+
+    # Attack picker
+    attack_names = [r.result_name for r in hist_results]
+    selected_name = st.selectbox("Select attack", attack_names)
+    result = next(r for r in hist_results if r.result_name == selected_name)
+
+    signal = np.asarray(result.signal_values).ravel()
+    labels = np.asarray(result.true).ravel()
+    members = signal[labels == 1]
+    non_members = signal[labels == 0]
+
+    # ---- Histogram ------------------------------------------------------
+    fig = go.Figure()
+    fig.add_trace(go.Histogram(
+        x=members,
+        name="Members (training data)",
+        nbinsx=100,
+        opacity=0.6,
+        marker_color="#4C9BE8",
+        hovertemplate="Score: %{x:.4f}<br>Count: %{y}<extra>Members</extra>",
+    ))
+    fig.add_trace(go.Histogram(
+        x=non_members,
+        name="Non-members",
+        nbinsx=100,
+        opacity=0.6,
+        marker_color="#E84C4C",
+        hovertemplate="Score: %{x:.4f}<br>Count: %{y}<extra>Non-members</extra>",
+    ))
+    fig.update_layout(
+        barmode="overlay",
+        xaxis_title="Attack signal score",
+        yaxis_title="Count",
+        legend=dict(orientation="h", yanchor="bottom", y=-0.3, xanchor="center", x=0.5),
+        height=400,
+        margin=dict(t=20),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+    # ---- Interactive threshold slider -----------------------------------
+    st.markdown("##### Decision threshold explorer")
+    st.caption("Move the threshold to see how TP/FP/TN/FN change.")
+
+    score_min = float(signal.min())
+    score_max = float(signal.max())
+    default_threshold = float(np.median(signal))
+
+    threshold = st.slider(
+        "Decision threshold", min_value=score_min, max_value=score_max,
+        value=default_threshold, step=(score_max - score_min) / 200,
+    )
+
+    preds = (signal >= threshold).astype(int)
+    tp = int(np.sum((preds == 1) & (labels == 1)))
+    fp = int(np.sum((preds == 1) & (labels == 0)))
+    tn = int(np.sum((preds == 0) & (labels == 0)))
+    fn = int(np.sum((preds == 0) & (labels == 1)))
+
+    total_pos = tp + fn
+    total_neg = tn + fp
+
+    tpr = tp / total_pos if total_pos else 0
+    fpr = fp / total_neg if total_neg else 0
+    acc = (tp + tn) / len(labels) if len(labels) else 0
+
+    c1, c2, c3, c4, c5 = st.columns(5)
+    c1.metric("TPR", f"{tpr:.4f}", help="True positive rate at this threshold.")
+    c2.metric("FPR", f"{fpr:.4f}", help="False positive rate at this threshold.")
+    c3.metric("Accuracy", f"{acc:.4f}")
+    c4.metric("TP / FN", f"{tp} / {fn}")
+    c5.metric("FP / TN", f"{fp} / {tn}")

--- a/leakpro/ui/components/results/roc_chart.py
+++ b/leakpro/ui/components/results/roc_chart.py
@@ -1,4 +1,4 @@
-"""Stage 4 — ROC Analysis tab: interactive Plotly ROC curves for all attacks."""
+"""Stage 4 — ROC Analysis tab: interactive Plotly ROC curves for all models and attacks."""
 
 from __future__ import annotations
 
@@ -7,69 +7,76 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
-_PALETTE = [
-    "#4C9BE8", "#E84C4C", "#27AE60", "#F5A623",
-    "#9B59B6", "#1ABC9C", "#E67E22", "#3498DB",
+# One base colour per model; attacks within a model share the same hue family
+_MODEL_COLOURS = [
+    "#4C9BE8",  # blue
+    "#E84C4C",  # red
+    "#27AE60",  # green
+    "#F5A623",  # orange
+    "#9B59B6",  # purple
 ]
 
 
-def render_roc(results: list) -> None:
-    """Render the interactive ROC curve tab."""
-    roc_results = [r for r in results if r.roc_auc is not None and r.fpr is not None]
+def render_roc(models: list) -> None:
+    """Render the interactive ROC curve tab with per-model colour coding."""
+    roc_entries = [
+        (mi, m, r)
+        for mi, m in enumerate(models)
+        for r in (m.get("audit_results") or [])
+        if r.roc_auc is not None and r.fpr is not None
+    ]
 
-    if not roc_results:
+    if not roc_entries:
         st.info("No ROC-capable results available (attacks with full score distribution required).")
         return
 
     st.caption(
         "Log-log scale — hover to inspect TPR/FPR values. "
+        "Curves are colour-coded by model. "
         "The random-guess baseline (AUC = 0.5) is the dashed diagonal."
     )
 
-    # Attack selector
-    attack_labels = [
-        f"{r.result_name} (AUC={r.roc_auc:.4f})" for r in roc_results
-    ]
-    selected = st.multiselect(
-        "Highlight attacks", options=attack_labels, default=attack_labels,
-        help="Deselect attacks to hide them from the chart."
-    )
-    selected_set = set(selected)
+    model_names = list({m["name"] for _, m, _ in roc_entries})
+    if len(model_names) > 1:
+        selected_model_names = set(st.multiselect(
+            "Show models", options=model_names, default=model_names,
+            key="roc_model_select",
+        ))
+    else:
+        selected_model_names = set(model_names)
 
     fig = go.Figure()
 
-    for i, r in enumerate(roc_results):
-        label = f"{r.result_name} (AUC={r.roc_auc:.4f})"
-        visible = label in selected_set
-        colour = _PALETTE[i % len(_PALETTE)]
+    for mi, m, r in roc_entries:
+        if m["name"] not in selected_model_names:
+            continue
 
-        fpr = np.asarray(r.fpr)
-        tpr = np.asarray(r.tpr)
+        colour = _MODEL_COLOURS[mi % len(_MODEL_COLOURS)]
+        label = f"{m['name']} / {r.result_name} (AUC={r.roc_auc:.4f})"
 
-        # Shaded fill under curve
+        fpr_arr = np.asarray(r.fpr)
+        tpr_arr = np.asarray(r.tpr)
+
         fig.add_trace(go.Scatter(
-            x=fpr, y=tpr,
+            x=fpr_arr, y=tpr_arr,
             fill="tozeroy",
-            fillcolor=f"rgba{tuple(int(colour.lstrip('#')[j:j+2], 16) for j in (0, 2, 4)) + (0.08,)}",
+            fillcolor=f"rgba{tuple(int(colour.lstrip('#')[j:j+2], 16) for j in (0, 2, 4)) + (0.07,)}",
             line={"width": 0},
             showlegend=False,
             hoverinfo="skip",
-            visible=visible or "legendonly",
         ))
 
         fig.add_trace(go.Scatter(
-            x=fpr, y=tpr,
+            x=fpr_arr, y=tpr_arr,
             mode="lines",
             name=label,
             line={"color": colour, "width": 2},
             hovertemplate=(
-                f"<b>{r.result_name}</b><br>"
+                f"<b>{label}</b><br>"
                 "FPR: %{x:.5f}<br>TPR: %{y:.5f}<extra></extra>"
             ),
-            visible=True if visible else "legendonly",
         ))
 
-    # Random guess baseline
     baseline = np.linspace(1e-5, 1)
     fig.add_trace(go.Scatter(
         x=baseline, y=baseline,
@@ -82,20 +89,22 @@ def render_roc(results: list) -> None:
     fig.update_layout(
         xaxis={"type": "log", "title": "False Positive Rate (FPR)", "range": [-5, 0]},
         yaxis={"type": "log", "title": "True Positive Rate (TPR)", "range": [-5, 0]},
-        legend={"orientation": "h", "yanchor": "bottom", "y": -0.35, "xanchor": "center", "x": 0.5},
-        height=520,
-        margin={"t": 20, "b": 120},
-        hovermode="x unified",
+        legend={"orientation": "h", "yanchor": "bottom", "y": -0.45, "xanchor": "center", "x": 0.5},
+        height=540,
+        margin={"t": 20, "b": 140},
+        hovermode="closest",
     )
 
     st.plotly_chart(fig, use_container_width=True)
 
-    # Metrics table
     st.markdown("##### TPR at fixed FPR thresholds")
     rows = []
-    for r in roc_results:
+    for _, m, r in roc_entries:
+        if m["name"] not in selected_model_names:
+            continue
         fpr_table = r.fixed_fpr_table or {}
         rows.append({
+            "Model": m["name"],
             "Attack": r.result_name,
             "AUC": f"{r.roc_auc:.4f}",
             "TPR@10%FPR": f"{fpr_table.get('TPR@10%FPR', 0):.4f}",

--- a/leakpro/ui/components/results/roc_chart.py
+++ b/leakpro/ui/components/results/roc_chart.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
-
 
 _PALETTE = [
     "#4C9BE8", "#E84C4C", "#27AE60", "#F5A623",
@@ -51,7 +51,7 @@ def render_roc(results: list) -> None:
             x=fpr, y=tpr,
             fill="tozeroy",
             fillcolor=f"rgba{tuple(int(colour.lstrip('#')[j:j+2], 16) for j in (0, 2, 4)) + (0.08,)}",
-            line=dict(width=0),
+            line={"width": 0},
             showlegend=False,
             hoverinfo="skip",
             visible=visible or "legendonly",
@@ -61,7 +61,7 @@ def render_roc(results: list) -> None:
             x=fpr, y=tpr,
             mode="lines",
             name=label,
-            line=dict(color=colour, width=2),
+            line={"color": colour, "width": 2},
             hovertemplate=(
                 f"<b>{r.result_name}</b><br>"
                 "FPR: %{x:.5f}<br>TPR: %{y:.5f}<extra></extra>"
@@ -75,16 +75,16 @@ def render_roc(results: list) -> None:
         x=baseline, y=baseline,
         mode="lines",
         name="Random guess (AUC=0.5)",
-        line=dict(dash="dash", color="#888888", width=1),
+        line={"dash": "dash", "color": "#888888", "width": 1},
         hoverinfo="skip",
     ))
 
     fig.update_layout(
-        xaxis=dict(type="log", title="False Positive Rate (FPR)", range=[-5, 0]),
-        yaxis=dict(type="log", title="True Positive Rate (TPR)", range=[-5, 0]),
-        legend=dict(orientation="h", yanchor="bottom", y=-0.35, xanchor="center", x=0.5),
+        xaxis={"type": "log", "title": "False Positive Rate (FPR)", "range": [-5, 0]},
+        yaxis={"type": "log", "title": "True Positive Rate (TPR)", "range": [-5, 0]},
+        legend={"orientation": "h", "yanchor": "bottom", "y": -0.35, "xanchor": "center", "x": 0.5},
         height=520,
-        margin=dict(t=20, b=120),
+        margin={"t": 20, "b": 120},
         hovermode="x unified",
     )
 
@@ -103,5 +103,4 @@ def render_roc(results: list) -> None:
             "TPR@0.1%FPR": f"{fpr_table.get('TPR@0.1%FPR', 0):.4f}",
             "TPR@0%FPR":  f"{fpr_table.get('TPR@0%FPR', 0):.4f}",
         })
-    import pandas as pd  # noqa: PLC0415
     st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)

--- a/leakpro/ui/components/results/roc_chart.py
+++ b/leakpro/ui/components/results/roc_chart.py
@@ -1,0 +1,107 @@
+"""Stage 4 — ROC Analysis tab: interactive Plotly ROC curves for all attacks."""
+
+from __future__ import annotations
+
+import numpy as np
+import plotly.graph_objects as go
+import streamlit as st
+
+
+_PALETTE = [
+    "#4C9BE8", "#E84C4C", "#27AE60", "#F5A623",
+    "#9B59B6", "#1ABC9C", "#E67E22", "#3498DB",
+]
+
+
+def render_roc(results: list) -> None:
+    """Render the interactive ROC curve tab."""
+    roc_results = [r for r in results if r.roc_auc is not None and r.fpr is not None]
+
+    if not roc_results:
+        st.info("No ROC-capable results available (attacks with full score distribution required).")
+        return
+
+    st.caption(
+        "Log-log scale — hover to inspect TPR/FPR values. "
+        "The random-guess baseline (AUC = 0.5) is the dashed diagonal."
+    )
+
+    # Attack selector
+    attack_labels = [
+        f"{r.result_name} (AUC={r.roc_auc:.4f})" for r in roc_results
+    ]
+    selected = st.multiselect(
+        "Highlight attacks", options=attack_labels, default=attack_labels,
+        help="Deselect attacks to hide them from the chart."
+    )
+    selected_set = set(selected)
+
+    fig = go.Figure()
+
+    for i, r in enumerate(roc_results):
+        label = f"{r.result_name} (AUC={r.roc_auc:.4f})"
+        visible = label in selected_set
+        colour = _PALETTE[i % len(_PALETTE)]
+
+        fpr = np.asarray(r.fpr)
+        tpr = np.asarray(r.tpr)
+
+        # Shaded fill under curve
+        fig.add_trace(go.Scatter(
+            x=fpr, y=tpr,
+            fill="tozeroy",
+            fillcolor=f"rgba{tuple(int(colour.lstrip('#')[j:j+2], 16) for j in (0, 2, 4)) + (0.08,)}",
+            line=dict(width=0),
+            showlegend=False,
+            hoverinfo="skip",
+            visible=visible or "legendonly",
+        ))
+
+        fig.add_trace(go.Scatter(
+            x=fpr, y=tpr,
+            mode="lines",
+            name=label,
+            line=dict(color=colour, width=2),
+            hovertemplate=(
+                f"<b>{r.result_name}</b><br>"
+                "FPR: %{x:.5f}<br>TPR: %{y:.5f}<extra></extra>"
+            ),
+            visible=True if visible else "legendonly",
+        ))
+
+    # Random guess baseline
+    baseline = np.linspace(1e-5, 1)
+    fig.add_trace(go.Scatter(
+        x=baseline, y=baseline,
+        mode="lines",
+        name="Random guess (AUC=0.5)",
+        line=dict(dash="dash", color="#888888", width=1),
+        hoverinfo="skip",
+    ))
+
+    fig.update_layout(
+        xaxis=dict(type="log", title="False Positive Rate (FPR)", range=[-5, 0]),
+        yaxis=dict(type="log", title="True Positive Rate (TPR)", range=[-5, 0]),
+        legend=dict(orientation="h", yanchor="bottom", y=-0.35, xanchor="center", x=0.5),
+        height=520,
+        margin=dict(t=20, b=120),
+        hovermode="x unified",
+    )
+
+    st.plotly_chart(fig, use_container_width=True)
+
+    # Metrics table
+    st.markdown("##### TPR at fixed FPR thresholds")
+    rows = []
+    for r in roc_results:
+        fpr_table = r.fixed_fpr_table or {}
+        rows.append({
+            "Attack": r.result_name,
+            "AUC": f"{r.roc_auc:.4f}",
+            "TPR@10%FPR": f"{fpr_table.get('TPR@10%FPR', 0):.4f}",
+            "TPR@1%FPR":  f"{fpr_table.get('TPR@1%FPR', 0):.4f}",
+            "TPR@0.1%FPR": f"{fpr_table.get('TPR@0.1%FPR', 0):.4f}",
+            "TPR@0%FPR":  f"{fpr_table.get('TPR@0%FPR', 0):.4f}",
+        })
+    import pandas as pd  # noqa: PLC0415
+    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)

--- a/leakpro/ui/components/results/sensitive_records.py
+++ b/leakpro/ui/components/results/sensitive_records.py
@@ -2,28 +2,20 @@
 
 from __future__ import annotations
 
-import io
-from pathlib import Path
-
 import numpy as np
 import pandas as pd
 import streamlit as st
 
-_CIFAR_DIR = Path(__file__).parent.parent.parent.parent.parent / "examples" / "mia" / "cifar"
-
 
 def render_sensitive_records(results: list) -> None:
     """Render the sensitive records explorer."""
-    # Pick best result by AUC
     valid = [r for r in results if r.signal_values is not None and r.roc_auc is not None]
     if not valid:
-        # Fall back to any result with signal values
         valid = [r for r in results if r.signal_values is not None]
     if not valid:
         st.info("No signal-value data available for sensitive records analysis.")
         return
 
-    # Attack selector
     attack_names = [r.result_name for r in valid]
     selected_name = st.selectbox("Select attack", attack_names, key="rec_attack_select")
     result = next(r for r in valid if r.result_name == selected_name)
@@ -31,15 +23,13 @@ def render_sensitive_records(results: list) -> None:
     signal = np.asarray(result.signal_values).ravel()
     labels = np.asarray(result.true).ravel()
 
-    # Filter to members only (training set samples)
     member_mask = labels == 1
     member_signals = signal[member_mask]
     member_original_indices = np.where(member_mask)[0]
 
-    # Sort members by descending signal score
     sorted_order = np.argsort(-member_signals)
     sorted_member_signals = member_signals[sorted_order]
-    sorted_member_audit_indices = member_original_indices[sorted_order]  # index into audit set
+    sorted_member_audit_indices = member_original_indices[sorted_order]
 
     top_n = st.slider(
         "Top-N riskiest samples", min_value=5, max_value=min(200, len(sorted_member_signals)),
@@ -49,44 +39,49 @@ def render_sensitive_records(results: list) -> None:
     top_signals = sorted_member_signals[:top_n]
     top_audit_indices = sorted_member_audit_indices[:top_n]
 
-    # ---- Load training images if available ------------------------------
     data_result = st.session_state.get("data_result")
     train_indices = None
     population_data = None
-
     if data_result is not None:
         train_indices = np.asarray(data_result["train_indices"])
-        population_data = data_result["data"]  # tensor (N, C, H, W) in [0,1]
+        population_data = data_result["data"]
 
-    # ---- Image grid (CIFAR) ---------------------------------------------
+    _render_image_grid(population_data, train_indices, top_audit_indices, top_signals)
+
+    st.markdown("---")
+    _render_csv_export(top_audit_indices, top_signals, labels, train_indices, top_n, selected_name)
+
+
+def _render_image_grid(
+    population_data: object,
+    train_indices: object,
+    top_audit_indices: np.ndarray,
+    top_signals: np.ndarray,
+) -> None:
+    """Render the image grid of top-N riskiest training images, or a fallback message."""
     if population_data is not None and train_indices is not None:
         st.markdown("##### Top-N riskiest training images")
         st.caption(
             "These training images were most confidently identified as training members "
             "by the attack — they are the most 'exposed' samples in your dataset."
         )
-
-        # Map audit-set member index → train_indices position
-        # The i-th member in the audit set corresponds to train_indices[i]
-        # (approximate — valid when the audit set preserves training order)
         num_members = len(train_indices)
         valid_mask = top_audit_indices < num_members
         display_indices = top_audit_indices[valid_mask]
         display_signals = top_signals[valid_mask]
 
         pop_indices = train_indices[display_indices]
-        images = population_data[pop_indices]  # (M, C, H, W) tensor in [0,1]
+        images = population_data[pop_indices]
 
         cols_per_row = 5
         rows = [
             list(range(i, min(i + cols_per_row, len(images))))
             for i in range(0, len(images), cols_per_row)
         ]
-
         for row_indices in rows:
             cols = st.columns(cols_per_row)
             for col, idx in zip(cols, row_indices):
-                img = images[idx].numpy().transpose(1, 2, 0)  # (H, W, C)
+                img = images[idx].numpy().transpose(1, 2, 0)
                 img = (img * 255).clip(0, 255).astype("uint8")
                 score = display_signals[idx]
                 col.image(img, caption=f"score: {score:.4f}", use_container_width=True)
@@ -96,8 +91,16 @@ def render_sensitive_records(results: list) -> None:
             "Run a full audit (starting from Stage 2) to enable image display."
         )
 
-    # ---- CSV export for all data types ----------------------------------
-    st.markdown("---")
+
+def _render_csv_export(
+    top_audit_indices: np.ndarray,
+    top_signals: np.ndarray,
+    labels: np.ndarray,
+    train_indices: object,
+    top_n: int,
+    selected_name: str,
+) -> None:
+    """Render the CSV export section with download button and preview table."""
     st.markdown("##### Export riskiest records as CSV")
 
     csv_rows = []
@@ -125,6 +128,5 @@ def render_sensitive_records(results: list) -> None:
         type="primary",
     )
 
-    # Preview table
     with st.expander("Preview CSV content"):
         st.dataframe(df_export, use_container_width=True, hide_index=True)

--- a/leakpro/ui/components/results/sensitive_records.py
+++ b/leakpro/ui/components/results/sensitive_records.py
@@ -7,14 +7,31 @@ import pandas as pd
 import streamlit as st
 
 
-def render_sensitive_records(results: list) -> None:
-    """Render the sensitive records explorer."""
+def render_sensitive_records(models: list) -> None:
+    """Render the sensitive records explorer with a model selector."""
+    audited = [m for m in models if m.get("audit_results")]
+    if not audited:
+        st.info("No signal-value data available for sensitive records analysis.")
+        return
+
+    # Model selector (skip if only one model)
+    if len(audited) > 1:
+        model_name = st.selectbox(
+            "Select model", [m["name"] for m in audited], key="rec_model_select"
+        )
+        model = next(m for m in audited if m["name"] == model_name)
+    else:
+        model = audited[0]
+
+    results = model.get("audit_results") or []
     valid = [r for r in results if r.signal_values is not None and r.roc_auc is not None]
     if not valid:
         valid = [r for r in results if r.signal_values is not None]
     if not valid:
-        st.info("No signal-value data available for sensitive records analysis.")
+        st.info(f"No signal-value data available for **{model['name']}**.")
         return
+
+    st.caption(f"Model: **{model['name']}**")
 
     attack_names = [r.result_name for r in valid]
     selected_name = st.selectbox("Select attack", attack_names, key="rec_attack_select")

--- a/leakpro/ui/components/results/sensitive_records.py
+++ b/leakpro/ui/components/results/sensitive_records.py
@@ -1,0 +1,130 @@
+"""Stage 4 — Sensitive Records tab: top-N riskiest training samples + CSV export."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+_CIFAR_DIR = Path(__file__).parent.parent.parent.parent.parent / "examples" / "mia" / "cifar"
+
+
+def render_sensitive_records(results: list) -> None:
+    """Render the sensitive records explorer."""
+    # Pick best result by AUC
+    valid = [r for r in results if r.signal_values is not None and r.roc_auc is not None]
+    if not valid:
+        # Fall back to any result with signal values
+        valid = [r for r in results if r.signal_values is not None]
+    if not valid:
+        st.info("No signal-value data available for sensitive records analysis.")
+        return
+
+    # Attack selector
+    attack_names = [r.result_name for r in valid]
+    selected_name = st.selectbox("Select attack", attack_names, key="rec_attack_select")
+    result = next(r for r in valid if r.result_name == selected_name)
+
+    signal = np.asarray(result.signal_values).ravel()
+    labels = np.asarray(result.true).ravel()
+
+    # Filter to members only (training set samples)
+    member_mask = labels == 1
+    member_signals = signal[member_mask]
+    member_original_indices = np.where(member_mask)[0]
+
+    # Sort members by descending signal score
+    sorted_order = np.argsort(-member_signals)
+    sorted_member_signals = member_signals[sorted_order]
+    sorted_member_audit_indices = member_original_indices[sorted_order]  # index into audit set
+
+    top_n = st.slider(
+        "Top-N riskiest samples", min_value=5, max_value=min(200, len(sorted_member_signals)),
+        value=min(20, len(sorted_member_signals)), key="rec_topn"
+    )
+
+    top_signals = sorted_member_signals[:top_n]
+    top_audit_indices = sorted_member_audit_indices[:top_n]
+
+    # ---- Load training images if available ------------------------------
+    data_result = st.session_state.get("data_result")
+    train_indices = None
+    population_data = None
+
+    if data_result is not None:
+        train_indices = np.asarray(data_result["train_indices"])
+        population_data = data_result["data"]  # tensor (N, C, H, W) in [0,1]
+
+    # ---- Image grid (CIFAR) ---------------------------------------------
+    if population_data is not None and train_indices is not None:
+        st.markdown("##### Top-N riskiest training images")
+        st.caption(
+            "These training images were most confidently identified as training members "
+            "by the attack — they are the most 'exposed' samples in your dataset."
+        )
+
+        # Map audit-set member index → train_indices position
+        # The i-th member in the audit set corresponds to train_indices[i]
+        # (approximate — valid when the audit set preserves training order)
+        num_members = len(train_indices)
+        valid_mask = top_audit_indices < num_members
+        display_indices = top_audit_indices[valid_mask]
+        display_signals = top_signals[valid_mask]
+
+        pop_indices = train_indices[display_indices]
+        images = population_data[pop_indices]  # (M, C, H, W) tensor in [0,1]
+
+        cols_per_row = 5
+        rows = [
+            list(range(i, min(i + cols_per_row, len(images))))
+            for i in range(0, len(images), cols_per_row)
+        ]
+
+        for row_indices in rows:
+            cols = st.columns(cols_per_row)
+            for col, idx in zip(cols, row_indices):
+                img = images[idx].numpy().transpose(1, 2, 0)  # (H, W, C)
+                img = (img * 255).clip(0, 255).astype("uint8")
+                score = display_signals[idx]
+                col.image(img, caption=f"score: {score:.4f}", use_container_width=True)
+    else:
+        st.info(
+            "Training images not available in this session. "
+            "Run a full audit (starting from Stage 2) to enable image display."
+        )
+
+    # ---- CSV export for all data types ----------------------------------
+    st.markdown("---")
+    st.markdown("##### Export riskiest records as CSV")
+
+    csv_rows = []
+    for rank, (audit_idx, score) in enumerate(
+        zip(top_audit_indices[:top_n], top_signals[:top_n]), start=1
+    ):
+        row: dict = {
+            "rank": rank,
+            "audit_set_index": int(audit_idx),
+            "risk_score": float(score),
+            "is_member": int(labels[audit_idx]) if audit_idx < len(labels) else "unknown",
+        }
+        if train_indices is not None and audit_idx < len(train_indices):
+            row["population_index"] = int(train_indices[audit_idx])
+        csv_rows.append(row)
+
+    df_export = pd.DataFrame(csv_rows)
+    csv_bytes = df_export.to_csv(index=False).encode()
+
+    st.download_button(
+        label=f"Download top-{top_n} records as CSV",
+        data=csv_bytes,
+        file_name=f"leakpro_sensitive_records_{selected_name}_top{top_n}.csv",
+        mime="text/csv",
+        type="primary",
+    )
+
+    # Preview table
+    with st.expander("Preview CSV content"):
+        st.dataframe(df_export, use_container_width=True, hide_index=True)

--- a/leakpro/ui/components/results/summary.py
+++ b/leakpro/ui/components/results/summary.py
@@ -5,41 +5,41 @@ from __future__ import annotations
 import streamlit as st
 
 
+def _risk_level(auc: float | None) -> tuple[str, str, str]:
+    """Return (label, icon, colour) for a given AUC."""
+    if auc is None:
+        return "Unknown", "❓", "#888888"
+    if auc >= 0.75:
+        return "HIGH", "🔴", "#E84C4C"
+    if auc >= 0.60:
+        return "MEDIUM", "🟡", "#F5A623"
+    return "LOW", "🟢", "#27AE60"
+
+
 def render_summary(results: list) -> None:
     """Render the summary risk dashboard."""
     if not results:
         st.warning("No results to display.")
         return
 
-    # Gather metrics
     valid = [r for r in results if r.roc_auc is not None]
     best_auc = max((r.roc_auc for r in valid), default=None)
     worst_tpr = max(
         (r.fixed_fpr_table.get("TPR@0.1%FPR", 0) for r in valid if r.fixed_fpr_table),
         default=None,
     )
-    num_attacks = len(results)
 
-    # DP-SGD context (if available)
-    dpsgd_enabled = st.session_state.get("dpsgd_enabled", False)
-    dpsgd_params = st.session_state.get("dpsgd_params", {})
-    train_result_dict = st.session_state.get("train_result_dict", {})
+    _render_risk_cards(best_auc, worst_tpr, len(results))
+    st.markdown("---")
+    st.subheader("Verdict")
+    _render_verdict(best_auc)
+    _render_dpsgd_panel(best_auc)
 
-    # ---- Risk level calculation ----------------------------------------
-    def _risk_level(auc: float | None) -> tuple[str, str, str]:
-        if auc is None:
-            return "Unknown", "❓", "#888888"
-        if auc >= 0.75:
-            return "HIGH", "🔴", "#E84C4C"
-        if auc >= 0.60:
-            return "MEDIUM", "🟡", "#F5A623"
-        return "LOW", "🟢", "#27AE60"
 
+def _render_risk_cards(best_auc: float | None, worst_tpr: float | None, num_attacks: int) -> None:
+    """Render the four top-level metric cards."""
     risk_label, risk_icon, risk_colour = _risk_level(best_auc)
-
-    # ---- Top metric cards -----------------------------------------------
     col1, col2, col3, col4 = st.columns(4)
-
     with col1:
         st.metric("Attacks run", num_attacks)
     with col2:
@@ -52,8 +52,7 @@ def render_summary(results: list) -> None:
         st.metric(
             "Worst TPR @ 0.1% FPR",
             f"{worst_tpr:.4f}" if worst_tpr is not None else "N/A",
-            help="True positive rate when accepting only 0.1% false positives — "
-                 "a strict real-world scenario.",
+            help="True positive rate when accepting only 0.1% false positives.",
         )
     with col4:
         st.markdown(
@@ -69,47 +68,53 @@ def render_summary(results: list) -> None:
             unsafe_allow_html=True,
         )
 
-    # ---- Plain-English verdict ------------------------------------------
+
+def _render_verdict(best_auc: float | None) -> None:
+    """Render the plain-English risk verdict."""
+    if best_auc is None:
+        st.info("No AUC-capable results available for verdict.")
+        return
+    if best_auc >= 0.75:
+        verdict = (
+            f"Your model is at **HIGH risk** of membership inference (best AUC = {best_auc:.3f}). "
+            "An attacker can reliably distinguish training samples from non-members. "
+            "Consider retraining with differential privacy (DP-SGD)."
+        )
+    elif best_auc >= 0.60:
+        verdict = (
+            f"Your model shows **moderate leakage** (best AUC = {best_auc:.3f}). "
+            "Attacks are partially effective. DP-SGD training may reduce this risk."
+        )
+    else:
+        verdict = (
+            f"Your model appears **well-protected** (best AUC = {best_auc:.3f}). "
+            "Membership inference attacks perform close to random guessing."
+        )
+    st.info(verdict)
+
+
+def _render_dpsgd_panel(best_auc: float | None) -> None:
+    """Render the DP-SGD impact panel when DP-SGD was used."""
+    dpsgd_enabled = st.session_state.get("dpsgd_enabled", False)
+    dpsgd_params = st.session_state.get("dpsgd_params", {})
+    if not (dpsgd_enabled and dpsgd_params):
+        return
+
     st.markdown("---")
-    st.subheader("Verdict")
+    st.subheader("Differential Privacy Impact")
+    c1, c2, c3, c4 = st.columns(4)
+    c1.metric("Target ε", dpsgd_params.get("target_epsilon", "—"))
+    c2.metric("Target δ", f"{dpsgd_params.get('target_delta', 0):.2e}")
+    c3.metric("Max grad norm", dpsgd_params.get("max_grad_norm", "—"))
+    train_result_dict = st.session_state.get("train_result_dict", {})
+    if train_result_dict:
+        test_acc = train_result_dict.get("test_result")
+        if test_acc:
+            c4.metric("Model test accuracy", f"{test_acc.accuracy:.3f}")
 
     if best_auc is not None:
-        if best_auc >= 0.75:
-            verdict = (
-                f"Your model is at **HIGH risk** of membership inference (best AUC = {best_auc:.3f}). "
-                "An attacker can reliably distinguish training samples from non-members. "
-                "Consider retraining with differential privacy (DP-SGD)."
-            )
-        elif best_auc >= 0.60:
-            verdict = (
-                f"Your model shows **moderate leakage** (best AUC = {best_auc:.3f}). "
-                "Attacks are partially effective. DP-SGD training may reduce this risk."
-            )
-        else:
-            verdict = (
-                f"Your model appears **well-protected** (best AUC = {best_auc:.3f}). "
-                "Membership inference attacks perform close to random guessing."
-            )
-        st.info(verdict)
-    else:
-        st.info("No AUC-capable results available for verdict.")
-
-    # ---- DP-SGD context panel ------------------------------------------
-    if dpsgd_enabled and dpsgd_params:
-        st.markdown("---")
-        st.subheader("Differential Privacy Impact")
-        c1, c2, c3, c4 = st.columns(4)
-        c1.metric("Target ε", dpsgd_params.get("target_epsilon", "—"))
-        c2.metric("Target δ", f"{dpsgd_params.get('target_delta', 0):.2e}")
-        c3.metric("Max grad norm", dpsgd_params.get("max_grad_norm", "—"))
-        if train_result_dict:
-            test_acc = train_result_dict.get("test_result")
-            if test_acc:
-                c4.metric("Model test accuracy", f"{test_acc.accuracy:.3f}")
-
-        if best_auc is not None:
-            st.markdown(
-                f"> DP-SGD (ε={dpsgd_params.get('target_epsilon')}) "
-                f"→ Best attack AUC = **{best_auc:.3f}** "
-                f"{'(significantly reduced — DP is working!)' if best_auc < 0.60 else '(DP may need stronger ε)'}"
-            )
+        suffix = "(significantly reduced — DP is working!)" if best_auc < 0.60 else "(DP may need stronger ε)"
+        st.markdown(
+            f"> DP-SGD (ε={dpsgd_params.get('target_epsilon')}) "
+            f"→ Best attack AUC = **{best_auc:.3f}** {suffix}"
+        )

--- a/leakpro/ui/components/results/summary.py
+++ b/leakpro/ui/components/results/summary.py
@@ -1,7 +1,8 @@
-"""Stage 4 — Summary tab: risk cards, traffic-light indicator, and plain-English verdict."""
+"""Stage 4 — Summary tab: multi-model comparison table and risk verdict."""
 
 from __future__ import annotations
 
+import pandas as pd
 import streamlit as st
 
 
@@ -16,105 +17,130 @@ def _risk_level(auc: float | None) -> tuple[str, str, str]:
     return "LOW", "🟢", "#27AE60"
 
 
-def render_summary(results: list) -> None:
-    """Render the summary risk dashboard."""
-    if not results:
+def render_summary(models: list) -> None:
+    """Render the multi-model summary comparison dashboard."""
+    if not models:
         st.warning("No results to display.")
         return
 
-    valid = [r for r in results if r.roc_auc is not None]
-    best_auc = max((r.roc_auc for r in valid), default=None)
-    worst_tpr = max(
-        (r.fixed_fpr_table.get("TPR@0.1%FPR", 0) for r in valid if r.fixed_fpr_table),
-        default=None,
-    )
-
-    _render_risk_cards(best_auc, worst_tpr, len(results))
+    st.subheader("Model Comparison")
+    _render_comparison_table(models)
     st.markdown("---")
     st.subheader("Verdict")
-    _render_verdict(best_auc)
-    _render_dpsgd_panel(best_auc)
+    _render_verdict(models)
 
 
-def _render_risk_cards(best_auc: float | None, worst_tpr: float | None, num_attacks: int) -> None:
-    """Render the four top-level metric cards."""
-    risk_label, risk_icon, risk_colour = _risk_level(best_auc)
-    col1, col2, col3, col4 = st.columns(4)
-    with col1:
-        st.metric("Attacks run", num_attacks)
-    with col2:
-        st.metric(
-            "Best attack AUC",
-            f"{best_auc:.4f}" if best_auc is not None else "N/A",
-            help="Area under the ROC curve — 0.5 = random, 1.0 = perfect attack.",
+def _model_best_auc(model: dict) -> float | None:
+    """Return the best (highest) AUC across all attacks for a model."""
+    results = model.get("audit_results") or []
+    valid = [r.roc_auc for r in results if r.roc_auc is not None]
+    return max(valid) if valid else None
+
+
+def _render_comparison_table(models: list) -> None:
+    """Render one row per model with key metrics."""
+    rows = []
+    for m in models:
+        results = m.get("audit_results") or []
+        valid = [r for r in results if r.roc_auc is not None]
+        best_auc = max((r.roc_auc for r in valid), default=None)
+        worst_tpr = max(
+            (r.fixed_fpr_table.get("TPR@0.1%FPR", 0) for r in valid if r.fixed_fpr_table),
+            default=None,
         )
-    with col3:
-        st.metric(
-            "Worst TPR @ 0.1% FPR",
-            f"{worst_tpr:.4f}" if worst_tpr is not None else "N/A",
-            help="True positive rate when accepting only 0.1% false positives.",
+        tr = m.get("train_result_dict") or {}
+        test_acc = tr.get("test_result")
+        risk_label, risk_icon, _ = _risk_level(best_auc)
+        dp_str = (
+            f"ε={m['dpsgd_params']['target_epsilon']}"
+            if m.get("dpsgd_enabled") and m.get("dpsgd_params")
+            else "No"
         )
-    with col4:
-        st.markdown(
-            f"""
-            <div style="text-align:center; padding:16px; border:2px solid {risk_colour};
-                        border-radius:10px; background:rgba(0,0,0,0.05);">
-                <div style="font-size:32px">{risk_icon}</div>
-                <div style="font-size:20px; font-weight:bold; color:{risk_colour}">
-                    {risk_label} RISK
+        rows.append({
+            "Model": m["name"],
+            "Best AUC": f"{best_auc:.4f}" if best_auc is not None else "N/A",
+            "TPR@0.1%FPR": f"{worst_tpr:.4f}" if worst_tpr is not None else "N/A",
+            "Test Accuracy": f"{test_acc.accuracy:.3f}" if test_acc else "N/A",
+            "DP-SGD": dp_str,
+            "Risk": f"{risk_icon} {risk_label}",
+        })
+    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+
+    # Traffic-light cards for each model
+    if len(models) > 1:
+        cols = st.columns(len(models))
+        for col, m in zip(cols, models):
+            best_auc = _model_best_auc(m)
+            _, risk_icon, risk_colour = _risk_level(best_auc)
+            auc_str = f"{best_auc:.3f}" if best_auc is not None else "N/A"
+            col.markdown(
+                f"""
+                <div style="text-align:center; padding:12px; border:2px solid {risk_colour};
+                            border-radius:8px; background:rgba(0,0,0,0.04);">
+                    <div style="font-size:24px">{risk_icon}</div>
+                    <strong>{m['name']}</strong><br/>
+                    <small>AUC = {auc_str}</small>
                 </div>
-            </div>
-            """,
+                """,
+                unsafe_allow_html=True,
+            )
+
+
+def _render_verdict(models: list) -> None:
+    """Render plain-English risk verdict for each model."""
+    for m in models:
+        best_auc = _model_best_auc(m)
+        _, _, colour = _risk_level(best_auc)
+        dp_note = ""
+        if m.get("dpsgd_enabled") and m.get("dpsgd_params"):
+            eps = m["dpsgd_params"].get("target_epsilon", "?")
+            dp_note = f" (DP-SGD ε={eps})"
+
+        if best_auc is None:
+            msg = f"**{m['name']}{dp_note}**: No AUC data available."
+        elif best_auc >= 0.75:
+            msg = (
+                f"**{m['name']}{dp_note}**: HIGH risk — AUC = {best_auc:.3f}. "
+                "An attacker can reliably identify training members."
+            )
+        elif best_auc >= 0.60:
+            msg = (
+                f"**{m['name']}{dp_note}**: MEDIUM risk — AUC = {best_auc:.3f}. "
+                "Attacks are partially effective."
+            )
+        else:
+            msg = (
+                f"**{m['name']}{dp_note}**: LOW risk — AUC = {best_auc:.3f}. "
+                "Attacks perform close to random guessing."
+            )
+        st.markdown(
+            f'<div style="padding:8px; border-left:4px solid {colour}; margin-bottom:8px;">'
+            f"{msg}</div>",
             unsafe_allow_html=True,
         )
 
-
-def _render_verdict(best_auc: float | None) -> None:
-    """Render the plain-English risk verdict."""
-    if best_auc is None:
-        st.info("No AUC-capable results available for verdict.")
-        return
-    if best_auc >= 0.75:
-        verdict = (
-            f"Your model is at **HIGH risk** of membership inference (best AUC = {best_auc:.3f}). "
-            "An attacker can reliably distinguish training samples from non-members. "
-            "Consider retraining with differential privacy (DP-SGD)."
-        )
-    elif best_auc >= 0.60:
-        verdict = (
-            f"Your model shows **moderate leakage** (best AUC = {best_auc:.3f}). "
-            "Attacks are partially effective. DP-SGD training may reduce this risk."
-        )
-    else:
-        verdict = (
-            f"Your model appears **well-protected** (best AUC = {best_auc:.3f}). "
-            "Membership inference attacks perform close to random guessing."
-        )
-    st.info(verdict)
-
-
-def _render_dpsgd_panel(best_auc: float | None) -> None:
-    """Render the DP-SGD impact panel when DP-SGD was used."""
-    dpsgd_enabled = st.session_state.get("dpsgd_enabled", False)
-    dpsgd_params = st.session_state.get("dpsgd_params", {})
-    if not (dpsgd_enabled and dpsgd_params):
-        return
-
-    st.markdown("---")
-    st.subheader("Differential Privacy Impact")
-    c1, c2, c3, c4 = st.columns(4)
-    c1.metric("Target ε", dpsgd_params.get("target_epsilon", "—"))
-    c2.metric("Target δ", f"{dpsgd_params.get('target_delta', 0):.2e}")
-    c3.metric("Max grad norm", dpsgd_params.get("max_grad_norm", "—"))
-    train_result_dict = st.session_state.get("train_result_dict", {})
-    if train_result_dict:
-        test_acc = train_result_dict.get("test_result")
-        if test_acc:
-            c4.metric("Model test accuracy", f"{test_acc.accuracy:.3f}")
-
-    if best_auc is not None:
-        suffix = "(significantly reduced — DP is working!)" if best_auc < 0.60 else "(DP may need stronger ε)"
-        st.markdown(
-            f"> DP-SGD (ε={dpsgd_params.get('target_epsilon')}) "
-            f"→ Best attack AUC = **{best_auc:.3f}** {suffix}"
-        )
+    # DP comparison narrative when multiple models present
+    dp_models = [m for m in models if m.get("dpsgd_enabled")]
+    std_models = [m for m in models if not m.get("dpsgd_enabled")]
+    if dp_models and std_models:
+        st.markdown("---")
+        st.subheader("Privacy-Accuracy Trade-off")
+        for std in std_models:
+            std_auc = _model_best_auc(std)
+            std_tr = (std.get("train_result_dict") or {}).get("test_result")
+            for dp in dp_models:
+                dp_auc = _model_best_auc(dp)
+                dp_tr = (dp.get("train_result_dict") or {}).get("test_result")
+                eps = (dp.get("dpsgd_params") or {}).get("target_epsilon", "?")
+                auc_delta = (
+                    f"AUC {std_auc:.3f} → {dp_auc:.3f}" if std_auc and dp_auc else "AUC N/A"
+                )
+                acc_delta = ""
+                if std_tr and dp_tr:
+                    diff = dp_tr.accuracy - std_tr.accuracy
+                    sign = "+" if diff >= 0 else ""
+                    acc_delta = f", accuracy {sign}{diff:.3f}"
+                st.info(
+                    f"**{std['name']}** vs **{dp['name']}** (ε={eps}): "
+                    f"{auc_delta}{acc_delta}"
+                )

--- a/leakpro/ui/components/results/summary.py
+++ b/leakpro/ui/components/results/summary.py
@@ -1,0 +1,115 @@
+"""Stage 4 — Summary tab: risk cards, traffic-light indicator, and plain-English verdict."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def render_summary(results: list) -> None:
+    """Render the summary risk dashboard."""
+    if not results:
+        st.warning("No results to display.")
+        return
+
+    # Gather metrics
+    valid = [r for r in results if r.roc_auc is not None]
+    best_auc = max((r.roc_auc for r in valid), default=None)
+    worst_tpr = max(
+        (r.fixed_fpr_table.get("TPR@0.1%FPR", 0) for r in valid if r.fixed_fpr_table),
+        default=None,
+    )
+    num_attacks = len(results)
+
+    # DP-SGD context (if available)
+    dpsgd_enabled = st.session_state.get("dpsgd_enabled", False)
+    dpsgd_params = st.session_state.get("dpsgd_params", {})
+    train_result_dict = st.session_state.get("train_result_dict", {})
+
+    # ---- Risk level calculation ----------------------------------------
+    def _risk_level(auc: float | None) -> tuple[str, str, str]:
+        if auc is None:
+            return "Unknown", "❓", "#888888"
+        if auc >= 0.75:
+            return "HIGH", "🔴", "#E84C4C"
+        if auc >= 0.60:
+            return "MEDIUM", "🟡", "#F5A623"
+        return "LOW", "🟢", "#27AE60"
+
+    risk_label, risk_icon, risk_colour = _risk_level(best_auc)
+
+    # ---- Top metric cards -----------------------------------------------
+    col1, col2, col3, col4 = st.columns(4)
+
+    with col1:
+        st.metric("Attacks run", num_attacks)
+    with col2:
+        st.metric(
+            "Best attack AUC",
+            f"{best_auc:.4f}" if best_auc is not None else "N/A",
+            help="Area under the ROC curve — 0.5 = random, 1.0 = perfect attack.",
+        )
+    with col3:
+        st.metric(
+            "Worst TPR @ 0.1% FPR",
+            f"{worst_tpr:.4f}" if worst_tpr is not None else "N/A",
+            help="True positive rate when accepting only 0.1% false positives — "
+                 "a strict real-world scenario.",
+        )
+    with col4:
+        st.markdown(
+            f"""
+            <div style="text-align:center; padding:16px; border:2px solid {risk_colour};
+                        border-radius:10px; background:rgba(0,0,0,0.05);">
+                <div style="font-size:32px">{risk_icon}</div>
+                <div style="font-size:20px; font-weight:bold; color:{risk_colour}">
+                    {risk_label} RISK
+                </div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    # ---- Plain-English verdict ------------------------------------------
+    st.markdown("---")
+    st.subheader("Verdict")
+
+    if best_auc is not None:
+        if best_auc >= 0.75:
+            verdict = (
+                f"Your model is at **HIGH risk** of membership inference (best AUC = {best_auc:.3f}). "
+                "An attacker can reliably distinguish training samples from non-members. "
+                "Consider retraining with differential privacy (DP-SGD)."
+            )
+        elif best_auc >= 0.60:
+            verdict = (
+                f"Your model shows **moderate leakage** (best AUC = {best_auc:.3f}). "
+                "Attacks are partially effective. DP-SGD training may reduce this risk."
+            )
+        else:
+            verdict = (
+                f"Your model appears **well-protected** (best AUC = {best_auc:.3f}). "
+                "Membership inference attacks perform close to random guessing."
+            )
+        st.info(verdict)
+    else:
+        st.info("No AUC-capable results available for verdict.")
+
+    # ---- DP-SGD context panel ------------------------------------------
+    if dpsgd_enabled and dpsgd_params:
+        st.markdown("---")
+        st.subheader("Differential Privacy Impact")
+        c1, c2, c3, c4 = st.columns(4)
+        c1.metric("Target ε", dpsgd_params.get("target_epsilon", "—"))
+        c2.metric("Target δ", f"{dpsgd_params.get('target_delta', 0):.2e}")
+        c3.metric("Max grad norm", dpsgd_params.get("max_grad_norm", "—"))
+        if train_result_dict:
+            test_acc = train_result_dict.get("test_result")
+            if test_acc:
+                c4.metric("Model test accuracy", f"{test_acc.accuracy:.3f}")
+
+        if best_auc is not None:
+            st.markdown(
+                f"> DP-SGD (ε={dpsgd_params.get('target_epsilon')}) "
+                f"→ Best attack AUC = **{best_auc:.3f}** "
+                f"{'(significantly reduced — DP is working!)' if best_auc < 0.60 else '(DP may need stronger ε)'}"
+            )

--- a/leakpro/ui/components/train.py
+++ b/leakpro/ui/components/train.py
@@ -14,16 +14,20 @@ def render_train() -> None:
     models: list[dict] = st.session_state.get("models", [])
     st.caption(f"{len(models)} model(s) defined — each will be trained to its own folder.")
 
-    train_config = st.session_state.train_config
     runner = LeakProRunner()
 
+    # Use first model's train_config for data prep (dataset choice); falls back to default
+    first_tc = models[0].get("train_config") if models else {}
+    if not first_tc:
+        first_tc = runner.default_train_config()
+
     st.subheader("Step 1 — Prepare Dataset")
-    _render_data_prep(runner, train_config)
+    _render_data_prep(runner, first_tc)
 
     if st.session_state.get("data_result"):
         st.markdown("---")
         st.subheader("Step 2 — Train Models")
-        _render_all_model_training(runner, train_config, models)
+        _render_all_model_training(runner, models)
 
     _render_navigation(models)
 
@@ -54,7 +58,7 @@ def _render_data_prep(runner: object, train_config: dict) -> None:
                 st.error(f"Data preparation failed: {e}")
 
 
-def _render_all_model_training(runner: object, train_config: dict, models: list[dict]) -> None:
+def _render_all_model_training(runner: object, models: list[dict]) -> None:
     """Render the Train All Models button and per-model result cards."""
     all_trained = all(m.get("train_result_dict") for m in models)
 
@@ -67,10 +71,11 @@ def _render_all_model_training(runner: object, train_config: dict, models: list[
                     continue
                 with st.spinner(f"Training **{model['name']}**…"):
                     log_ph = st.empty()
+                    model_tc = model.get("train_config") or {}
                     try:
                         if model["dpsgd_enabled"]:
                             result = runner.train_dpsgd(  # type: ignore[attr-defined]
-                                train_config,
+                                model_tc,
                                 model["dpsgd_params"],
                                 st.session_state.data_result,
                                 target_folder=model["target_folder"],
@@ -78,7 +83,7 @@ def _render_all_model_training(runner: object, train_config: dict, models: list[
                             )
                         else:
                             result = runner.train_standard(  # type: ignore[attr-defined]
-                                train_config,
+                                model_tc,
                                 st.session_state.data_result,
                                 target_folder=model["target_folder"],
                                 log_container=log_ph,

--- a/leakpro/ui/components/train.py
+++ b/leakpro/ui/components/train.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import streamlit as st
 import plotly.graph_objects as go
+import streamlit as st
 
 
 def render_train() -> None:
@@ -18,18 +18,25 @@ def render_train() -> None:
     train_config = st.session_state.train_config
     runner = LeakProRunner()
 
-    # ------------------------------------------------------------------ #
-    # Step 2a — Prepare dataset
-    # ------------------------------------------------------------------ #
     st.subheader("Step 1 — Prepare Dataset")
+    _render_data_prep(runner, train_config)
 
+    if st.session_state.get("data_result"):
+        st.markdown("---")
+        st.subheader("Step 2 — Train Model")
+        _render_model_training(runner, train_config, dpsgd)
+
+    _render_navigation()
+
+
+def _render_data_prep(runner: object, train_config: dict) -> None:
+    """Render dataset download / status section."""
     if not st.session_state.get("data_result"):
         if st.button("Download & Prepare Data", type="primary"):
-            log_container = st.empty()
             status_msg = st.empty()
             with st.spinner("Preparing dataset…"):
                 try:
-                    data_result = runner.prepare_data(train_config, log_container=status_msg)
+                    data_result = runner.prepare_data(train_config, log_container=status_msg)  # type: ignore[attr-defined]
                     st.session_state.data_result = data_result
                     st.rerun()
                 except Exception as e:  # noqa: BLE001
@@ -41,41 +48,37 @@ def render_train() -> None:
             f"{len(dr['test_indices'])} test samples ({dr['dataset_name']})."
         )
 
-    # ------------------------------------------------------------------ #
-    # Step 2b — Train model
-    # ------------------------------------------------------------------ #
-    if st.session_state.get("data_result"):
-        st.markdown("---")
-        st.subheader("Step 2 — Train Model")
 
-        if not st.session_state.get("train_result_dict"):
-            if st.button("Train Model", type="primary"):
-                log_placeholder = st.empty()
-                with st.spinner("Training… this may take several minutes."):
-                    try:
-                        if dpsgd:
-                            result = runner.train_dpsgd(
-                                train_config,
-                                st.session_state.dpsgd_params,
-                                st.session_state.data_result,
-                                log_container=log_placeholder,
-                            )
-                        else:
-                            result = runner.train_standard(
-                                train_config,
-                                st.session_state.data_result,
-                                log_container=log_placeholder,
-                            )
-                        st.session_state.train_result_dict = result
-                        st.rerun()
-                    except Exception as e:  # noqa: BLE001
-                        st.error(f"Training failed: {e}")
-        else:
-            _show_training_metrics(st.session_state.train_result_dict, dpsgd)
+def _render_model_training(runner: object, train_config: dict, dpsgd: bool) -> None:
+    """Render model training button and metrics."""
+    if not st.session_state.get("train_result_dict"):
+        if st.button("Train Model", type="primary"):
+            log_placeholder = st.empty()
+            with st.spinner("Training… this may take several minutes."):
+                try:
+                    if dpsgd:
+                        result = runner.train_dpsgd(  # type: ignore[attr-defined]
+                            train_config,
+                            st.session_state.dpsgd_params,
+                            st.session_state.data_result,
+                            log_container=log_placeholder,
+                        )
+                    else:
+                        result = runner.train_standard(  # type: ignore[attr-defined]
+                            train_config,
+                            st.session_state.data_result,
+                            log_container=log_placeholder,
+                        )
+                    st.session_state.train_result_dict = result
+                    st.rerun()
+                except Exception as e:  # noqa: BLE001
+                    st.error(f"Training failed: {e}")
+    else:
+        _show_training_metrics(st.session_state.train_result_dict, dpsgd)
 
-    # ------------------------------------------------------------------ #
-    # Navigation
-    # ------------------------------------------------------------------ #
+
+def _render_navigation() -> None:
+    """Render back / forward navigation buttons."""
     if st.session_state.get("train_result_dict"):
         st.markdown("---")
         col_back, _, col_fwd = st.columns([1, 3, 1])
@@ -99,13 +102,12 @@ def render_train() -> None:
 
 
 def _show_training_metrics(result: dict, dpsgd: bool) -> None:
+    """Render post-training accuracy / loss charts and summary cards."""
     train_result = result["train_result"]
     test_result = result["test_result"]
-
     train_acc_history = train_result.metrics.extra.get("accuracy_history", [])
     train_loss_history = train_result.metrics.extra.get("loss_history", [])
 
-    # Summary cards
     cols = st.columns(4)
     cols[0].metric("Final Train Accuracy", f"{train_result.metrics.accuracy:.3f}")
     cols[1].metric("Test Accuracy", f"{test_result.accuracy:.3f}")
@@ -113,26 +115,35 @@ def _show_training_metrics(result: dict, dpsgd: bool) -> None:
     if dpsgd and "dpsgd_params" in result:
         cols[3].metric("Target ε", f"{result['dpsgd_params']['target_epsilon']}")
 
-    # Training curves
     if train_acc_history:
         epochs = list(range(1, len(train_acc_history) + 1))
         fig = go.Figure()
-        fig.add_trace(go.Scatter(x=epochs, y=train_acc_history, name="Train Accuracy",
-                                 line=dict(color="#4C9BE8")))
-        fig.add_scatter(x=[epochs[-1]], y=[test_result.accuracy],
-                        mode="markers", name="Test Accuracy",
-                        marker=dict(color="#E84C4C", size=10, symbol="star"))
-        fig.update_layout(title="Accuracy over Epochs", xaxis_title="Epoch",
-                          yaxis_title="Accuracy", height=300, margin=dict(t=40))
+        fig.add_trace(go.Scatter(
+            x=epochs, y=train_acc_history, name="Train Accuracy",
+            line={"color": "#4C9BE8"},
+        ))
+        fig.add_scatter(
+            x=[epochs[-1]], y=[test_result.accuracy],
+            mode="markers", name="Test Accuracy",
+            marker={"color": "#E84C4C", "size": 10, "symbol": "star"},
+        )
+        fig.update_layout(
+            title="Accuracy over Epochs", xaxis_title="Epoch",
+            yaxis_title="Accuracy", height=300, margin={"t": 40},
+        )
         st.plotly_chart(fig, use_container_width=True)
 
     if train_loss_history:
         epochs = list(range(1, len(train_loss_history) + 1))
         fig2 = go.Figure()
-        fig2.add_trace(go.Scatter(x=epochs, y=train_loss_history, name="Train Loss",
-                                  line=dict(color="#F5A623")))
-        fig2.update_layout(title="Loss over Epochs", xaxis_title="Epoch",
-                           yaxis_title="Loss", height=300, margin=dict(t=40))
+        fig2.add_trace(go.Scatter(
+            x=epochs, y=train_loss_history, name="Train Loss",
+            line={"color": "#F5A623"},
+        ))
+        fig2.update_layout(
+            title="Loss over Epochs", xaxis_title="Epoch",
+            yaxis_title="Loss", height=300, margin={"t": 40},
+        )
         st.plotly_chart(fig2, use_container_width=True)
 
     st.success(f"Model saved to: `{result['target_folder']}`")

--- a/leakpro/ui/components/train.py
+++ b/leakpro/ui/components/train.py
@@ -23,7 +23,7 @@ def render_train() -> None:
     # ------------------------------------------------------------------ #
     st.subheader("Step 1 — Prepare Dataset")
 
-    if "data_result" not in st.session_state:
+    if not st.session_state.get("data_result"):
         if st.button("Download & Prepare Data", type="primary"):
             log_container = st.empty()
             status_msg = st.empty()
@@ -44,11 +44,11 @@ def render_train() -> None:
     # ------------------------------------------------------------------ #
     # Step 2b — Train model
     # ------------------------------------------------------------------ #
-    if "data_result" in st.session_state:
+    if st.session_state.get("data_result"):
         st.markdown("---")
         st.subheader("Step 2 — Train Model")
 
-        if "train_result_dict" not in st.session_state:
+        if not st.session_state.get("train_result_dict"):
             if st.button("Train Model", type="primary"):
                 log_placeholder = st.empty()
                 with st.spinner("Training… this may take several minutes."):
@@ -76,12 +76,11 @@ def render_train() -> None:
     # ------------------------------------------------------------------ #
     # Navigation
     # ------------------------------------------------------------------ #
-    if "train_result_dict" in st.session_state:
+    if st.session_state.get("train_result_dict"):
         st.markdown("---")
         col_back, _, col_fwd = st.columns([1, 3, 1])
         with col_back:
             if st.button("← Reconfigure", use_container_width=True):
-                # Clear training results when going back
                 st.session_state.pop("train_result_dict", None)
                 st.session_state.pop("data_result", None)
                 st.session_state.stage = 1
@@ -90,7 +89,7 @@ def render_train() -> None:
             if st.button("Run Attacks →", type="primary", use_container_width=True):
                 st.session_state.stage = 3
                 st.rerun()
-    elif "data_result" not in st.session_state:
+    elif not st.session_state.get("data_result"):
         st.markdown("---")
         col_back, _ = st.columns([1, 4])
         with col_back:

--- a/leakpro/ui/components/train.py
+++ b/leakpro/ui/components/train.py
@@ -1,0 +1,139 @@
+"""Stage 2 — Train the target model and display training metrics."""
+
+from __future__ import annotations
+
+import streamlit as st
+import plotly.graph_objects as go
+
+
+def render_train() -> None:
+    """Render the training stage."""
+    from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
+
+    st.title("🏋️  Stage 2 — Train Target Model")
+    dpsgd = st.session_state.get("dpsgd_enabled", False)
+    mode_label = "DP-SGD (differential privacy)" if dpsgd else "standard (no privacy)"
+    st.caption(f"Training mode: **{mode_label}**")
+
+    train_config = st.session_state.train_config
+    runner = LeakProRunner()
+
+    # ------------------------------------------------------------------ #
+    # Step 2a — Prepare dataset
+    # ------------------------------------------------------------------ #
+    st.subheader("Step 1 — Prepare Dataset")
+
+    if "data_result" not in st.session_state:
+        if st.button("Download & Prepare Data", type="primary"):
+            log_container = st.empty()
+            status_msg = st.empty()
+            with st.spinner("Preparing dataset…"):
+                try:
+                    data_result = runner.prepare_data(train_config, log_container=status_msg)
+                    st.session_state.data_result = data_result
+                    st.rerun()
+                except Exception as e:  # noqa: BLE001
+                    st.error(f"Data preparation failed: {e}")
+    else:
+        dr = st.session_state.data_result
+        st.success(
+            f"Dataset ready — {len(dr['train_indices'])} train / "
+            f"{len(dr['test_indices'])} test samples ({dr['dataset_name']})."
+        )
+
+    # ------------------------------------------------------------------ #
+    # Step 2b — Train model
+    # ------------------------------------------------------------------ #
+    if "data_result" in st.session_state:
+        st.markdown("---")
+        st.subheader("Step 2 — Train Model")
+
+        if "train_result_dict" not in st.session_state:
+            if st.button("Train Model", type="primary"):
+                log_placeholder = st.empty()
+                with st.spinner("Training… this may take several minutes."):
+                    try:
+                        if dpsgd:
+                            result = runner.train_dpsgd(
+                                train_config,
+                                st.session_state.dpsgd_params,
+                                st.session_state.data_result,
+                                log_container=log_placeholder,
+                            )
+                        else:
+                            result = runner.train_standard(
+                                train_config,
+                                st.session_state.data_result,
+                                log_container=log_placeholder,
+                            )
+                        st.session_state.train_result_dict = result
+                        st.rerun()
+                    except Exception as e:  # noqa: BLE001
+                        st.error(f"Training failed: {e}")
+        else:
+            _show_training_metrics(st.session_state.train_result_dict, dpsgd)
+
+    # ------------------------------------------------------------------ #
+    # Navigation
+    # ------------------------------------------------------------------ #
+    if "train_result_dict" in st.session_state:
+        st.markdown("---")
+        col_back, _, col_fwd = st.columns([1, 3, 1])
+        with col_back:
+            if st.button("← Reconfigure", use_container_width=True):
+                # Clear training results when going back
+                st.session_state.pop("train_result_dict", None)
+                st.session_state.pop("data_result", None)
+                st.session_state.stage = 1
+                st.rerun()
+        with col_fwd:
+            if st.button("Run Attacks →", type="primary", use_container_width=True):
+                st.session_state.stage = 3
+                st.rerun()
+    elif "data_result" not in st.session_state:
+        st.markdown("---")
+        col_back, _ = st.columns([1, 4])
+        with col_back:
+            if st.button("← Reconfigure", use_container_width=True):
+                st.session_state.stage = 1
+                st.rerun()
+
+
+def _show_training_metrics(result: dict, dpsgd: bool) -> None:
+    train_result = result["train_result"]
+    test_result = result["test_result"]
+
+    train_acc_history = train_result.metrics.extra.get("accuracy_history", [])
+    train_loss_history = train_result.metrics.extra.get("loss_history", [])
+
+    # Summary cards
+    cols = st.columns(4)
+    cols[0].metric("Final Train Accuracy", f"{train_result.metrics.accuracy:.3f}")
+    cols[1].metric("Test Accuracy", f"{test_result.accuracy:.3f}")
+    cols[2].metric("Final Train Loss", f"{train_result.metrics.loss:.4f}")
+    if dpsgd and "dpsgd_params" in result:
+        cols[3].metric("Target ε", f"{result['dpsgd_params']['target_epsilon']}")
+
+    # Training curves
+    if train_acc_history:
+        epochs = list(range(1, len(train_acc_history) + 1))
+        fig = go.Figure()
+        fig.add_trace(go.Scatter(x=epochs, y=train_acc_history, name="Train Accuracy",
+                                 line=dict(color="#4C9BE8")))
+        fig.add_scatter(x=[epochs[-1]], y=[test_result.accuracy],
+                        mode="markers", name="Test Accuracy",
+                        marker=dict(color="#E84C4C", size=10, symbol="star"))
+        fig.update_layout(title="Accuracy over Epochs", xaxis_title="Epoch",
+                          yaxis_title="Accuracy", height=300, margin=dict(t=40))
+        st.plotly_chart(fig, use_container_width=True)
+
+    if train_loss_history:
+        epochs = list(range(1, len(train_loss_history) + 1))
+        fig2 = go.Figure()
+        fig2.add_trace(go.Scatter(x=epochs, y=train_loss_history, name="Train Loss",
+                                  line=dict(color="#F5A623")))
+        fig2.update_layout(title="Loss over Epochs", xaxis_title="Epoch",
+                           yaxis_title="Loss", height=300, margin=dict(t=40))
+        st.plotly_chart(fig2, use_container_width=True)
+
+    st.success(f"Model saved to: `{result['target_folder']}`")

--- a/leakpro/ui/components/train.py
+++ b/leakpro/ui/components/train.py
@@ -31,22 +31,28 @@ def render_train() -> None:
 
 def _render_data_prep(runner: object, train_config: dict) -> None:
     """Render dataset download / status section."""
-    if not st.session_state.get("data_result"):
-        if st.button("Download & Prepare Data", type="primary"):
-            status_msg = st.empty()
-            with st.spinner("Preparing dataset…"):
-                try:
-                    data_result = runner.prepare_data(train_config, log_container=status_msg)  # type: ignore[attr-defined]
-                    st.session_state.data_result = data_result
-                    st.rerun()
-                except Exception as e:  # noqa: BLE001
-                    st.error(f"Data preparation failed: {e}")
-    else:
+    # Always allow re-preparing data so stale session indices don't carry over.
+    if st.session_state.get("data_result"):
         dr = st.session_state.data_result
         st.success(
             f"Dataset ready — {len(dr['train_indices'])} train / "
             f"{len(dr['test_indices'])} test samples ({dr['dataset_name']})."
         )
+        if st.button("Re-prepare Data"):
+            st.session_state.pop("data_result", None)
+            st.session_state.pop("train_result_dict", None)
+            st.rerun()
+        return
+
+    if st.button("Download & Prepare Data", type="primary"):
+        status_msg = st.empty()
+        with st.spinner("Preparing dataset…"):
+            try:
+                data_result = runner.prepare_data(train_config, log_container=status_msg)  # type: ignore[attr-defined]
+                st.session_state.data_result = data_result
+                st.rerun()
+            except Exception as e:  # noqa: BLE001
+                st.error(f"Data preparation failed: {e}")
 
 
 def _render_model_training(runner: object, train_config: dict, dpsgd: bool) -> None:

--- a/leakpro/ui/components/train.py
+++ b/leakpro/ui/components/train.py
@@ -1,4 +1,4 @@
-"""Stage 2 — Train the target model and display training metrics."""
+"""Stage 2 — Train all target models and display per-model metrics."""
 
 from __future__ import annotations
 
@@ -10,10 +10,9 @@ def render_train() -> None:
     """Render the training stage."""
     from leakpro.ui.runner import LeakProRunner  # noqa: PLC0415
 
-    st.title("🏋️  Stage 2 — Train Target Model")
-    dpsgd = st.session_state.get("dpsgd_enabled", False)
-    mode_label = "DP-SGD (differential privacy)" if dpsgd else "standard (no privacy)"
-    st.caption(f"Training mode: **{mode_label}**")
+    st.title("🏋️  Stage 2 — Train Models")
+    models: list[dict] = st.session_state.get("models", [])
+    st.caption(f"{len(models)} model(s) defined — each will be trained to its own folder.")
 
     train_config = st.session_state.train_config
     runner = LeakProRunner()
@@ -23,15 +22,14 @@ def render_train() -> None:
 
     if st.session_state.get("data_result"):
         st.markdown("---")
-        st.subheader("Step 2 — Train Model")
-        _render_model_training(runner, train_config, dpsgd)
+        st.subheader("Step 2 — Train Models")
+        _render_all_model_training(runner, train_config, models)
 
-    _render_navigation()
+    _render_navigation(models)
 
 
 def _render_data_prep(runner: object, train_config: dict) -> None:
     """Render dataset download / status section."""
-    # Always allow re-preparing data so stale session indices don't carry over.
     if st.session_state.get("data_result"):
         dr = st.session_state.data_result
         st.success(
@@ -40,7 +38,8 @@ def _render_data_prep(runner: object, train_config: dict) -> None:
         )
         if st.button("Re-prepare Data"):
             st.session_state.pop("data_result", None)
-            st.session_state.pop("train_result_dict", None)
+            for m in st.session_state.get("models", []):
+                m["train_result_dict"] = None
             st.rerun()
         return
 
@@ -55,42 +54,84 @@ def _render_data_prep(runner: object, train_config: dict) -> None:
                 st.error(f"Data preparation failed: {e}")
 
 
-def _render_model_training(runner: object, train_config: dict, dpsgd: bool) -> None:
-    """Render model training button and metrics."""
-    if not st.session_state.get("train_result_dict"):
-        if st.button("Train Model", type="primary"):
-            log_placeholder = st.empty()
-            with st.spinner("Training… this may take several minutes."):
-                try:
-                    if dpsgd:
-                        result = runner.train_dpsgd(  # type: ignore[attr-defined]
-                            train_config,
-                            st.session_state.dpsgd_params,
-                            st.session_state.data_result,
-                            log_container=log_placeholder,
-                        )
-                    else:
-                        result = runner.train_standard(  # type: ignore[attr-defined]
-                            train_config,
-                            st.session_state.data_result,
-                            log_container=log_placeholder,
-                        )
-                    st.session_state.train_result_dict = result
-                    st.rerun()
-                except Exception as e:  # noqa: BLE001
-                    st.error(f"Training failed: {e}")
-    else:
-        _show_training_metrics(st.session_state.train_result_dict, dpsgd)
+def _render_all_model_training(runner: object, train_config: dict, models: list[dict]) -> None:
+    """Render the Train All Models button and per-model result cards."""
+    all_trained = all(m.get("train_result_dict") for m in models)
+
+    if not all_trained:
+        pending = [m for m in models if not m.get("train_result_dict")]
+        st.caption(f"{len(pending)} model(s) still need training.")
+        if st.button("Train All Models", type="primary"):
+            for model in models:
+                if model.get("train_result_dict"):
+                    continue
+                with st.spinner(f"Training **{model['name']}**…"):
+                    log_ph = st.empty()
+                    try:
+                        if model["dpsgd_enabled"]:
+                            result = runner.train_dpsgd(  # type: ignore[attr-defined]
+                                train_config,
+                                model["dpsgd_params"],
+                                st.session_state.data_result,
+                                target_folder=model["target_folder"],
+                                log_container=log_ph,
+                            )
+                        else:
+                            result = runner.train_standard(  # type: ignore[attr-defined]
+                                train_config,
+                                st.session_state.data_result,
+                                target_folder=model["target_folder"],
+                                log_container=log_ph,
+                            )
+                        model["train_result_dict"] = result
+                        st.success(f"✅ {model['name']} trained.")
+                    except Exception as e:  # noqa: BLE001
+                        st.error(f"Training failed for **{model['name']}**: {e}")
+            st.session_state.models = models
+            st.rerun()
+
+    # Show results for already-trained models
+    trained = [m for m in models if m.get("train_result_dict")]
+    if trained:
+        st.markdown("##### Trained Models")
+        _render_training_summary_table(trained)
+        for model in trained:
+            with st.expander(f"📈 {model['name']} — training curves", expanded=False):
+                _show_training_metrics(model["train_result_dict"], model["dpsgd_enabled"])
 
 
-def _render_navigation() -> None:
+def _render_training_summary_table(models: list[dict]) -> None:
+    """Render a summary table of all trained models."""
+    import pandas as pd  # noqa: PLC0415
+
+    rows = []
+    for m in models:
+        tr = m["train_result_dict"]
+        train_acc = tr["train_result"].metrics.accuracy
+        test_acc = tr["test_result"].accuracy
+        dp_str = (
+            f"ε={m['dpsgd_params']['target_epsilon']}" if m["dpsgd_enabled"] else "No"
+        )
+        rows.append({
+            "Model": m["name"],
+            "Train Acc": f"{train_acc:.3f}",
+            "Test Acc": f"{test_acc:.3f}",
+            "DP-SGD": dp_str,
+            "Folder": tr["target_folder"],
+        })
+    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+
+
+def _render_navigation(models: list[dict]) -> None:
     """Render back / forward navigation buttons."""
-    if st.session_state.get("train_result_dict"):
+    all_trained = bool(models) and all(m.get("train_result_dict") for m in models)
+    if all_trained:
         st.markdown("---")
         col_back, _, col_fwd = st.columns([1, 3, 1])
         with col_back:
             if st.button("← Reconfigure", use_container_width=True):
-                st.session_state.pop("train_result_dict", None)
+                for m in models:
+                    m["train_result_dict"] = None
                 st.session_state.pop("data_result", None)
                 st.session_state.stage = 1
                 st.rerun()

--- a/leakpro/ui/dashboard.py
+++ b/leakpro/ui/dashboard.py
@@ -101,7 +101,7 @@ with st.sidebar:
                         background:rgba(39,174,96,0.1); font-size:13px;">
                 🛡️ <strong>DP-SGD ON</strong><br/>
                 ε = {dp.get('target_epsilon', '?')}<br/>
-                δ = {dp.get('target_delta', '?'):.2e if isinstance(dp.get('target_delta'), float) else '?'}
+                δ = {f"{dp['target_delta']:.2e}" if isinstance(dp.get('target_delta'), float) else '?'}
             </div>
             """,
             unsafe_allow_html=True,

--- a/leakpro/ui/dashboard.py
+++ b/leakpro/ui/dashboard.py
@@ -29,8 +29,7 @@ st.set_page_config(
 # ---- Session state defaults --------------------------------------------
 _STAGE_DEFAULTS: dict = {
     "stage": 0,
-    "train_config": None,
-    "audit_config": None,
+    "config_phase": 1,  # 1 = model count selector, 2 = per-model tabs
     "data_result": None,
     "models": [],  # list of model spec dicts — populated by configure.py
 }
@@ -50,7 +49,7 @@ _STAGES = [
 
 _STAGE_DONE_FLAGS = {
     0: lambda: st.session_state.stage > 0,
-    1: lambda: st.session_state.train_config is not None and st.session_state.stage > 1,
+    1: lambda: bool(st.session_state.get("models")) and st.session_state.stage > 1,
     2: lambda: any(m.get("train_result_dict") for m in st.session_state.get("models", [])),
     3: lambda: any(m.get("audit_results") for m in st.session_state.get("models", [])),
     4: lambda: False,  # results stage is never "done"

--- a/leakpro/ui/dashboard.py
+++ b/leakpro/ui/dashboard.py
@@ -1,0 +1,214 @@
+"""LeakPro Streamlit Auditor — main entry point.
+
+Launch with:
+    streamlit run leakpro/ui/dashboard.py
+
+from the project root directory.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+# Ensure project root is importable
+_PROJECT_ROOT = Path(__file__).parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# ---- Page config --------------------------------------------------------
+st.set_page_config(
+    page_title="LeakPro — Privacy Auditor",
+    page_icon="🔒",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+# ---- Session state defaults --------------------------------------------
+_STAGE_DEFAULTS: dict = {
+    "stage": 0,
+    "train_config": None,
+    "audit_config": None,
+    "dpsgd_enabled": False,
+    "dpsgd_params": None,
+    "data_result": None,
+    "train_result_dict": None,
+    "audit_results": None,
+}
+
+for key, default in _STAGE_DEFAULTS.items():
+    if key not in st.session_state:
+        st.session_state[key] = default
+
+# ---- Sidebar pipeline tracker ------------------------------------------
+_STAGES = [
+    (0, "Overview",        "🏠"),
+    (1, "Configure",       "⚙️"),
+    (2, "Train Model",     "🏋️"),
+    (3, "Run Attacks",     "🔍"),
+    (4, "Explore Results", "📊"),
+]
+
+_STAGE_DONE_FLAGS = {
+    0: lambda: st.session_state.stage > 0,
+    1: lambda: st.session_state.train_config is not None and st.session_state.stage > 1,
+    2: lambda: st.session_state.train_result_dict is not None,
+    3: lambda: st.session_state.audit_results is not None,
+    4: lambda: False,  # results stage is never "done"
+}
+
+
+def _stage_icon(stage_idx: int) -> str:
+    current = st.session_state.stage
+    if _STAGE_DONE_FLAGS[stage_idx]():
+        return "✅"
+    if stage_idx == current:
+        return "▶️"
+    return "○"
+
+
+with st.sidebar:
+    st.markdown("## 🔒 LeakPro")
+    st.markdown("**Privacy Audit Pipeline**")
+    st.markdown("---")
+
+    for idx, name, emoji in _STAGES:
+        icon = _stage_icon(idx)
+        label = f"{icon}  {emoji} {name}"
+
+        # Allow clicking completed stages to jump back
+        if idx < st.session_state.stage:
+            if st.button(label, key=f"nav_{idx}", use_container_width=True):
+                st.session_state.stage = idx
+                st.rerun()
+        else:
+            colour = "#4C9BE8" if idx == st.session_state.stage else "#666"
+            st.markdown(
+                f'<p style="color:{colour}; margin:4px 0; padding:6px 8px;">{label}</p>',
+                unsafe_allow_html=True,
+            )
+
+    st.markdown("---")
+
+    # DP-SGD indicator in sidebar
+    if st.session_state.dpsgd_enabled:
+        dp = st.session_state.dpsgd_params or {}
+        st.markdown(
+            f"""
+            <div style="padding:8px; border:1px solid #27AE60; border-radius:6px;
+                        background:rgba(39,174,96,0.1); font-size:13px;">
+                🛡️ <strong>DP-SGD ON</strong><br/>
+                ε = {dp.get('target_epsilon', '?')}<br/>
+                δ = {dp.get('target_delta', '?'):.2e if isinstance(dp.get('target_delta'), float) else '?'}
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+    else:
+        st.markdown(
+            """
+            <div style="padding:8px; border:1px solid #666; border-radius:6px;
+                        font-size:13px; color:#888;">
+                🔓 No DP-SGD
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+# ---- Helper rendered inside Stage 4 ------------------------------------
+
+def _render_attack_details(results: list) -> None:
+    """Render per-attack expandable detail sections."""
+    for r in results:
+        with st.expander(f"{r.result_name}  (AUC = {r.roc_auc:.4f if r.roc_auc else 'N/A'})"):
+            col1, col2 = st.columns(2)
+            with col1:
+                st.markdown("**Configuration**")
+                if r.metadata:
+                    import pandas as pd  # noqa: PLC0415
+                    meta = r.metadata if isinstance(r.metadata, dict) else r.metadata.model_dump()
+                    st.dataframe(
+                        pd.DataFrame(
+                            [{"Parameter": k, "Value": v} for k, v in meta.items()]
+                        ),
+                        use_container_width=True,
+                        hide_index=True,
+                    )
+                else:
+                    st.caption("No configuration metadata available.")
+
+            with col2:
+                st.markdown("**Metrics**")
+                rows = [
+                    {"Metric": "AUC", "Value": f"{r.roc_auc:.5f}" if r.roc_auc else "N/A"},
+                ]
+                if r.fixed_fpr_table:
+                    for k, v in r.fixed_fpr_table.items():
+                        rows.append({"Metric": k, "Value": f"{v:.5f}"})
+                import pandas as pd  # noqa: PLC0415
+                st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+
+
+# ---- Route to current stage --------------------------------------------
+current_stage = st.session_state.stage
+
+if current_stage == 0:
+    from leakpro.ui.components.overview import render_overview  # noqa: PLC0415
+    render_overview()
+
+elif current_stage == 1:
+    from leakpro.ui.components.configure import render_configure  # noqa: PLC0415
+    render_configure()
+
+elif current_stage == 2:
+    from leakpro.ui.components.train import render_train  # noqa: PLC0415
+    render_train()
+
+elif current_stage == 3:
+    from leakpro.ui.components.audit import render_audit  # noqa: PLC0415
+    render_audit()
+
+elif current_stage == 4:
+    # ---- Results stage with sub-tabs -----------------------------------
+    st.title("📊  Stage 4 — Explore Results")
+
+    results = st.session_state.get("audit_results", [])
+
+    if not results:
+        st.warning("No audit results found. Run the audit first (Stage 3).")
+        if st.button("← Go to Stage 3"):
+            st.session_state.stage = 3
+            st.rerun()
+    else:
+        tab_summary, tab_roc, tab_hist, tab_records, tab_detail = st.tabs([
+            "Summary", "ROC Analysis", "Signal Histograms", "Sensitive Records", "Attack Details"
+        ])
+
+        with tab_summary:
+            from leakpro.ui.components.results.summary import render_summary  # noqa: PLC0415
+            render_summary(results)
+
+        with tab_roc:
+            from leakpro.ui.components.results.roc_chart import render_roc  # noqa: PLC0415
+            render_roc(results)
+
+        with tab_hist:
+            from leakpro.ui.components.results.histograms import render_histograms  # noqa: PLC0415
+            render_histograms(results)
+
+        with tab_records:
+            from leakpro.ui.components.results.sensitive_records import render_sensitive_records  # noqa: PLC0415
+            render_sensitive_records(results)
+
+        with tab_detail:
+            _render_attack_details(results)
+
+        # Back button
+        st.markdown("---")
+        if st.button("← Run Another Audit"):
+            st.session_state.stage = 1
+            for key in ["data_result", "train_result_dict", "audit_results"]:
+                st.session_state.pop(key, None)
+            st.rerun()

--- a/leakpro/ui/dashboard.py
+++ b/leakpro/ui/dashboard.py
@@ -31,11 +31,8 @@ _STAGE_DEFAULTS: dict = {
     "stage": 0,
     "train_config": None,
     "audit_config": None,
-    "dpsgd_enabled": False,
-    "dpsgd_params": None,
     "data_result": None,
-    "train_result_dict": None,
-    "audit_results": None,
+    "models": [],  # list of model spec dicts — populated by configure.py
 }
 
 for key, default in _STAGE_DEFAULTS.items():
@@ -46,7 +43,7 @@ for key, default in _STAGE_DEFAULTS.items():
 _STAGES = [
     (0, "Overview",        "🏠"),
     (1, "Configure",       "⚙️"),
-    (2, "Train Model",     "🏋️"),
+    (2, "Train Models",    "🏋️"),
     (3, "Run Attacks",     "🔍"),
     (4, "Explore Results", "📊"),
 ]
@@ -54,8 +51,8 @@ _STAGES = [
 _STAGE_DONE_FLAGS = {
     0: lambda: st.session_state.stage > 0,
     1: lambda: st.session_state.train_config is not None and st.session_state.stage > 1,
-    2: lambda: st.session_state.train_result_dict is not None,
-    3: lambda: st.session_state.audit_results is not None,
+    2: lambda: any(m.get("train_result_dict") for m in st.session_state.get("models", [])),
+    3: lambda: any(m.get("audit_results") for m in st.session_state.get("models", [])),
     4: lambda: False,  # results stage is never "done"
 }
 
@@ -78,7 +75,6 @@ with st.sidebar:
         icon = _stage_icon(idx)
         label = f"{icon}  {emoji} {name}"
 
-        # Allow clicking completed stages to jump back
         if idx < st.session_state.stage:
             if st.button(label, key=f"nav_{idx}", use_container_width=True):
                 st.session_state.stage = idx
@@ -92,64 +88,61 @@ with st.sidebar:
 
     st.markdown("---")
 
-    # DP-SGD indicator in sidebar
-    if st.session_state.dpsgd_enabled:
-        dp = st.session_state.dpsgd_params or {}
+    # DP-SGD model summary in sidebar
+    _models = st.session_state.get("models", [])
+    _dp_models = [m for m in _models if m.get("dpsgd_enabled")]
+    if _dp_models:
+        lines = [f"🛡️ <strong>DP-SGD</strong> ({len(_dp_models)}/{len(_models)} models)"]
+        for m in _dp_models:
+            dp = m.get("dpsgd_params") or {}
+            eps = dp.get("target_epsilon", "?")
+            delta_val = dp.get("target_delta")
+            delta_str = f"{delta_val:.2e}" if isinstance(delta_val, float) else "?"
+            lines.append(f"&nbsp;&nbsp;• {m['name']}: ε={eps}, δ={delta_str}")
         st.markdown(
-            f"""
-            <div style="padding:8px; border:1px solid #27AE60; border-radius:6px;
-                        background:rgba(39,174,96,0.1); font-size:13px;">
-                🛡️ <strong>DP-SGD ON</strong><br/>
-                ε = {dp.get('target_epsilon', '?')}<br/>
-                δ = {f"{dp['target_delta']:.2e}" if isinstance(dp.get('target_delta'), float) else '?'}
-            </div>
-            """,
+            f"""<div style="padding:8px; border:1px solid #27AE60; border-radius:6px;
+                background:rgba(39,174,96,0.1); font-size:13px;">{"<br/>".join(lines)}</div>""",
             unsafe_allow_html=True,
         )
     else:
         st.markdown(
-            """
-            <div style="padding:8px; border:1px solid #666; border-radius:6px;
-                        font-size:13px; color:#888;">
-                🔓 No DP-SGD
-            </div>
-            """,
+            """<div style="padding:8px; border:1px solid #666; border-radius:6px;
+                font-size:13px; color:#888;">🔓 No DP-SGD</div>""",
             unsafe_allow_html=True,
         )
 
 # ---- Helper rendered inside Stage 4 ------------------------------------
 
-def _render_attack_details(results: list) -> None:
-    """Render per-attack expandable detail sections."""
-    for r in results:
-        auc_str = f"{r.roc_auc:.4f}" if r.roc_auc is not None else "N/A"
-        with st.expander(f"{r.result_name}  (AUC = {auc_str})"):
-            col1, col2 = st.columns(2)
-            with col1:
-                st.markdown("**Configuration**")
-                if r.metadata:
-                    import pandas as pd  # noqa: PLC0415
-                    meta = r.metadata if isinstance(r.metadata, dict) else r.metadata.model_dump()
-                    st.dataframe(
-                        pd.DataFrame(
-                            [{"Parameter": k, "Value": v} for k, v in meta.items()]
-                        ),
-                        use_container_width=True,
-                        hide_index=True,
-                    )
-                else:
-                    st.caption("No configuration metadata available.")
+def _render_attack_details(models: list) -> None:
+    """Render per-model, per-attack expandable detail sections."""
+    import pandas as pd  # noqa: PLC0415
 
-            with col2:
-                st.markdown("**Metrics**")
-                rows = [
-                    {"Metric": "AUC", "Value": f"{r.roc_auc:.5f}" if r.roc_auc is not None else "N/A"},
-                ]
-                if r.fixed_fpr_table:
-                    for k, v in r.fixed_fpr_table.items():
-                        rows.append({"Metric": k, "Value": f"{v:.5f}"})
-                import pandas as pd  # noqa: PLC0415
-                st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+    for m in models:
+        results = m.get("audit_results") or []
+        if not results:
+            continue
+        st.markdown(f"#### {m['name']}")
+        for r in results:
+            auc_str = f"{r.roc_auc:.4f}" if r.roc_auc is not None else "N/A"
+            with st.expander(f"{r.result_name}  (AUC = {auc_str})"):
+                col1, col2 = st.columns(2)
+                with col1:
+                    st.markdown("**Configuration**")
+                    if r.metadata:
+                        meta = r.metadata if isinstance(r.metadata, dict) else r.metadata.model_dump()
+                        st.dataframe(
+                            pd.DataFrame([{"Parameter": k, "Value": v} for k, v in meta.items()]),
+                            use_container_width=True, hide_index=True,
+                        )
+                    else:
+                        st.caption("No configuration metadata available.")
+                with col2:
+                    st.markdown("**Metrics**")
+                    rows = [{"Metric": "AUC", "Value": f"{r.roc_auc:.5f}" if r.roc_auc is not None else "N/A"}]
+                    if r.fixed_fpr_table:
+                        for k, v in r.fixed_fpr_table.items():
+                            rows.append({"Metric": k, "Value": f"{v:.5f}"})
+                    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
 
 
 # ---- Route to current stage --------------------------------------------
@@ -172,12 +165,11 @@ elif current_stage == 3:
     render_audit()
 
 elif current_stage == 4:
-    # ---- Results stage with sub-tabs -----------------------------------
     st.title("📊  Stage 4 — Explore Results")
 
-    results = st.session_state.get("audit_results", [])
+    audited_models = [m for m in st.session_state.get("models", []) if m.get("audit_results")]
 
-    if not results:
+    if not audited_models:
         st.warning("No audit results found. Run the audit first (Stage 3).")
         if st.button("← Go to Stage 3"):
             st.session_state.stage = 3
@@ -189,27 +181,28 @@ elif current_stage == 4:
 
         with tab_summary:
             from leakpro.ui.components.results.summary import render_summary  # noqa: PLC0415
-            render_summary(results)
+            render_summary(audited_models)
 
         with tab_roc:
             from leakpro.ui.components.results.roc_chart import render_roc  # noqa: PLC0415
-            render_roc(results)
+            render_roc(audited_models)
 
         with tab_hist:
             from leakpro.ui.components.results.histograms import render_histograms  # noqa: PLC0415
-            render_histograms(results)
+            render_histograms(audited_models)
 
         with tab_records:
             from leakpro.ui.components.results.sensitive_records import render_sensitive_records  # noqa: PLC0415
-            render_sensitive_records(results)
+            render_sensitive_records(audited_models)
 
         with tab_detail:
-            _render_attack_details(results)
+            _render_attack_details(audited_models)
 
-        # Back button
         st.markdown("---")
         if st.button("← Run Another Audit"):
             st.session_state.stage = 1
-            for key in ["data_result", "train_result_dict", "audit_results"]:
-                st.session_state.pop(key, None)
+            for m in st.session_state.get("models", []):
+                m["train_result_dict"] = None
+                m["audit_results"] = None
+            st.session_state.pop("data_result", None)
             st.rerun()

--- a/leakpro/ui/dashboard.py
+++ b/leakpro/ui/dashboard.py
@@ -122,7 +122,8 @@ with st.sidebar:
 def _render_attack_details(results: list) -> None:
     """Render per-attack expandable detail sections."""
     for r in results:
-        with st.expander(f"{r.result_name}  (AUC = {r.roc_auc:.4f if r.roc_auc else 'N/A'})"):
+        auc_str = f"{r.roc_auc:.4f}" if r.roc_auc is not None else "N/A"
+        with st.expander(f"{r.result_name}  (AUC = {auc_str})"):
             col1, col2 = st.columns(2)
             with col1:
                 st.markdown("**Configuration**")
@@ -142,7 +143,7 @@ def _render_attack_details(results: list) -> None:
             with col2:
                 st.markdown("**Metrics**")
                 rows = [
-                    {"Metric": "AUC", "Value": f"{r.roc_auc:.5f}" if r.roc_auc else "N/A"},
+                    {"Metric": "AUC", "Value": f"{r.roc_auc:.5f}" if r.roc_auc is not None else "N/A"},
                 ]
                 if r.fixed_fpr_table:
                     for k, v in r.fixed_fpr_table.items():

--- a/leakpro/ui/runner.py
+++ b/leakpro/ui/runner.py
@@ -366,12 +366,16 @@ class LeakProRunner:
     # ------------------------------------------------------------------
 
     def run_audit(
-        self, target_folder: str, dpsgd: bool = False, log_container: object | None = None
+        self,
+        target_folder: str,
+        attack_list: list[dict] | None = None,
+        dpsgd: bool = False,
+        log_container: object | None = None,
     ) -> list:
         """Run LeakPro MIA attacks against the model in target_folder.
 
-        Writes a temporary audit config overriding target.target_folder,
-        runs the audit, then deletes the temp file.
+        Writes a temporary audit config overriding target.target_folder and
+        (optionally) audit.attack_list, runs the audit, then deletes the temp file.
         """
         with _in_cifar_dir():
             if dpsgd:
@@ -386,6 +390,8 @@ class LeakProRunner:
             with open(base_config) as f:
                 config = yaml.safe_load(f)
             config["target"]["target_folder"] = target_folder
+            if attack_list:
+                config["audit"]["attack_list"] = attack_list
 
             temp_path = f"_audit_temp_{uuid.uuid4().hex}.yaml"
             try:

--- a/leakpro/ui/runner.py
+++ b/leakpro/ui/runner.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import numpy as np
 import torch
 import yaml
-from sklearn.model_selection import train_test_split
 from torch import cat, nn, optim, tensor
 from torch.utils.data import DataLoader
 from torchvision.datasets import CIFAR10, CIFAR100

--- a/leakpro/ui/runner.py
+++ b/leakpro/ui/runner.py
@@ -134,23 +134,29 @@ class LeakProRunner:
             # ---- import UserDataset (defined inside the handler) ---------
             from cifar_handler import CifarInputHandler  # noqa: PLC0415
 
-            population_dataset = CifarInputHandler.UserDataset(data, targets)
-
-            # ---- save population pickle if missing -----------------------
-            pkl_path = Path(f"data/{dataset_name}.pkl")
-            pkl_path.parent.mkdir(exist_ok=True)
-            if not pkl_path.exists():
-                with open(pkl_path, "wb") as f:
-                    pickle.dump(population_dataset, f)
-                if log_container:
-                    log_container.success(f"Population dataset saved to {pkl_path}")
-
-            # ---- train / test split --------------------------------------
-            dataset_size = len(population_dataset)
+            # ---- train / test split with sequential indices --------------
+            # Shuffle the full dataset so the split is random, but assign
+            # sequential (0-based) indices so that position == population-index.
+            # This is required by the MIA attack logit-cache which assumes
+            # logits[i] corresponds to population point i.
+            dataset_size = len(data)
             train_size = int(f_train * dataset_size)
             test_size = int(f_test * dataset_size)
-            selected = np.random.choice(np.arange(dataset_size), train_size + test_size, replace=False)
-            train_indices, test_indices = train_test_split(selected, test_size=test_size)
+            perm = np.random.permutation(dataset_size)
+            data = data[perm]
+            targets = targets[perm]
+            train_indices = np.arange(train_size)                        # [0 … train_size-1]
+            test_indices = np.arange(train_size, train_size + test_size) # [train_size … train_size+test_size-1]
+
+            population_dataset = CifarInputHandler.UserDataset(data, targets)
+
+            # ---- always overwrite the population pickle so it matches ----
+            pkl_path = Path(f"data/{dataset_name}.pkl")
+            pkl_path.parent.mkdir(exist_ok=True)
+            with open(pkl_path, "wb") as f:
+                pickle.dump(population_dataset, f)
+            if log_container:
+                log_container.success(f"Population dataset saved to {pkl_path}")
 
             train_subset = CifarInputHandler.UserDataset(data[train_indices], targets[train_indices])
             test_subset = CifarInputHandler.UserDataset(

--- a/leakpro/ui/runner.py
+++ b/leakpro/ui/runner.py
@@ -11,12 +11,14 @@ import logging
 import os
 import pickle
 import sys
+import uuid
 from collections.abc import Iterator
 from pathlib import Path
 
 import numpy as np
 import torch
 import yaml
+from sklearn.model_selection import train_test_split
 from torch import cat, nn, optim, tensor
 from torch.utils.data import DataLoader
 from torchvision.datasets import CIFAR10, CIFAR100
@@ -120,7 +122,6 @@ class LeakProRunner:
             if log_container:
                 log_container.info(f"Downloading / loading {dataset_name}…")
 
-            # ---- load torchvision dataset --------------------------------
             cls = CIFAR10 if dataset_name == "cifar10" else CIFAR100
             trainset = cls(root=root, train=True, download=True)
             testset = cls(root=root, train=False, download=True)
@@ -130,32 +131,23 @@ class LeakProRunner:
             data = cat([train_data, test_data], dim=0)
             targets = cat([tensor(trainset.targets), tensor(testset.targets)], dim=0)
 
-            # ---- import UserDataset (defined inside the handler) ---------
             from cifar_handler import CifarInputHandler  # noqa: PLC0415
-
-            # ---- train / test split with sequential indices --------------
-            # Shuffle the full dataset so the split is random, but assign
-            # sequential (0-based) indices so that position == population-index.
-            # This is required by the MIA attack logit-cache which assumes
-            # logits[i] corresponds to population point i.
-            dataset_size = len(data)
-            train_size = int(f_train * dataset_size)
-            test_size = int(f_test * dataset_size)
-            perm = np.random.permutation(dataset_size)
-            data = data[perm]
-            targets = targets[perm]
-            train_indices = np.arange(train_size)                        # [0 … train_size-1]
-            test_indices = np.arange(train_size, train_size + test_size) # [train_size … train_size+test_size-1]
 
             population_dataset = CifarInputHandler.UserDataset(data, targets)
 
-            # ---- always overwrite the population pickle so it matches ----
             pkl_path = Path(f"data/{dataset_name}.pkl")
             pkl_path.parent.mkdir(exist_ok=True)
-            with open(pkl_path, "wb") as f:
-                pickle.dump(population_dataset, f)
-            if log_container:
-                log_container.success(f"Population dataset saved to {pkl_path}")
+            if not pkl_path.exists():
+                with open(pkl_path, "wb") as f:
+                    pickle.dump(population_dataset, f)
+                if log_container:
+                    log_container.success(f"Population dataset saved to {pkl_path}")
+
+            dataset_size = len(population_dataset)
+            train_size = int(f_train * dataset_size)
+            test_size = int(f_test * dataset_size)
+            selected = np.random.choice(np.arange(dataset_size), train_size + test_size, replace=False)
+            train_indices, test_indices = train_test_split(selected, test_size=test_size)
 
             train_subset = CifarInputHandler.UserDataset(data[train_indices], targets[train_indices])
             test_subset = CifarInputHandler.UserDataset(
@@ -186,7 +178,11 @@ class LeakProRunner:
     # ------------------------------------------------------------------
 
     def train_standard(
-        self, train_config: dict, data_result: dict, log_container: object | None = None
+        self,
+        train_config: dict,
+        data_result: dict,
+        target_folder: str,
+        log_container: object | None = None,
     ) -> dict:
         """Train target model without differential privacy.
 
@@ -202,8 +198,8 @@ class LeakProRunner:
             epochs: int = train_config["train"]["epochs"]
             lr: float = train_config["train"]["learning_rate"]
             weight_decay: float = train_config["train"]["weight_decay"]
-            target_folder = Path(train_config["run"]["log_dir"])
-            target_folder.mkdir(parents=True, exist_ok=True)
+            folder = Path(target_folder)
+            folder.mkdir(parents=True, exist_ok=True)
 
             model = WideResNet(depth=28, num_classes=num_classes, widen_factor=2)
             criterion = nn.CrossEntropyLoss()
@@ -226,11 +222,8 @@ class LeakProRunner:
                 data_result["test_loader"], train_result.model, criterion
             )
 
-            # Save model
-            model_path = target_folder / "target_model.pkl"
-            torch.save(train_result.model.state_dict(), model_path)
+            torch.save(train_result.model.state_dict(), folder / "target_model.pkl")
 
-            # Save metadata
             meta = LeakPro.make_mia_metadata(
                 train_result=train_result,
                 optimizer=optimizer,
@@ -242,7 +235,7 @@ class LeakProRunner:
                 test_indices=data_result["test_indices"],
                 dataset_name=data_result["dataset_name"],
             )
-            with open(target_folder / "model_metadata.pkl", "wb") as f:
+            with open(folder / "model_metadata.pkl", "wb") as f:
                 pickle.dump(meta, f)
 
             if log_container:
@@ -256,7 +249,7 @@ class LeakProRunner:
                 "train_result": train_result,
                 "test_result": test_result,
                 "epochs": epochs,
-                "target_folder": str(target_folder),
+                "target_folder": str(folder),
                 "optimizer": optimizer,
                 "criterion": criterion,
             }
@@ -270,6 +263,7 @@ class LeakProRunner:
         train_config: dict,
         dpsgd_params: dict,
         data_result: dict,
+        target_folder: str,
         log_container: object | None = None,
     ) -> dict:
         """Train target model with differential privacy (DP-SGD via Opacus).
@@ -277,7 +271,7 @@ class LeakProRunner:
         dpsgd_params keys: target_epsilon, target_delta, max_grad_norm,
                            virtual_batch_size (optional, default 16)
 
-        Returns same dict shape as train_standard, plus 'achieved_epsilon'.
+        Returns same dict shape as train_standard, plus 'dpsgd_params'.
         """
         with _in_cifar_dir():
             from cifar_handler_dpsgd import CifarInputHandlerDPsgd  # noqa: PLC0415
@@ -288,12 +282,11 @@ class LeakProRunner:
             epochs: int = train_config["train"]["epochs"]
             lr: float = train_config["train"]["learning_rate"]
             momentum: float = train_config["train"].get("momentum", 0.9)
-            target_folder = Path("target_dpsgd")
-            target_folder.mkdir(parents=True, exist_ok=True)
+            folder = Path(target_folder)
+            folder.mkdir(parents=True, exist_ok=True)
 
             virtual_batch_size: int = dpsgd_params.get("virtual_batch_size", 16)
 
-            # Build and save dpsgd_dic.pkl that the handler reads
             sample_rate = 1.0 / len(data_result["train_loader"])
             privacy_dict = {
                 "target_epsilon": dpsgd_params["target_epsilon"],
@@ -305,7 +298,7 @@ class LeakProRunner:
                 "eps_error": 0.01,
                 "max_grad_norm": dpsgd_params["max_grad_norm"],
             }
-            privacy_pkl_path = str(target_folder / "dpsgd_dic.pkl")
+            privacy_pkl_path = str(folder / "dpsgd_dic.pkl")
             with open(privacy_pkl_path, "wb") as f:
                 pickle.dump(privacy_dict, f)
 
@@ -335,7 +328,7 @@ class LeakProRunner:
                 data_result["test_loader"], train_result.model, criterion
             )
 
-            torch.save(train_result.model.state_dict(), target_folder / "target_model.pkl")
+            torch.save(train_result.model.state_dict(), folder / "target_model.pkl")
 
             meta = LeakPro.make_mia_metadata(
                 train_result=train_result,
@@ -348,7 +341,7 @@ class LeakProRunner:
                 test_indices=data_result["test_indices"],
                 dataset_name=data_result["dataset_name"],
             )
-            with open(target_folder / "model_metadata.pkl", "wb") as f:
+            with open(folder / "model_metadata.pkl", "wb") as f:
                 pickle.dump(meta, f)
 
             if log_container:
@@ -362,7 +355,7 @@ class LeakProRunner:
                 "train_result": train_result,
                 "test_result": test_result,
                 "epochs": epochs,
-                "target_folder": str(target_folder),
+                "target_folder": str(folder),
                 "optimizer": optimizer,
                 "criterion": criterion,
                 "dpsgd_params": privacy_dict,
@@ -372,25 +365,44 @@ class LeakProRunner:
     # Stage 3 – run audit
     # ------------------------------------------------------------------
 
-    def run_audit(self, dpsgd: bool = False, log_container: object | None = None) -> list:
-        """Run LeakPro MIA attacks and return a list of MIAResult objects."""
+    def run_audit(
+        self, target_folder: str, dpsgd: bool = False, log_container: object | None = None
+    ) -> list:
+        """Run LeakPro MIA attacks against the model in target_folder.
+
+        Writes a temporary audit config overriding target.target_folder,
+        runs the audit, then deletes the temp file.
+        """
         with _in_cifar_dir():
             if dpsgd:
                 from cifar_handler_dpsgd import CifarInputHandlerDPsgd  # noqa: PLC0415
                 handler_cls = CifarInputHandlerDPsgd
-                config_path = "audit_dpsgd.yaml"
+                base_config = "audit_dpsgd.yaml"
             else:
                 from cifar_handler import CifarInputHandler  # noqa: PLC0415
                 handler_cls = CifarInputHandler
-                config_path = "audit.yaml"
+                base_config = "audit.yaml"
 
-            if log_container:
-                log_container.info(f"Initialising audit with config: {config_path}")
+            with open(base_config) as f:
+                config = yaml.safe_load(f)
+            config["target"]["target_folder"] = target_folder
 
-            maybe_stream = _stream_logs(log_container) if log_container else contextlib.nullcontext()
-            with maybe_stream:
-                leakpro = LeakPro(handler_cls, config_path)
-                results = leakpro.run_audit(create_pdf=False)
+            temp_path = f"_audit_temp_{uuid.uuid4().hex}.yaml"
+            try:
+                with open(temp_path, "w") as f:
+                    yaml.dump(config, f)
+
+                if log_container:
+                    log_container.info(
+                        f"Auditing model at '{target_folder}' with config: {base_config}"
+                    )
+
+                maybe_stream = _stream_logs(log_container) if log_container else contextlib.nullcontext()
+                with maybe_stream:
+                    leakpro = LeakPro(handler_cls, temp_path)
+                    results = leakpro.run_audit(create_pdf=False)
+            finally:
+                Path(temp_path).unlink(missing_ok=True)
 
             if log_container:
                 log_container.success(f"Audit complete — {len(results)} attack(s) finished.")

--- a/leakpro/ui/runner.py
+++ b/leakpro/ui/runner.py
@@ -28,6 +28,12 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 _CIFAR_DIR = _PROJECT_ROOT / "examples" / "mia" / "cifar"
 
+# Also put the CIFAR dir on sys.path so that LeakPro's internal re-imports
+# of the handler (e.g. during shadow model training) can find 'cifar_handler'
+# by its simple module name — matching how the notebooks import it.
+if str(_CIFAR_DIR) not in sys.path:
+    sys.path.insert(0, str(_CIFAR_DIR))
+
 # Lazy imports from leakpro (available once project root is on path)
 from leakpro import LeakPro  # noqa: E402
 from leakpro.utils.logger import logger as leakpro_logger  # noqa: E402
@@ -124,7 +130,7 @@ class LeakProRunner:
             targets = cat([tensor(trainset.targets), tensor(testset.targets)], dim=0)
 
             # ---- import UserDataset (defined inside the handler) ---------
-            from examples.mia.cifar.cifar_handler import CifarInputHandler  # noqa: PLC0415
+            from cifar_handler import CifarInputHandler  # noqa: PLC0415
 
             population_dataset = CifarInputHandler.UserDataset(data, targets)
 
@@ -179,8 +185,8 @@ class LeakProRunner:
             model, train_result, test_result, epochs, target_folder
         """
         with _in_cifar_dir():
-            from examples.mia.cifar.cifar_handler import CifarInputHandler  # noqa: PLC0415
-            from examples.mia.cifar.target_model_class import WideResNet  # noqa: PLC0415
+            from cifar_handler import CifarInputHandler  # noqa: PLC0415
+            from target_model_class import WideResNet  # noqa: PLC0415
 
             dataset_name: str = data_result["dataset_name"]
             num_classes = 10 if dataset_name == "cifar10" else 100
@@ -265,8 +271,8 @@ class LeakProRunner:
         Returns same dict shape as train_standard, plus 'achieved_epsilon'.
         """
         with _in_cifar_dir():
-            from examples.mia.cifar.cifar_handler_dpsgd import CifarInputHandlerDPsgd  # noqa: PLC0415
-            from examples.mia.cifar.target_model_class import ResNet18_DPsgd  # noqa: PLC0415
+            from cifar_handler_dpsgd import CifarInputHandlerDPsgd  # noqa: PLC0415
+            from target_model_class import ResNet18_DPsgd  # noqa: PLC0415
 
             dataset_name: str = data_result["dataset_name"]
             num_classes = 10 if dataset_name == "cifar10" else 100
@@ -361,11 +367,11 @@ class LeakProRunner:
         """Run LeakPro MIA attacks and return a list of MIAResult objects."""
         with _in_cifar_dir():
             if dpsgd:
-                from examples.mia.cifar.cifar_handler_dpsgd import CifarInputHandlerDPsgd  # noqa: PLC0415
+                from cifar_handler_dpsgd import CifarInputHandlerDPsgd  # noqa: PLC0415
                 handler_cls = CifarInputHandlerDPsgd
                 config_path = "audit_dpsgd.yaml"
             else:
-                from examples.mia.cifar.cifar_handler import CifarInputHandler  # noqa: PLC0415
+                from cifar_handler import CifarInputHandler  # noqa: PLC0415
                 handler_cls = CifarInputHandler
                 config_path = "audit.yaml"
 

--- a/leakpro/ui/runner.py
+++ b/leakpro/ui/runner.py
@@ -11,6 +11,7 @@ import logging
 import os
 import pickle
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import numpy as np
@@ -35,8 +36,8 @@ if str(_CIFAR_DIR) not in sys.path:
     sys.path.insert(0, str(_CIFAR_DIR))
 
 # Lazy imports from leakpro (available once project root is on path)
-from leakpro import LeakPro  # noqa: E402
-from leakpro.utils.logger import logger as leakpro_logger  # noqa: E402
+from leakpro import LeakPro  # noqa: E402, I001
+from leakpro.utils.logger import logger as leakpro_logger  # noqa: E402, I001
 
 
 # ---------------------------------------------------------------------------
@@ -49,13 +50,14 @@ class StreamlitLogHandler(logging.Handler):
     Attach before a long-running call; detach afterwards.
     """
 
-    def __init__(self, container) -> None:
+    def __init__(self, container: object) -> None:
         super().__init__()
         self.container = container
         self._lines: list[str] = []
         self.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(message)s"))
 
     def emit(self, record: logging.LogRecord) -> None:
+        """Format and emit a log record to the Streamlit container."""
         msg = self.format(record)
         self._lines.append(msg)
         # Keep only the most recent 30 lines to avoid giant text areas
@@ -63,7 +65,7 @@ class StreamlitLogHandler(logging.Handler):
 
 
 @contextlib.contextmanager
-def _stream_logs(container):
+def _stream_logs(container: object) -> Iterator[StreamlitLogHandler]:
     """Context manager that attaches/detaches a StreamlitLogHandler."""
     handler = StreamlitLogHandler(container)
     leakpro_logger.addHandler(handler)
@@ -74,7 +76,7 @@ def _stream_logs(container):
 
 
 @contextlib.contextmanager
-def _in_cifar_dir():
+def _in_cifar_dir() -> Iterator[None]:
     """Temporarily change the working directory to the CIFAR example folder.
 
     This is required because audit.yaml uses relative paths (./target, ./data/…).
@@ -98,7 +100,7 @@ class LeakProRunner:
     # Stage 2a – prepare dataset
     # ------------------------------------------------------------------
 
-    def prepare_data(self, train_config: dict, log_container=None) -> dict:
+    def prepare_data(self, train_config: dict, log_container: object | None = None) -> dict:
         """Download CIFAR data, build population dataset, create train/test splits.
 
         Returns a dict with keys:
@@ -178,7 +180,9 @@ class LeakProRunner:
     # Stage 2b – standard training
     # ------------------------------------------------------------------
 
-    def train_standard(self, train_config: dict, data_result: dict, log_container=None) -> dict:
+    def train_standard(
+        self, train_config: dict, data_result: dict, log_container: object | None = None
+    ) -> dict:
         """Train target model without differential privacy.
 
         Returns a dict with keys:
@@ -261,7 +265,7 @@ class LeakProRunner:
         train_config: dict,
         dpsgd_params: dict,
         data_result: dict,
-        log_container=None,
+        log_container: object | None = None,
     ) -> dict:
         """Train target model with differential privacy (DP-SGD via Opacus).
 
@@ -363,7 +367,7 @@ class LeakProRunner:
     # Stage 3 – run audit
     # ------------------------------------------------------------------
 
-    def run_audit(self, dpsgd: bool = False, log_container=None) -> list:
+    def run_audit(self, dpsgd: bool = False, log_container: object | None = None) -> list:
         """Run LeakPro MIA attacks and return a list of MIAResult objects."""
         with _in_cifar_dir():
             if dpsgd:
@@ -402,20 +406,20 @@ class LeakProRunner:
         if not data_objects_dir.exists():
             return results
         for json_file in sorted(data_objects_dir.glob("*.json")):
-            try:
+            with contextlib.suppress(Exception):
                 results.append(MIAResult.load(str(json_file)))
-            except Exception:  # noqa: BLE001
-                pass
         return results
 
     @staticmethod
     def default_train_config() -> dict:
+        """Return the default training configuration loaded from CIFAR train_config.yaml."""
         config_path = _CIFAR_DIR / "train_config.yaml"
         with open(config_path) as f:
             return yaml.safe_load(f)
 
     @staticmethod
     def default_audit_config() -> dict:
+        """Return the default audit configuration loaded from CIFAR audit.yaml."""
         config_path = _CIFAR_DIR / "audit.yaml"
         with open(config_path) as f:
             return yaml.safe_load(f)

--- a/leakpro/ui/runner.py
+++ b/leakpro/ui/runner.py
@@ -1,0 +1,415 @@
+"""Backend runner: wraps the LeakPro pipeline for the Streamlit UI.
+
+Handles data preparation, model training (standard + DP-SGD), and audit execution.
+Log messages are streamed to the UI via a custom logging handler.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import pickle
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import yaml
+from sklearn.model_selection import train_test_split
+from torch import cat, nn, optim, tensor
+from torch.utils.data import DataLoader
+from torchvision.datasets import CIFAR10, CIFAR100
+
+# Ensure project root is on sys.path when the UI is launched directly
+_PROJECT_ROOT = Path(__file__).parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+_CIFAR_DIR = _PROJECT_ROOT / "examples" / "mia" / "cifar"
+
+# Lazy imports from leakpro (available once project root is on path)
+from leakpro import LeakPro  # noqa: E402
+from leakpro.utils.logger import logger as leakpro_logger  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Streamlit log handler
+# ---------------------------------------------------------------------------
+
+class StreamlitLogHandler(logging.Handler):
+    """Captures leakpro log messages and writes them to a Streamlit container.
+
+    Attach before a long-running call; detach afterwards.
+    """
+
+    def __init__(self, container) -> None:
+        super().__init__()
+        self.container = container
+        self._lines: list[str] = []
+        self.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        msg = self.format(record)
+        self._lines.append(msg)
+        # Keep only the most recent 30 lines to avoid giant text areas
+        self.container.code("\n".join(self._lines[-30:]), language=None)
+
+
+@contextlib.contextmanager
+def _stream_logs(container):
+    """Context manager that attaches/detaches a StreamlitLogHandler."""
+    handler = StreamlitLogHandler(container)
+    leakpro_logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        leakpro_logger.removeHandler(handler)
+
+
+@contextlib.contextmanager
+def _in_cifar_dir():
+    """Temporarily change the working directory to the CIFAR example folder.
+
+    This is required because audit.yaml uses relative paths (./target, ./data/…).
+    """
+    original = os.getcwd()
+    os.chdir(_CIFAR_DIR)
+    try:
+        yield
+    finally:
+        os.chdir(original)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline runner
+# ---------------------------------------------------------------------------
+
+class LeakProRunner:
+    """Orchestrates the full LeakPro auditing pipeline for the Streamlit UI."""
+
+    # ------------------------------------------------------------------
+    # Stage 2a – prepare dataset
+    # ------------------------------------------------------------------
+
+    def prepare_data(self, train_config: dict, log_container=None) -> dict:
+        """Download CIFAR data, build population dataset, create train/test splits.
+
+        Returns a dict with keys:
+            data, targets, population_dataset, dataset_name,
+            train_loader, test_loader, train_indices, test_indices
+        """
+        with _in_cifar_dir():
+            dataset_name: str = train_config["data"]["dataset"]
+            root: str = train_config["data"]["data_dir"]
+            batch_size: int = train_config["train"]["batch_size"]
+            f_train: float = train_config["data"]["f_train"]
+            f_test: float = train_config["data"]["f_test"]
+            random_seed: int = train_config["run"].get("random_seed", 42)
+
+            np.random.seed(random_seed)
+            torch.manual_seed(random_seed)
+
+            if log_container:
+                log_container.info(f"Downloading / loading {dataset_name}…")
+
+            # ---- load torchvision dataset --------------------------------
+            cls = CIFAR10 if dataset_name == "cifar10" else CIFAR100
+            trainset = cls(root=root, train=True, download=True)
+            testset = cls(root=root, train=False, download=True)
+
+            train_data = tensor(trainset.data).permute(0, 3, 1, 2).float() / 255
+            test_data = tensor(testset.data).permute(0, 3, 1, 2).float() / 255
+            data = cat([train_data, test_data], dim=0)
+            targets = cat([tensor(trainset.targets), tensor(testset.targets)], dim=0)
+
+            # ---- import UserDataset (defined inside the handler) ---------
+            from examples.mia.cifar.cifar_handler import CifarInputHandler  # noqa: PLC0415
+
+            population_dataset = CifarInputHandler.UserDataset(data, targets)
+
+            # ---- save population pickle if missing -----------------------
+            pkl_path = Path(f"data/{dataset_name}.pkl")
+            pkl_path.parent.mkdir(exist_ok=True)
+            if not pkl_path.exists():
+                with open(pkl_path, "wb") as f:
+                    pickle.dump(population_dataset, f)
+                if log_container:
+                    log_container.success(f"Population dataset saved to {pkl_path}")
+
+            # ---- train / test split --------------------------------------
+            dataset_size = len(population_dataset)
+            train_size = int(f_train * dataset_size)
+            test_size = int(f_test * dataset_size)
+            selected = np.random.choice(np.arange(dataset_size), train_size + test_size, replace=False)
+            train_indices, test_indices = train_test_split(selected, test_size=test_size)
+
+            train_subset = CifarInputHandler.UserDataset(data[train_indices], targets[train_indices])
+            test_subset = CifarInputHandler.UserDataset(
+                data[test_indices], targets[test_indices], **train_subset.return_params()
+            )
+
+            train_loader = DataLoader(train_subset, batch_size=batch_size, shuffle=True)
+            test_loader = DataLoader(test_subset, batch_size=batch_size, shuffle=False)
+
+            if log_container:
+                log_container.success(
+                    f"Dataset ready — {train_size} train / {test_size} test samples."
+                )
+
+            return {
+                "data": data,
+                "targets": targets,
+                "population_dataset": population_dataset,
+                "dataset_name": dataset_name,
+                "train_loader": train_loader,
+                "test_loader": test_loader,
+                "train_indices": train_indices,
+                "test_indices": test_indices,
+            }
+
+    # ------------------------------------------------------------------
+    # Stage 2b – standard training
+    # ------------------------------------------------------------------
+
+    def train_standard(self, train_config: dict, data_result: dict, log_container=None) -> dict:
+        """Train target model without differential privacy.
+
+        Returns a dict with keys:
+            model, train_result, test_result, epochs, target_folder
+        """
+        with _in_cifar_dir():
+            from examples.mia.cifar.cifar_handler import CifarInputHandler  # noqa: PLC0415
+            from examples.mia.cifar.target_model_class import WideResNet  # noqa: PLC0415
+
+            dataset_name: str = data_result["dataset_name"]
+            num_classes = 10 if dataset_name == "cifar10" else 100
+            epochs: int = train_config["train"]["epochs"]
+            lr: float = train_config["train"]["learning_rate"]
+            weight_decay: float = train_config["train"]["weight_decay"]
+            target_folder = Path(train_config["run"]["log_dir"])
+            target_folder.mkdir(parents=True, exist_ok=True)
+
+            model = WideResNet(depth=28, num_classes=num_classes, widen_factor=2)
+            criterion = nn.CrossEntropyLoss()
+            optimizer = optim.Adam(model.parameters(), lr=lr, weight_decay=weight_decay)
+
+            if log_container:
+                log_container.info("Starting standard training…")
+
+            maybe_stream = _stream_logs(log_container) if log_container else contextlib.nullcontext()
+            with maybe_stream:
+                train_result = CifarInputHandler().train(
+                    dataloader=data_result["train_loader"],
+                    model=model,
+                    criterion=criterion,
+                    optimizer=optimizer,
+                    epochs=epochs,
+                )
+
+            test_result = CifarInputHandler().eval(
+                data_result["test_loader"], train_result.model, criterion
+            )
+
+            # Save model
+            model_path = target_folder / "target_model.pkl"
+            torch.save(train_result.model.state_dict(), model_path)
+
+            # Save metadata
+            meta = LeakPro.make_mia_metadata(
+                train_result=train_result,
+                optimizer=optimizer,
+                loss_fn=criterion,
+                dataloader=data_result["train_loader"],
+                test_result=test_result,
+                epochs=epochs,
+                train_indices=data_result["train_indices"],
+                test_indices=data_result["test_indices"],
+                dataset_name=data_result["dataset_name"],
+            )
+            with open(target_folder / "model_metadata.pkl", "wb") as f:
+                pickle.dump(meta, f)
+
+            if log_container:
+                log_container.success(
+                    f"Training complete — train acc: {train_result.metrics.accuracy:.3f}, "
+                    f"test acc: {test_result.accuracy:.3f}"
+                )
+
+            return {
+                "model": train_result.model,
+                "train_result": train_result,
+                "test_result": test_result,
+                "epochs": epochs,
+                "target_folder": str(target_folder),
+                "optimizer": optimizer,
+                "criterion": criterion,
+            }
+
+    # ------------------------------------------------------------------
+    # Stage 2c – DP-SGD training
+    # ------------------------------------------------------------------
+
+    def train_dpsgd(
+        self,
+        train_config: dict,
+        dpsgd_params: dict,
+        data_result: dict,
+        log_container=None,
+    ) -> dict:
+        """Train target model with differential privacy (DP-SGD via Opacus).
+
+        dpsgd_params keys: target_epsilon, target_delta, max_grad_norm,
+                           virtual_batch_size (optional, default 16)
+
+        Returns same dict shape as train_standard, plus 'achieved_epsilon'.
+        """
+        with _in_cifar_dir():
+            from examples.mia.cifar.cifar_handler_dpsgd import CifarInputHandlerDPsgd  # noqa: PLC0415
+            from examples.mia.cifar.target_model_class import ResNet18_DPsgd  # noqa: PLC0415
+
+            dataset_name: str = data_result["dataset_name"]
+            num_classes = 10 if dataset_name == "cifar10" else 100
+            epochs: int = train_config["train"]["epochs"]
+            lr: float = train_config["train"]["learning_rate"]
+            momentum: float = train_config["train"].get("momentum", 0.9)
+            target_folder = Path("target_dpsgd")
+            target_folder.mkdir(parents=True, exist_ok=True)
+
+            virtual_batch_size: int = dpsgd_params.get("virtual_batch_size", 16)
+
+            # Build and save dpsgd_dic.pkl that the handler reads
+            sample_rate = 1.0 / len(data_result["train_loader"])
+            privacy_dict = {
+                "target_epsilon": dpsgd_params["target_epsilon"],
+                "target_delta": dpsgd_params["target_delta"],
+                "sample_rate": sample_rate,
+                "epochs": epochs,
+                "epsilon_tolerance": 0.01,
+                "accountant": "prv",
+                "eps_error": 0.01,
+                "max_grad_norm": dpsgd_params["max_grad_norm"],
+            }
+            privacy_pkl_path = str(target_folder / "dpsgd_dic.pkl")
+            with open(privacy_pkl_path, "wb") as f:
+                pickle.dump(privacy_dict, f)
+
+            model = ResNet18_DPsgd(num_classes=num_classes, dpsgd=True)
+            criterion = nn.CrossEntropyLoss()
+            optimizer = optim.SGD(model.parameters(), lr=lr, momentum=momentum)
+
+            if log_container:
+                log_container.info(
+                    f"Starting DP-SGD training (ε={dpsgd_params['target_epsilon']}, "
+                    f"δ={dpsgd_params['target_delta']})…"
+                )
+
+            maybe_stream = _stream_logs(log_container) if log_container else contextlib.nullcontext()
+            with maybe_stream:
+                train_result = CifarInputHandlerDPsgd().train(
+                    dataloader=data_result["train_loader"],
+                    model=model,
+                    criterion=criterion,
+                    optimizer=optimizer,
+                    epochs=epochs,
+                    dpsgd_metadata_path=privacy_pkl_path,
+                    virtual_batch_size=virtual_batch_size,
+                )
+
+            test_result = CifarInputHandlerDPsgd().eval(
+                data_result["test_loader"], train_result.model, criterion
+            )
+
+            torch.save(train_result.model.state_dict(), target_folder / "target_model.pkl")
+
+            meta = LeakPro.make_mia_metadata(
+                train_result=train_result,
+                optimizer=optimizer,
+                loss_fn=criterion,
+                dataloader=data_result["train_loader"],
+                test_result=test_result,
+                epochs=epochs,
+                train_indices=data_result["train_indices"],
+                test_indices=data_result["test_indices"],
+                dataset_name=data_result["dataset_name"],
+            )
+            with open(target_folder / "model_metadata.pkl", "wb") as f:
+                pickle.dump(meta, f)
+
+            if log_container:
+                log_container.success(
+                    f"DP-SGD training complete — train acc: {train_result.metrics.accuracy:.3f}, "
+                    f"test acc: {test_result.accuracy:.3f}"
+                )
+
+            return {
+                "model": train_result.model,
+                "train_result": train_result,
+                "test_result": test_result,
+                "epochs": epochs,
+                "target_folder": str(target_folder),
+                "optimizer": optimizer,
+                "criterion": criterion,
+                "dpsgd_params": privacy_dict,
+            }
+
+    # ------------------------------------------------------------------
+    # Stage 3 – run audit
+    # ------------------------------------------------------------------
+
+    def run_audit(self, dpsgd: bool = False, log_container=None) -> list:
+        """Run LeakPro MIA attacks and return a list of MIAResult objects."""
+        with _in_cifar_dir():
+            if dpsgd:
+                from examples.mia.cifar.cifar_handler_dpsgd import CifarInputHandlerDPsgd  # noqa: PLC0415
+                handler_cls = CifarInputHandlerDPsgd
+                config_path = "audit_dpsgd.yaml"
+            else:
+                from examples.mia.cifar.cifar_handler import CifarInputHandler  # noqa: PLC0415
+                handler_cls = CifarInputHandler
+                config_path = "audit.yaml"
+
+            if log_container:
+                log_container.info(f"Initialising audit with config: {config_path}")
+
+            maybe_stream = _stream_logs(log_container) if log_container else contextlib.nullcontext()
+            with maybe_stream:
+                leakpro = LeakPro(handler_cls, config_path)
+                results = leakpro.run_audit(create_pdf=False)
+
+            if log_container:
+                log_container.success(f"Audit complete — {len(results)} attack(s) finished.")
+
+            return results
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def load_audit_results_from_disk(output_dir: str) -> list:
+        """Load previously saved MIAResult objects from a leakpro_output directory."""
+        from leakpro.reporting.mia_result import MIAResult  # noqa: PLC0415
+
+        data_objects_dir = Path(output_dir) / "data_objects"
+        results = []
+        if not data_objects_dir.exists():
+            return results
+        for json_file in sorted(data_objects_dir.glob("*.json")):
+            try:
+                results.append(MIAResult.load(str(json_file)))
+            except Exception:  # noqa: BLE001
+                pass
+        return results
+
+    @staticmethod
+    def default_train_config() -> dict:
+        config_path = _CIFAR_DIR / "train_config.yaml"
+        with open(config_path) as f:
+            return yaml.safe_load(f)
+
+    @staticmethod
+    def default_audit_config() -> dict:
+        config_path = _CIFAR_DIR / "audit.yaml"
+        with open(config_path) as f:
+            return yaml.safe_load(f)


### PR DESCRIPTION
## Streamlit Privacy Auditor UI — MVP + UX Improvements

### Summary
- Adds an end-to-end Streamlit wizard UI (`leakpro/ui/`) for running MIA privacy audits without touching any code
- Fixes a correctness bug in the logit cache indexing that caused RMIA to fail with out-of-bounds errors
- Improves the audit workflow with re-audit support and configurable per-attack parameters

### What's included

**New UI (`leakpro/ui/`)**

A 4-stage wizard launched via `streamlit run leakpro/ui/dashboard.py`:

| Stage | What it does |
|-------|-------------|
| 0 — Overview | Landing page with Start / Re-audit / Resume options |
| 1 — Configure | Training hyperparameters, attack selection, DP-SGD toggle |
| 2 — Train | Dataset download, model training with live log stream |
| 3 — Audit | Attack execution with live progress |
| 4 — Results | ROC curves, signal histograms, sensitive records export |

**Bug fix — logit cache indexing**

`prepare_data()` previously assigned random population-space indices to train/test splits.
RMIA and BASE attacks assume `logits_cache[i]` corresponds to population point `i`,
causing `IndexError: index N is out of bounds` at audit time.

Fix: the population is now shuffled once and sequential 0-based indices are assigned
(`train = [0…n-1]`, `test = [n…n+m-1]`), so position always equals population index.
The population pickle is always regenerated to stay consistent.

**UX improvements**
- **Re-audit mode** — reuse a trained model with different attacks/parameters, skips straight to Stage 3
- **Per-attack parameter expanders** in Stage 1 — shadow model count, data fraction, online mode, augmentation settings per attack
- **Re-prepare Data button** in Stage 2 — prevents stale session indices from carrying over between runs

### Test plan
- [ ] Fresh audit: configure → download data → train → run RMIA/BASE/LiRA → view results
- [ ] Re-audit: after a completed audit, click "Re-audit same model", change attack params, run again without retraining
- [ ] Verify logit cache shape matches population size (60 000 × num_classes for CIFAR-10)
- [ ] DP-SGD training completes and epsilon is reported in results
- [ ] SSH port forwarding (`ssh -L 8501:localhost:8501 user@host`) required to access from a remote machine
