### PR TITLE
Partial shadow inheritance

### DIFF
--- a/leakpro/attacks/utils/model_handler.py
+++ b/leakpro/attacks/utils/model_handler.py
@@ -39,6 +39,7 @@ class ModelHandler():
 
         # get the bluepring for the model
         if self.use_target_model_setup:
+            self.model_path = handler.configs.target.module_path
             self.model_class = handler.target_model_blueprint.__name__
             self.model_blueprint = handler.target_model_blueprint
         else:
@@ -51,23 +52,29 @@ class ModelHandler():
                 raise ValueError(f"Failed to create model blueprint from {self.model_class} in {self.model_path}") from e
 
         if self.use_target_model_setup:
-            self.init_params = target_setup.init_params
+            self.init_params = (target_setup.init_params or {}).copy()
             optimizer_name = target_setup.optimizer.name
-            self.optimizer_config = target_setup.optimizer.params
+            self.optimizer_config = (target_setup.optimizer.params or {}).copy()
             criterion_name = target_setup.criterion.name
-            self.loss_config = target_setup.criterion.params
+            self.loss_config = (target_setup.criterion.params or {}).copy()
             self.epochs = target_setup.epochs
+            self.batch_size = target_setup.data_loader.params.get("batch_size")
         else:
             # Inherit defaults from target and apply caller overrides when present.
-            self.init_params = target_setup.init_params.copy()
+            self.init_params = (target_setup.init_params or {}).copy()
             self.init_params.update(caller_configs.init_params or {})
             optimizer_cfg = caller_configs.optimizer or target_setup.optimizer
             criterion_cfg = caller_configs.criterion or target_setup.criterion
             optimizer_name = optimizer_cfg.name
-            self.optimizer_config = optimizer_cfg.params
+            self.optimizer_config = (optimizer_cfg.params or {}).copy()
             criterion_name = criterion_cfg.name
-            self.loss_config = criterion_cfg.params
+            self.loss_config = (criterion_cfg.params or {}).copy()
             self.epochs = caller_configs.epochs if caller_configs.epochs is not None else target_setup.epochs
+            target_batch_size = target_setup.data_loader.params.get("batch_size")
+            self.batch_size = caller_configs.batch_size if caller_configs.batch_size is not None else target_batch_size
+
+        self.optimizer_name = optimizer_name.lower()
+        self.criterion_name = criterion_name.lower()
 
         # Get optimizer class
         self.optimizer_class = self._get_optimizer_class(optimizer_name)

--- a/leakpro/attacks/utils/model_handler.py
+++ b/leakpro/attacks/utils/model_handler.py
@@ -35,40 +35,45 @@ class ModelHandler():
 
         caller_configs = getattr(handler.configs, caller) if caller is not None else None
         self.use_target_model_setup = caller_configs is None
+        target_setup = handler.target_model_metadata
 
         # get the bluepring for the model
         if self.use_target_model_setup:
             self.model_class = handler.target_model_blueprint.__name__
             self.model_blueprint = handler.target_model_blueprint
         else:
-            try:
-                self.model_path = caller_configs.module_path
-                self.model_class = caller_configs.model_class
-            except AttributeError as e:
-                raise ValueError("Model path or class not provided in shadow model config") from e
+            # Allow partial shadow model config by inheriting from the target setup.
+            self.model_path = caller_configs.module_path or handler.configs.target.module_path
+            self.model_class = caller_configs.model_class or handler.configs.target.model_class
             try:
                 self.model_blueprint = self._import_model_from_path(self.model_path, self.model_class)
             except Exception as e:
                 raise ValueError(f"Failed to create model blueprint from {self.model_class} in {self.model_path}") from e
 
-        # Pick either target config or caller config
-        setup_config = handler.target_model_metadata if self.use_target_model_setup else caller_configs
-        # extract the init params
-        self.init_params = setup_config.init_params
+        if self.use_target_model_setup:
+            self.init_params = target_setup.init_params
+            optimizer_name = target_setup.optimizer.name
+            self.optimizer_config = target_setup.optimizer.params
+            criterion_name = target_setup.criterion.name
+            self.loss_config = target_setup.criterion.params
+            self.epochs = target_setup.epochs
+        else:
+            # Inherit defaults from target and apply caller overrides when present.
+            self.init_params = target_setup.init_params.copy()
+            self.init_params.update(caller_configs.init_params or {})
+            optimizer_cfg = caller_configs.optimizer or target_setup.optimizer
+            criterion_cfg = caller_configs.criterion or target_setup.criterion
+            optimizer_name = optimizer_cfg.name
+            self.optimizer_config = optimizer_cfg.params
+            criterion_name = criterion_cfg.name
+            self.loss_config = criterion_cfg.params
+            self.epochs = caller_configs.epochs if caller_configs.epochs is not None else target_setup.epochs
 
         # Get optimizer class
-        optimizer_name = setup_config.optimizer.name
         self.optimizer_class = self._get_optimizer_class(optimizer_name)
-        # copy to only have parameters left
-        self.optimizer_config = setup_config.optimizer.params
 
         # Get criterion class
-        criterion_class = setup_config.criterion.name
-        self.criterion_class = self._get_criterion_class(criterion_class)
-        # copy to only have parameters left
-        self.loss_config = setup_config.criterion.params
-
-        self.epochs = setup_config.epochs
+        self.criterion_class = self._get_criterion_class(criterion_name)
 
         # Set the storage paths for objects created by the handler
         storage_path = handler.configs.audit.output_dir
@@ -214,4 +219,3 @@ class ModelHandler():
                 return joblib.load(f)
         except FileNotFoundError as e:
             raise FileNotFoundError(f"Metadata at {metadata_path} not found") from e
-

--- a/leakpro/attacks/utils/model_handler.py
+++ b/leakpro/attacks/utils/model_handler.py
@@ -35,43 +35,7 @@ class ModelHandler():
 
         caller_configs = getattr(handler.configs, caller) if caller is not None else None
         self.use_target_model_setup = caller_configs is None
-        target_setup = handler.target_model_metadata
-
-        # get the bluepring for the model
-        if self.use_target_model_setup:
-            self.model_path = handler.configs.target.module_path
-            self.model_class = handler.target_model_blueprint.__name__
-            self.model_blueprint = handler.target_model_blueprint
-        else:
-            # Allow partial shadow model config by inheriting from the target setup.
-            self.model_path = caller_configs.module_path or handler.configs.target.module_path
-            self.model_class = caller_configs.model_class or handler.configs.target.model_class
-            try:
-                self.model_blueprint = self._import_model_from_path(self.model_path, self.model_class)
-            except Exception as e:
-                raise ValueError(f"Failed to create model blueprint from {self.model_class} in {self.model_path}") from e
-
-        if self.use_target_model_setup:
-            self.init_params = (target_setup.init_params or {}).copy()
-            optimizer_name = target_setup.optimizer.name
-            self.optimizer_config = (target_setup.optimizer.params or {}).copy()
-            criterion_name = target_setup.criterion.name
-            self.loss_config = (target_setup.criterion.params or {}).copy()
-            self.epochs = target_setup.epochs
-            self.batch_size = target_setup.data_loader.params.get("batch_size")
-        else:
-            # Inherit defaults from target and apply caller overrides when present.
-            self.init_params = (target_setup.init_params or {}).copy()
-            self.init_params.update(caller_configs.init_params or {})
-            optimizer_cfg = caller_configs.optimizer or target_setup.optimizer
-            criterion_cfg = caller_configs.criterion or target_setup.criterion
-            optimizer_name = optimizer_cfg.name
-            self.optimizer_config = (optimizer_cfg.params or {}).copy()
-            criterion_name = criterion_cfg.name
-            self.loss_config = (criterion_cfg.params or {}).copy()
-            self.epochs = caller_configs.epochs if caller_configs.epochs is not None else target_setup.epochs
-            target_batch_size = target_setup.data_loader.params.get("batch_size")
-            self.batch_size = caller_configs.batch_size if caller_configs.batch_size is not None else target_batch_size
+        optimizer_name, criterion_name = self._load_model_setup(caller_configs)
 
         self.optimizer_name = optimizer_name.lower()
         self.criterion_name = criterion_name.lower()
@@ -102,6 +66,41 @@ class ModelHandler():
 
         criterion = self.handler.get_criterion()
         self.cache_logits(PytorchModel(self.handler.target_model, criterion), name="target")
+
+    def _load_model_setup(self:Self, caller_configs) -> Tuple[str, str]:  # noqa: ANN001
+        """Load the effective model, optimizer, and criterion setup."""
+        target_setup = self.handler.target_model_metadata
+
+        if self.use_target_model_setup:
+            self.model_path = self.handler.configs.target.module_path
+            self.model_class = self.handler.target_model_blueprint.__name__
+            self.model_blueprint = self.handler.target_model_blueprint
+            self.init_params = (target_setup.init_params or {}).copy()
+            self.optimizer_config = (target_setup.optimizer.params or {}).copy()
+            self.loss_config = (target_setup.criterion.params or {}).copy()
+            self.epochs = target_setup.epochs
+            self.batch_size = target_setup.data_loader.params.get("batch_size")
+            return target_setup.optimizer.name, target_setup.criterion.name
+
+        # Allow partial shadow model config by inheriting from the target setup.
+        self.model_path = caller_configs.module_path or self.handler.configs.target.module_path
+        self.model_class = caller_configs.model_class or self.handler.configs.target.model_class
+        try:
+            self.model_blueprint = self._import_model_from_path(self.model_path, self.model_class)
+        except Exception as e:
+            raise ValueError(f"Failed to create model blueprint from {self.model_class} in {self.model_path}") from e
+
+        # Inherit defaults from target and apply caller overrides when present.
+        self.init_params = (target_setup.init_params or {}).copy()
+        self.init_params.update(caller_configs.init_params or {})
+        optimizer_cfg = caller_configs.optimizer or target_setup.optimizer
+        criterion_cfg = caller_configs.criterion or target_setup.criterion
+        self.optimizer_config = (optimizer_cfg.params or {}).copy()
+        self.loss_config = (criterion_cfg.params or {}).copy()
+        self.epochs = caller_configs.epochs if caller_configs.epochs is not None else target_setup.epochs
+        target_batch_size = target_setup.data_loader.params.get("batch_size")
+        self.batch_size = caller_configs.batch_size if caller_configs.batch_size is not None else target_batch_size
+        return optimizer_cfg.name, criterion_cfg.name
 
 
     def cache_logits(self:Self, model:Union[Module, list[Module]], name:str) -> None:

--- a/leakpro/attacks/utils/model_handler.py
+++ b/leakpro/attacks/utils/model_handler.py
@@ -16,7 +16,7 @@ from leakpro.input_handler.user_imports import (
 )
 from leakpro.signals.signal import ModelLogits
 from leakpro.signals.signal_extractor import PytorchModel
-from leakpro.utils.import_helper import Self, Tuple, Union
+from leakpro.utils.import_helper import Any, Self, Tuple, Union
 from leakpro.utils.logger import logger
 from leakpro.utils.save_load import hash_model
 
@@ -83,24 +83,43 @@ class ModelHandler():
             return target_setup.optimizer.name, target_setup.criterion.name
 
         # Allow partial shadow model config by inheriting from the target setup.
-        self.model_path = caller_configs.module_path or self.handler.configs.target.module_path
-        self.model_class = caller_configs.model_class or self.handler.configs.target.model_class
+        self.model_path = self._get_config_value(caller_configs, "module_path") or self.handler.configs.target.module_path
+        self.model_class = self._get_config_value(caller_configs, "model_class") or self.handler.configs.target.model_class
         try:
             self.model_blueprint = self._import_model_from_path(self.model_path, self.model_class)
         except Exception as e:
             raise ValueError(f"Failed to create model blueprint from {self.model_class} in {self.model_path}") from e
 
         # Inherit defaults from target and apply caller overrides when present.
-        self.init_params = (target_setup.init_params or {}).copy()
-        self.init_params.update(caller_configs.init_params or {})
-        optimizer_cfg = caller_configs.optimizer or target_setup.optimizer
-        criterion_cfg = caller_configs.criterion or target_setup.criterion
+        caller_init_params = self._get_config_value(caller_configs, "init_params")
+        target_init_params = (target_setup.init_params or {}).copy()
+        if caller_init_params is None:
+            self.init_params = target_init_params
+        elif caller_init_params:
+            self.init_params = target_init_params
+            self.init_params.update(caller_init_params)
+        else:
+            self.init_params = {}
+        optimizer_cfg = self._get_config_value(caller_configs, "optimizer") or target_setup.optimizer
+        criterion_cfg = self._get_config_value(caller_configs, "criterion") or target_setup.criterion
         self.optimizer_config = (optimizer_cfg.params or {}).copy()
         self.loss_config = (criterion_cfg.params or {}).copy()
-        self.epochs = caller_configs.epochs if caller_configs.epochs is not None else target_setup.epochs
+        caller_epochs = self._get_config_value(caller_configs, "epochs")
+        self.epochs = caller_epochs if caller_epochs is not None else target_setup.epochs
         target_batch_size = target_setup.data_loader.params.get("batch_size")
-        self.batch_size = caller_configs.batch_size if caller_configs.batch_size is not None else target_batch_size
+        caller_batch_size = self._get_config_value(caller_configs, "batch_size")
+        self.batch_size = caller_batch_size if caller_batch_size is not None else target_batch_size
         return optimizer_cfg.name, criterion_cfg.name
+
+    def _get_config_value(self:Self, configs:Any, field_name:str) -> Any:
+        """Read config values safely from Pydantic models, DotMaps, and dictionaries."""
+        if configs is None:
+            return None
+        if isinstance(configs, dict):
+            return configs.get(field_name)
+        if hasattr(configs, "get"):
+            return configs.get(field_name, None)
+        return getattr(configs, field_name, None)
 
 
     def cache_logits(self:Self, model:Union[Module, list[Module]], name:str) -> None:
@@ -143,10 +162,11 @@ class ModelHandler():
             optimizer_name (str): The name of the optimizer.
 
         """
+        optimizer_name = optimizer_name.lower()
         try:
             return get_optimizer_mapping()[optimizer_name]
         except Exception as e:
-            raise ValueError(f"Failed to create optimizer from {self.optimizer_config['name']}") from e
+            raise ValueError(f"Failed to create optimizer from {optimizer_name}") from e
 
     def _get_criterion_class(self:Self, criterion_name:str)->None:
         """Get the criterion class based on the criterion name.
@@ -156,10 +176,11 @@ class ModelHandler():
             criterion_name (str): The name of the criterion.
 
         """
+        criterion_name = criterion_name.lower()
         try:
             return get_criterion_mapping()[criterion_name]
         except Exception as e:
-            raise ValueError(f"Failed to create criterion from {self.criterion_config['name']}") from e
+            raise ValueError(f"Failed to create criterion from {criterion_name}") from e
 
     def _get_model_criterion_optimizer(self:Self) -> Tuple[Module, Module, Module]:
         """Get the model, criterion, and optimizer from the handler or config."""

--- a/leakpro/attacks/utils/shadow_model_handler.py
+++ b/leakpro/attacks/utils/shadow_model_handler.py
@@ -13,7 +13,7 @@ from leakpro.attacks.utils.model_handler import ModelHandler
 from leakpro.input_handler.mia_handler import MIAHandler
 from leakpro.schemas import ShadowModelTrainingSchema, TrainingOutput
 from leakpro.signals.signal_extractor import PytorchModel
-from leakpro.utils.import_helper import Self, Tuple
+from leakpro.utils.import_helper import Any, Dict, List, Self, Tuple, Union
 from leakpro.utils.logger import logger
 
 
@@ -67,7 +67,7 @@ class ShadowModelHandler(ModelHandler):
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    def _freeze_value(self:Self, value):  # noqa: ANN001, ANN201
+    def _freeze_value(self:Self, value: Union[List, Dict, Any]) -> Union[tuple, Any]:
         """Convert nested config values to a stable, comparable structure.
 
         Args:
@@ -149,7 +149,7 @@ class ShadowModelHandler(ModelHandler):
             self._freeze_value(metadata.init_params),
         )
 
-    def _filter(self:Self, data_size:int, online:bool)->list[int]:
+    def _filter(self:Self, data_size:int, online:bool) -> tuple[list[int], list[int]]:
         """Find cached shadow models compatible with the current configuration.
 
         Args:
@@ -161,7 +161,7 @@ class ShadowModelHandler(ModelHandler):
 
         Returns:
         -------
-            list[int]: Two lists packed in a tuple-like return value:
+            tuple[list[int], list[int]]: Two lists packed in a tuple-like return value:
             all discovered metadata indices and the subset whose stored
             signature matches the current effective training configuration.
 

--- a/leakpro/attacks/utils/shadow_model_handler.py
+++ b/leakpro/attacks/utils/shadow_model_handler.py
@@ -67,7 +67,105 @@ class ShadowModelHandler(ModelHandler):
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    def _filter(self:Self, data_size:int)->list[int]:
+    def _freeze_value(self:Self, value):  # noqa: ANN001, ANN201
+        """Convert nested config values to a stable, comparable structure.
+
+        Args:
+        ----
+            value: Arbitrary config value taken from shadow-model settings or metadata.
+
+        Returns:
+        -------
+            A recursively normalized representation that can be compared safely
+            when deciding whether cached shadow models were trained with the
+            same effective configuration.
+
+        """
+        if isinstance(value, dict):
+            return tuple((key, self._freeze_value(val)) for key, val in sorted(value.items()))
+        if isinstance(value, list):
+            return tuple(self._freeze_value(item) for item in value)
+        return value
+
+    def _current_training_signature(self:Self, data_size:int, online:bool) -> tuple:
+        """Build the effective training signature for the current shadow setup.
+
+        Args:
+        ----
+            data_size (int): Number of samples that will be used to train a
+                shadow model.
+            online (bool): Whether the shadow models are created in online mode.
+
+        Returns:
+        -------
+            tuple: Normalized description of the active shadow-model training
+            configuration, including architecture, optimizer, criterion,
+            initialization parameters, batch size, and target-model identity.
+
+        """
+        return (
+            data_size,
+            self.model_class,
+            self.model_path,
+            self.target_model_hash,
+            self.optimizer_name,
+            self._freeze_value(self.optimizer_config),
+            self.criterion_name,
+            self._freeze_value(self.loss_config),
+            self.epochs,
+            self.batch_size,
+            online,
+            self._freeze_value(self.init_params),
+        )
+
+    def _metadata_training_signature(self:Self, metadata: ShadowModelTrainingSchema) -> tuple:
+        """Build a normalized training signature from stored shadow metadata.
+
+        Args:
+        ----
+            metadata (ShadowModelTrainingSchema): Metadata loaded for a cached
+                shadow model.
+
+        Returns:
+        -------
+            tuple: Normalized representation of the stored training setup. If
+            older metadata files do not contain newly added fields, they will
+            naturally fail to match the current signature and therefore be
+            retrained instead of being silently reused.
+
+        """
+        return (
+            metadata.num_train,
+            metadata.model_class,
+            getattr(metadata, "model_module_path", None),
+            metadata.target_model_hash,
+            metadata.optimizer.lower(),
+            self._freeze_value(getattr(metadata, "optimizer_params", None)),
+            metadata.criterion.lower(),
+            self._freeze_value(getattr(metadata, "criterion_params", None)),
+            metadata.epochs,
+            getattr(metadata, "batch_size", None),
+            metadata.online,
+            self._freeze_value(metadata.init_params),
+        )
+
+    def _filter(self:Self, data_size:int, online:bool)->list[int]:
+        """Find cached shadow models compatible with the current configuration.
+
+        Args:
+        ----
+            data_size (int): Number of samples that should be used for each
+                shadow-model training run.
+            online (bool): Whether the requested shadow models are for online
+                or offline use.
+
+        Returns:
+        -------
+            list[int]: Two lists packed in a tuple-like return value:
+            all discovered metadata indices and the subset whose stored
+            signature matches the current effective training configuration.
+
+        """
         # Get the metadata for the shadow models
         entries = os.listdir(self.storage_path)
         pattern = re.compile(rf"^{self.metadata_storage_name}_\d+\.pkl$")
@@ -76,17 +174,14 @@ class ShadowModelHandler(ModelHandler):
         # Extract the index of the metadata
         all_indices = [int(re.search(r"\d+", f).group()) for f in files]
 
-        # Setup checks
-        # TODO: we use the same shadow models for all targets!
-        filter_checks = [data_size, self.model_class]
+        expected_signature = self._current_training_signature(data_size, online)
 
         # Filter out indices to only keep the ones that passes the checks
         filtered_indices = []
         for i in all_indices:
             metadata = self._load_shadow_metadata(i)
             assert isinstance(metadata, ShadowModelTrainingSchema), "Shadow Model metadata is not of the correct type"
-            meta_check_values = [metadata.num_train, metadata.model_class]
-            if all(a == b for a, b in zip(filter_checks, meta_check_values)):
+            if self._metadata_training_signature(metadata) == expected_signature:
                 filtered_indices.append(i)
 
         return all_indices, filtered_indices
@@ -151,7 +246,7 @@ class ShadowModelHandler(ModelHandler):
 
         # Get the size of the dataset
         data_size = int(len(shadow_population)*training_fraction)
-        all_indices, filtered_indices = self._filter(data_size)
+        all_indices, filtered_indices = self._filter(data_size, online)
 
         # Create a list of indices to use for the new shadow models
         n_existing_models = len(filtered_indices)
@@ -173,7 +268,7 @@ class ShadowModelHandler(ModelHandler):
         for i, indx in enumerate(indices_to_use):
             # Get dataloader
             data_indices = shadow_population[np.where(A[i,:] == 1)]
-            data_loader = self.handler.get_dataloader(data_indices, params=None)
+            data_loader = self.handler.get_dataloader(data_indices, params=None, batch_size=self.batch_size)
 
             # Get shadow model blueprint
             model, criterion, optimizer = self._get_model_criterion_optimizer()
@@ -206,13 +301,17 @@ class ShadowModelHandler(ModelHandler):
                 init_params=self.init_params,
                 train_indices = data_indices,
                 num_train = len(data_indices),
-                optimizer = optimizer.__class__.__name__,
-                criterion = criterion.__class__.__name__,
+                optimizer = self.optimizer_name,
+                optimizer_params = self.optimizer_config,
+                criterion = self.criterion_name,
+                criterion_params = self.loss_config,
                 epochs = self.epochs,
+                batch_size = data_loader.batch_size,
                 train_result = training_results.metrics,
                 test_result = test_result,
                 online = online,
                 model_class = self.model_class,
+                model_module_path = self.model_path,
                 target_model_hash= self.target_model_hash
             )
 

--- a/leakpro/attacks/utils/shadow_model_handler.py
+++ b/leakpro/attacks/utils/shadow_model_handler.py
@@ -180,7 +180,8 @@ class ShadowModelHandler(ModelHandler):
         filtered_indices = []
         for i in all_indices:
             metadata = self._load_shadow_metadata(i)
-            assert isinstance(metadata, ShadowModelTrainingSchema), "Shadow Model metadata is not of the correct type"
+            if not isinstance(metadata, ShadowModelTrainingSchema):
+                raise TypeError("Shadow Model metadata is not of the correct type")
             if self._metadata_training_signature(metadata) == expected_signature:
                 filtered_indices.append(i)
 
@@ -263,7 +264,9 @@ class ShadowModelHandler(ModelHandler):
             next_index += 1
 
         A = self.construct_balanced_assignments(len(shadow_population), num_models)  # noqa: N806
-        assert np.all(np.sum(A,axis=1) == len(shadow_population)//2)
+        expected_size = len(shadow_population) // 2
+        if not np.all(np.sum(A, axis=1) == expected_size):
+            raise ValueError("Balanced shadow assignments must contain half of the shadow population per model")
         shadow_population = np.array(shadow_population)
         for i, indx in enumerate(indices_to_use):
             # Get dataloader
@@ -278,7 +281,8 @@ class ShadowModelHandler(ModelHandler):
             training_results = self.handler.train(data_loader, model, criterion, optimizer, self.epochs)
 
             # Read out results
-            assert isinstance(training_results, TrainingOutput)
+            if not isinstance(training_results, TrainingOutput):
+                raise TypeError("Shadow model training must return TrainingOutput")
             shadow_model = training_results.model
 
             # Evaluate shadow model on remaining aux data
@@ -306,7 +310,7 @@ class ShadowModelHandler(ModelHandler):
                 criterion = self.criterion_name,
                 criterion_params = self.loss_config,
                 epochs = self.epochs,
-                batch_size = data_loader.batch_size,
+                batch_size = self.batch_size,
                 train_result = training_results.metrics,
                 test_result = test_result,
                 online = online,

--- a/leakpro/schemas.py
+++ b/leakpro/schemas.py
@@ -101,13 +101,13 @@ class TargetConfig(BaseModel):
 class ShadowModelConfig(BaseModel):
     """Configuration for the Shadow models."""
 
-    model_class: Optional[str] = None
-    module_path: Optional[str] = None
+    model_class: Optional[str] = Field(default=None, description="Class name of the shadow model")
+    module_path: Optional[str] = Field(default=None, description="Path to the shadow model module")
     init_params: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Model initialization parameters")
-    optimizer: Optional[OptimizerConfig] = Field(..., description="Optimizer configuration")
-    criterion: Optional[LossConfig] = Field(..., description="Loss function configuration")
-    batch_size: Optional[int] = Field(..., ge=1, description="Batch size used during training")
-    epochs: Optional[int] = Field(..., ge=1, description="Number of training epochs")
+    optimizer: Optional[OptimizerConfig] = Field(default=None, description="Optimizer configuration")
+    criterion: Optional[LossConfig] = Field(default=None, description="Loss function configuration")
+    batch_size: Optional[int] = Field(default=None, ge=1, description="Batch size used during training")
+    epochs: Optional[int] = Field(default=None, ge=1, description="Number of training epochs")
 
     model_config = ConfigDict(extra="forbid")  # Prevent extra fields
 

--- a/leakpro/schemas.py
+++ b/leakpro/schemas.py
@@ -179,12 +179,16 @@ class ShadowModelTrainingSchema(BaseModel):
     train_indices: List[int] = Field(..., description="Indices of training samples")
     num_train: int = Field(..., ge=0, description="Number of training samples")
     optimizer: str = Field(..., description="Optimizer name")
+    optimizer_params: Dict[str, Any] = Field(default_factory=dict, description="Optimizer parameters")
     criterion: str = Field(..., description="Criterion (loss function) name")
+    criterion_params: Dict[str, Any] = Field(default_factory=dict, description="Criterion parameters")
     epochs: int = Field(..., ge=1, description="Number of training epochs")
+    batch_size: Optional[int] = Field(default=None, ge=1, description="Batch size used during training")
     train_result: EvalOutput = Field(..., description="Evaluation output for the training set")
     test_result: EvalOutput = Field(..., description="Evaluation output for the test set")
     online: bool = Field(..., description="Online vs. offline training")
     model_class: str = Field(..., description="Model class name")
+    model_module_path: Optional[str] = Field(default=None, description="Path to the model module")
     target_model_hash: str = Field(..., description="Hash of target model")
 
     model_config = ConfigDict(extra="forbid")  # Prevent extra fields

--- a/leakpro/schemas.py
+++ b/leakpro/schemas.py
@@ -101,9 +101,15 @@ class TargetConfig(BaseModel):
 class ShadowModelConfig(BaseModel):
     """Configuration for the Shadow models."""
 
-    model_class: Optional[str] = Field(default=None, description="Class name of the shadow model")
-    module_path: Optional[str] = Field(default=None, description="Path to the shadow model module")
-    init_params: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Model initialization parameters")
+    model_class: Optional[str] = Field(
+        default=None,
+        description="Class name of the shadow model. Defaults to the target model class.",
+    )
+    module_path: Optional[str] = Field(
+        default=None,
+        description="Path to the shadow model module. Defaults to the target model module path.",
+    )
+    init_params: Optional[Dict[str, Any]] = Field(default=None, description="Model initialization parameters")
     optimizer: Optional[OptimizerConfig] = Field(default=None, description="Optimizer configuration")
     criterion: Optional[LossConfig] = Field(default=None, description="Loss function configuration")
     batch_size: Optional[int] = Field(default=None, ge=1, description="Batch size used during training")

--- a/leakpro/schemas.py
+++ b/leakpro/schemas.py
@@ -103,7 +103,10 @@ class ShadowModelConfig(BaseModel):
 
     model_class: Optional[str] = Field(
         default=None,
-        description="Class name of the shadow model. Defaults to the target model class.",
+        description=(
+            "Class name of the shadow model. Defaults to the target model class. "
+            "If set without module_path, the class is imported from the target model module path."
+        ),
     )
     module_path: Optional[str] = Field(
         default=None,

--- a/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
+++ b/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
@@ -7,7 +7,7 @@ from pytest import raises
 from leakpro.attacks.utils.shadow_model_handler import ShadowModelHandler
 from leakpro.tests.constants import get_shadow_model_config
 from leakpro.tests.input_handler.image_input_handler import ImageInputHandler
-from leakpro.schemas import ShadowModelConfig
+from leakpro.schemas import OptimizerConfig, ShadowModelConfig
 
 def test_shadow_model_handler_singleton(image_handler:ImageInputHandler) -> None:
     """Test that only one instance gets created."""
@@ -89,3 +89,37 @@ def test_shadow_model_creation_and_loading(image_handler:ImageInputHandler) -> N
     true_mask_0 = np.array([True if item in meta.train_indices else False for item in image_handler.test_indices])
     assert np.array_equal(mask[:, 0], true_mask_0)
 
+
+def test_shadow_model_partial_inheritance_from_target(image_handler: ImageInputHandler) -> None:
+    """Shadow model should inherit missing fields from target setup."""
+    image_handler.configs.shadow_model = ShadowModelConfig(init_params={"dpsgd": False})
+
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+    sm = ShadowModelHandler(image_handler)
+
+    expected_init_params = image_handler.target_model_metadata.init_params.copy()
+    expected_init_params.update({"dpsgd": False})
+
+    assert sm.model_class == image_handler.configs.target.model_class
+    assert sm.init_params == expected_init_params
+    assert sm.optimizer_config == image_handler.target_model_metadata.optimizer.params
+    assert sm.loss_config == image_handler.target_model_metadata.criterion.params
+    assert sm.epochs == image_handler.target_model_metadata.epochs
+
+
+def test_shadow_model_partial_override_optimizer_only(image_handler: ImageInputHandler) -> None:
+    """Provided optimizer should override while other fields still inherit."""
+    image_handler.configs.shadow_model = ShadowModelConfig(
+        optimizer=OptimizerConfig(name="adam", params={"lr": 0.002})
+    )
+
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+    sm = ShadowModelHandler(image_handler)
+
+    assert sm.model_class == image_handler.configs.target.model_class
+    assert sm.optimizer_class.__name__.lower() == "adam"
+    assert sm.optimizer_config["lr"] == 0.002
+    assert sm.loss_config == image_handler.target_model_metadata.criterion.params
+    assert sm.epochs == image_handler.target_model_metadata.epochs

--- a/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
+++ b/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
@@ -1,13 +1,14 @@
 """Test the shadow model handler module."""
 import os
+import pickle
 
 import numpy as np
 from pytest import raises
 
 from leakpro.attacks.utils.shadow_model_handler import ShadowModelHandler
+from leakpro.schemas import EvalOutput, OptimizerConfig, ShadowModelConfig, ShadowModelTrainingSchema, TrainingOutput
 from leakpro.tests.constants import get_shadow_model_config
 from leakpro.tests.input_handler.image_input_handler import ImageInputHandler
-from leakpro.schemas import OptimizerConfig, ShadowModelConfig
 
 def test_shadow_model_handler_singleton(image_handler:ImageInputHandler) -> None:
     """Test that only one instance gets created."""
@@ -77,6 +78,9 @@ def test_shadow_model_creation_and_loading(image_handler:ImageInputHandler) -> N
     # Test loading
     meta= sm._load_metadata(sm.storage_path + f"/metadata_{indx}.pkl")
     assert meta.num_train == training_fraction * len(image_handler.test_indices)
+    assert meta.batch_size == image_handler.configs.shadow_model.batch_size
+    assert meta.optimizer_params == image_handler.configs.shadow_model.optimizer.params
+    assert meta.criterion_params == image_handler.configs.shadow_model.criterion.params
     shadow_model_indices = [indx]
     models, indices = sm.get_shadow_models(shadow_model_indices)
     for model in models:
@@ -123,3 +127,85 @@ def test_shadow_model_partial_override_optimizer_only(image_handler: ImageInputH
     assert sm.optimizer_config["lr"] == 0.002
     assert sm.loss_config == image_handler.target_model_metadata.criterion.params
     assert sm.epochs == image_handler.target_model_metadata.epochs
+
+
+def test_shadow_model_filter_requires_full_config_match(image_handler: ImageInputHandler, tmp_path) -> None:
+    """Reuse should require the full effective training configuration, not just class and size."""
+    image_handler.configs.shadow_model = ShadowModelConfig(
+        init_params={"dpsgd": False},
+        optimizer=OptimizerConfig(name="adam", params={"lr": 0.002}),
+        batch_size=16,
+    )
+
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+    sm = ShadowModelHandler(image_handler)
+    sm.storage_path = str(tmp_path)
+
+    metadata_kwargs = {
+        "init_params": sm.init_params,
+        "train_indices": [0, 1, 2, 3, 4],
+        "num_train": 5,
+        "optimizer": sm.optimizer_name,
+        "optimizer_params": sm.optimizer_config,
+        "criterion": sm.criterion_name,
+        "criterion_params": sm.loss_config,
+        "epochs": sm.epochs,
+        "batch_size": sm.batch_size,
+        "train_result": EvalOutput(accuracy=0.0, loss=0.0),
+        "test_result": EvalOutput(accuracy=0.0, loss=0.0),
+        "online": True,
+        "model_class": sm.model_class,
+        "model_module_path": sm.model_path,
+        "target_model_hash": sm.target_model_hash,
+    }
+    matching_metadata = ShadowModelTrainingSchema(**metadata_kwargs)
+    stale_metadata = ShadowModelTrainingSchema(
+        **{
+            **metadata_kwargs,
+            "optimizer_params": {"lr": 0.5},
+        }
+    )
+
+    with open(tmp_path / "metadata_0.pkl", "wb") as file:
+        pickle.dump(matching_metadata, file)
+    with open(tmp_path / "metadata_1.pkl", "wb") as file:
+        pickle.dump(stale_metadata, file)
+
+    all_indices, filtered_indices = sm._filter(data_size=5, online=True)
+
+    assert all_indices == [0, 1]
+    assert filtered_indices == [0]
+
+
+def test_shadow_model_creation_uses_shadow_batch_size(
+    image_handler: ImageInputHandler,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Shadow training dataloader should honor the configured shadow-model batch size."""
+    shadow_config = ShadowModelConfig(**get_shadow_model_config())
+    shadow_config.batch_size = 7
+    image_handler.configs.shadow_model = shadow_config
+
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+    sm = ShadowModelHandler(image_handler)
+    sm.storage_path = str(tmp_path / "attack_objects")
+    os.makedirs(sm.storage_path, exist_ok=True)
+    sm.attack_cache_folder_path = str(tmp_path / "attack_cache")
+    os.makedirs(sm.attack_cache_folder_path, exist_ok=True)
+
+    observed = {}
+
+    def fake_train(data_loader, model, criterion, optimizer, epochs):
+        observed["batch_size"] = data_loader.batch_size
+        return TrainingOutput(model=model, metrics=EvalOutput(accuracy=0.0, loss=0.0))
+
+    monkeypatch.setattr(image_handler, "train", fake_train)
+    monkeypatch.setattr(image_handler, "eval", lambda *args, **kwargs: EvalOutput(accuracy=0.0, loss=0.0))
+    monkeypatch.setattr(sm, "cache_logits", lambda *args, **kwargs: None)
+
+    sm.create_shadow_models(num_models=1, shadow_population=image_handler.test_indices, training_fraction=0.5, online=False)
+
+    assert observed["batch_size"] == shadow_config.batch_size

--- a/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
+++ b/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
@@ -174,7 +174,7 @@ def test_shadow_model_filter_requires_full_config_match(image_handler: ImageInpu
 
     all_indices, filtered_indices = sm._filter(data_size=5, online=True)
 
-    assert all_indices == [0, 1]
+    assert sorted(all_indices) == [0, 1]
     assert filtered_indices == [0]
 
 

--- a/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
+++ b/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
@@ -6,7 +6,7 @@ import numpy as np
 from pytest import raises
 
 from leakpro.attacks.utils.shadow_model_handler import ShadowModelHandler
-from leakpro.schemas import EvalOutput, OptimizerConfig, ShadowModelConfig, ShadowModelTrainingSchema, TrainingOutput
+from leakpro.schemas import EvalOutput, LossConfig, OptimizerConfig, ShadowModelConfig, ShadowModelTrainingSchema, TrainingOutput
 from leakpro.tests.constants import get_shadow_model_config
 from leakpro.tests.input_handler.image_input_handler import ImageInputHandler
 
@@ -112,6 +112,29 @@ def test_shadow_model_partial_inheritance_from_target(image_handler: ImageInputH
     assert sm.epochs == image_handler.target_model_metadata.epochs
 
 
+def test_shadow_model_init_params_distinguish_missing_partial_and_empty(image_handler: ImageInputHandler) -> None:
+    """Missing, partial, and empty init_params should have distinct inheritance behavior."""
+    image_handler.target_model_metadata.init_params = {"width": 16, "dpsgd": True}
+
+    image_handler.configs.shadow_model = ShadowModelConfig()
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+    sm = ShadowModelHandler(image_handler)
+    assert sm.init_params == {"width": 16, "dpsgd": True}
+
+    image_handler.configs.shadow_model = ShadowModelConfig(init_params={"dpsgd": False})
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+    sm = ShadowModelHandler(image_handler)
+    assert sm.init_params == {"width": 16, "dpsgd": False}
+
+    image_handler.configs.shadow_model = ShadowModelConfig(init_params={})
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+    sm = ShadowModelHandler(image_handler)
+    assert sm.init_params == {}
+
+
 def test_shadow_model_partial_override_optimizer_only(image_handler: ImageInputHandler) -> None:
     """Provided optimizer should override while other fields still inherit."""
     image_handler.configs.shadow_model = ShadowModelConfig(
@@ -127,6 +150,46 @@ def test_shadow_model_partial_override_optimizer_only(image_handler: ImageInputH
     assert sm.optimizer_config["lr"] == 0.002
     assert sm.loss_config == image_handler.target_model_metadata.criterion.params
     assert sm.epochs == image_handler.target_model_metadata.epochs
+
+
+def test_shadow_model_model_class_without_module_path_uses_target_module(image_handler: ImageInputHandler) -> None:
+    """model_class without module_path should resolve against the target module path."""
+    image_handler.configs.shadow_model = ShadowModelConfig(model_class="ConvNet_Dummy")
+
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+
+    expected_path = image_handler.configs.target.module_path
+    with raises(ValueError) as excinfo:
+        ShadowModelHandler(image_handler)
+
+    assert str(excinfo.value) == f"Failed to create model blueprint from ConvNet_Dummy in {expected_path}"
+
+
+def test_shadow_model_invalid_optimizer_error_uses_optimizer_name(image_handler: ImageInputHandler) -> None:
+    """Invalid optimizer errors should not depend on optimizer params containing a name key."""
+    image_handler.configs.shadow_model = ShadowModelConfig(optimizer=OptimizerConfig(name="not_an_optimizer"))
+
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+
+    with raises(ValueError) as excinfo:
+        ShadowModelHandler(image_handler)
+
+    assert str(excinfo.value) == "Failed to create optimizer from not_an_optimizer"
+
+
+def test_shadow_model_invalid_criterion_error_uses_criterion_name(image_handler: ImageInputHandler) -> None:
+    """Invalid criterion errors should not reference a nonexistent criterion_config attribute."""
+    image_handler.configs.shadow_model = ShadowModelConfig(criterion=LossConfig(name="not_a_loss"))
+
+    if ShadowModelHandler.is_created() is True:
+        ShadowModelHandler.delete_instance()
+
+    with raises(ValueError) as excinfo:
+        ShadowModelHandler(image_handler)
+
+    assert str(excinfo.value) == "Failed to create criterion from not_a_loss"
 
 
 def test_shadow_model_filter_requires_full_config_match(image_handler: ImageInputHandler, tmp_path) -> None:


### PR DESCRIPTION
# Description

Summary of changes
Updated the shadow model inheritance logic. 
- [x] Partial shadow_model config inheritance was implemented so missing shadow settings now fall back to the target model setup instead of requiring a fully duplicated shadow config. That includes inherited model path/class, init params, optimizer, criterion, epochs, and batch size, while still allowing shadow-specific overrides.

Furthermore, silent faults or possibility of running leakpro with unintended setups have been reduced.  
- [x] Shadow-model cache reuse was fixed so existing shadow models are no longer reused just because they share num_train and model_class. Reuse now checks the full effective training setup, including optimizer settings, criterion settings, init params, batch size, online/offline mode
- [x] Shadow_model.batch_size now actually affects training. Before the field could be present in config but be silently ignored during dataloader creation
- [x] Shadow metadata was expanded so saved shadow runs now record the fields needed for safe reuse decisions, including optimizer params, criterion params, batch size, and model module path
- [x] Tests were added to cover the new behavior: one verifies partial inheritance from the target setup, one checks partial optimizer override behavior, one ensures stale cached shadow metadata is rejected when configs differ, and one verifies that the configured shadow batch size is really used


## Resolved Issues

- [x] fixes #313
- [x] fixas #347  

## How Has This Been Tested?
This was tested by running the celebA DP example with both target model and shadow models without DPsgd enabled. Then another time, setting only 
`shadow_model:`
`   init_params:`
`       dpsgd: True` 
