### PR TITLE
LDG-19: adding online to filter

### DIFF
--- a/leakpro/attacks/mia_attacks/base.py
+++ b/leakpro/attacks/mia_attacks/base.py
@@ -101,7 +101,7 @@ class AttackBASE(AbstractMIA):
             num_models = self.num_shadow_models,
             shadow_population = self.attack_data_indices,
             training_fraction = self.training_data_fraction,
-            online = self.online)
+        )
         # load shadow models
         self.shadow_models, _ = ShadowModelHandler().get_shadow_models(self.shadow_model_indices)
         if self.online is False:

--- a/leakpro/attacks/mia_attacks/dts.py
+++ b/leakpro/attacks/mia_attacks/dts.py
@@ -179,7 +179,7 @@ class AttackDTS(AbstractMIA):
         self.shadow_model_indices = ShadowModelHandler().create_shadow_models(num_models = self.num_shadow_models,
                                                                               shadow_population = self.attack_data_indices,
                                                                               training_fraction = self.training_data_fraction,
-                                                                              online = self.online)
+                                                                              )
 
         self.shadow_models, _ = ShadowModelHandler().get_shadow_models(self.shadow_model_indices)
 

--- a/leakpro/attacks/mia_attacks/lira.py
+++ b/leakpro/attacks/mia_attacks/lira.py
@@ -95,10 +95,12 @@ class AttackLiRA(AbstractMIA):
         """Rescale the logits to a range of [0, 1].
 
         Args:
+        ----
             logits (np.ndarray): The logits to be rescaled.
             true_label (np.ndarray): The true labels for the logits.
 
         Returns:
+        -------
             np.ndarray: The rescaled logits.
 
         """

--- a/leakpro/attacks/mia_attacks/lira.py
+++ b/leakpro/attacks/mia_attacks/lira.py
@@ -138,7 +138,7 @@ class AttackLiRA(AbstractMIA):
         self.shadow_model_indices = ShadowModelHandler().create_shadow_models(num_models = self.num_shadow_models,
                                                                               shadow_population =  self.attack_data_indices,
                                                                               training_fraction = self.training_data_fraction,
-                                                                              online = self.online)
+                                                                              )
 
         self.shadow_models, _ = ShadowModelHandler().get_shadow_models(self.shadow_model_indices)
 

--- a/leakpro/attacks/mia_attacks/multi_signal_lira.py
+++ b/leakpro/attacks/mia_attacks/multi_signal_lira.py
@@ -122,7 +122,7 @@ class AttackMSLiRA(AbstractMIA):
         self.shadow_model_indices = ShadowModelHandler().create_shadow_models(num_models = self.num_shadow_models,
                                                                               shadow_population =  self.attack_data_indices,
                                                                               training_fraction = self.training_data_fraction,
-                                                                              online = self.online)
+                                                                              )
 
         self.shadow_models, _ = ShadowModelHandler().get_shadow_models(self.shadow_model_indices)
 

--- a/leakpro/attacks/mia_attacks/oslo.py
+++ b/leakpro/attacks/mia_attacks/oslo.py
@@ -119,7 +119,6 @@ class AttackOSLO(AbstractMIA):
             num_models = self.num_source_models + self.num_validation_models,
             shadow_population =  self.attack_data_indices,
             training_fraction = self.training_data_fraction,
-            online = self.online
         )
 
         self.shadow_models, _ = ShadowModelHandler().get_shadow_models(self.shadow_model_indices)

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -127,7 +127,7 @@ class AttackRMIA(AbstractMIA):
             num_models = self.num_shadow_models,
             shadow_population = self.attack_data_indices,
             training_fraction = self.training_data_fraction,
-            online = True)
+            online = self.online)
         # load shadow models
         self.shadow_models, _ = ShadowModelHandler().get_shadow_models(self.shadow_model_indices)
 

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -182,7 +182,8 @@ class AttackRMIA(AbstractMIA):
         self.ratio_z = p_z_given_theta / (p_z + self.epsilon)
 
     def _run_attack(self:Self) -> None:
-        logger.info("Running RMIA online attack")
+        mode = "online" if self.online else "offline"
+        logger.info(f"Running RMIA {mode} attack")
 
         # collect the softmax output of the correct class
         n_audit_points = len(self.ground_truth_indices)

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -127,7 +127,7 @@ class AttackRMIA(AbstractMIA):
             num_models = self.num_shadow_models,
             shadow_population = self.attack_data_indices,
             training_fraction = self.training_data_fraction,
-            online = self.online)
+        )
         # load shadow models
         self.shadow_models, _ = ShadowModelHandler().get_shadow_models(self.shadow_model_indices)
 

--- a/leakpro/attacks/mia_attacks/yoqo.py
+++ b/leakpro/attacks/mia_attacks/yoqo.py
@@ -108,7 +108,7 @@ class AttackYOQO(AbstractMIA):
         self.shadow_model_indices = ShadowModelHandler().create_shadow_models(num_models = self.num_shadow_models,
                                                                               shadow_population =  self.attack_data_indices,
                                                                               training_fraction = self.training_data_fraction,
-                                                                              online = self.online)
+                                                                              )
 
         self.shadow_models, _ = ShadowModelHandler().get_shadow_models(self.shadow_model_indices)
 

--- a/leakpro/attacks/utils/shadow_model_handler.py
+++ b/leakpro/attacks/utils/shadow_model_handler.py
@@ -91,14 +91,13 @@ class ShadowModelHandler(ModelHandler):
             return tuple(self._freeze_value(item) for item in value)
         return value
 
-    def _current_training_signature(self:Self, data_size:int, online:bool) -> tuple:
+    def _current_training_signature(self:Self, data_size:int) -> tuple:
         """Build the effective training signature for the current shadow setup.
 
         Args:
         ----
             data_size (int): Number of samples that will be used to train a
                 shadow model.
-            online (bool): Whether the shadow models are created in online mode.
 
         Returns:
         -------
@@ -118,7 +117,6 @@ class ShadowModelHandler(ModelHandler):
             self._freeze_value(self.loss_config),
             self.epochs,
             self.batch_size,
-            online,
             self._freeze_value(self.init_params),
         )
 
@@ -149,19 +147,16 @@ class ShadowModelHandler(ModelHandler):
             self._freeze_value(getattr(metadata, "criterion_params", None)),
             metadata.epochs,
             getattr(metadata, "batch_size", None),
-            metadata.online,
             self._freeze_value(metadata.init_params),
         )
 
-    def _filter(self:Self, data_size:int, online:bool=False) -> tuple[list[int], list[int]]:
+    def _filter(self:Self, data_size:int) -> tuple[list[int], list[int]]:
         """Find cached shadow models compatible with the current configuration.
 
         Args:
         ----
             data_size (int): Number of samples that should be used for each
                 shadow-model training run.
-            online (bool): Whether the requested shadow models are for online
-                or offline use.
 
         Returns:
         -------
@@ -175,7 +170,7 @@ class ShadowModelHandler(ModelHandler):
         files = [f for f in entries if pattern.match(f)]
         all_indices = [int(re.search(r"\d+", f).group()) for f in files]
 
-        current_sig = self._current_training_signature(data_size, online)
+        current_sig = self._current_training_signature(data_size)
 
         filtered_indices = []
         for i in all_indices:
@@ -230,7 +225,6 @@ class ShadowModelHandler(ModelHandler):
         num_models:int,
         shadow_population: list,
         training_fraction:float=0.1,
-        online:bool=False
     ) -> list[int]:
         """Create and train shadow models based on the blueprint.
 
@@ -239,7 +233,6 @@ class ShadowModelHandler(ModelHandler):
             num_models (int): The number of shadow models to create.
             shadow_population (list): The indices in population eligible for training the shadow models.
             training_fraction (float): The fraction of the shadow population to use for training of a shadow model.
-            online (bool): Whether the shadow models are created using an online or offline dataset.
 
         Returns:
         -------
@@ -251,7 +244,7 @@ class ShadowModelHandler(ModelHandler):
 
         # Get the size of the dataset
         data_size = int(len(shadow_population)*training_fraction)
-        all_indices, filtered_indices = self._filter(data_size, online)
+        all_indices, filtered_indices = self._filter(data_size)
 
         # Create a list of indices to use for the new shadow models
         n_existing_models = len(filtered_indices)
@@ -319,7 +312,6 @@ class ShadowModelHandler(ModelHandler):
                 batch_size = self.batch_size,
                 train_result = training_results.metrics,
                 test_result = test_result,
-                online = online,
                 model_class = self.model_class,
                 model_module_path = self.model_path,
                 target_model_hash= self.target_model_hash,

--- a/leakpro/attacks/utils/shadow_model_handler.py
+++ b/leakpro/attacks/utils/shadow_model_handler.py
@@ -251,7 +251,7 @@ class ShadowModelHandler(ModelHandler):
 
         # Get the size of the dataset
         data_size = int(len(shadow_population)*training_fraction)
-        all_indices, filtered_indices = self._filter(data_size)
+        all_indices, filtered_indices = self._filter(data_size, online)
 
         # Create a list of indices to use for the new shadow models
         n_existing_models = len(filtered_indices)

--- a/leakpro/schemas.py
+++ b/leakpro/schemas.py
@@ -199,7 +199,6 @@ class ShadowModelTrainingSchema(BaseModel):
     batch_size: Optional[int] = Field(default=None, ge=1, description="Batch size used during training")
     train_result: EvalOutput = Field(..., description="Evaluation output for the training set")
     test_result: EvalOutput = Field(..., description="Evaluation output for the test set")
-    online: bool = Field(..., description="Online vs. offline training")
     model_class: str = Field(..., description="Model class name")
     model_module_path: Optional[str] = Field(default=None, description="Path to the model module")
     target_model_hash: str = Field(..., description="Hash of target model")

--- a/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
+++ b/leakpro/tests/mia_attacks/utils/test_shadow_model_handler.py
@@ -68,12 +68,11 @@ def test_shadow_model_creation_and_loading(image_handler:ImageInputHandler) -> N
     # Test creation
     n_models = 2
     training_fraction = 0.5
-    online = False
 
     entries_start = os.listdir(sm.storage_path)
     n_entries_start = len(entries_start)
 
-    indx = sm.create_shadow_models(n_models, image_handler.test_indices, training_fraction, online)[0]
+    indx = sm.create_shadow_models(n_models, image_handler.test_indices, training_fraction)[0]
     entries = os.listdir(sm.storage_path)
     n_entries_phase1 = len(entries)
     assert n_entries_phase1 - n_entries_start == 2*n_models
@@ -222,7 +221,6 @@ def test_shadow_model_filter_requires_full_config_match(image_handler: ImageInpu
         "batch_size": sm.batch_size,
         "train_result": EvalOutput(accuracy=0.0, loss=0.0),
         "test_result": EvalOutput(accuracy=0.0, loss=0.0),
-        "online": True,
         "model_class": sm.model_class,
         "model_module_path": sm.model_path,
         "target_model_hash": sm.target_model_hash,
@@ -241,7 +239,7 @@ def test_shadow_model_filter_requires_full_config_match(image_handler: ImageInpu
     with open(tmp_path / "metadata_1.pkl", "wb") as file:
         pickle.dump(stale_metadata, file)
 
-    all_indices, filtered_indices = sm._filter(data_size=5, online=True)
+    all_indices, filtered_indices = sm._filter(data_size=5)
 
     assert sorted(all_indices) == [0, 1]
     assert filtered_indices == [0]
@@ -275,7 +273,7 @@ def test_shadow_model_creation_uses_shadow_batch_size(
     monkeypatch.setattr(image_handler, "eval", lambda *args, **kwargs: EvalOutput(accuracy=0.0, loss=0.0))
     monkeypatch.setattr(sm, "cache_logits", lambda *args, **kwargs: None)
 
-    sm.create_shadow_models(num_models=1, shadow_population=image_handler.test_indices, training_fraction=0.5, online=False)
+    sm.create_shadow_models(num_models=1, shadow_population=image_handler.test_indices, training_fraction=0.5)
 
     assert observed["batch_size"] == shadow_config.batch_size
 
@@ -316,7 +314,6 @@ def test_filter_rejects_shadow_models_from_different_population(image_handler: I
         "batch_size": sm.batch_size,
         "train_result": EvalOutput(accuracy=0.0, loss=0.0),
         "test_result": EvalOutput(accuracy=0.0, loss=0.0),
-        "online": False,
         "model_class": sm.model_class,
         "model_module_path": sm.model_path,
         "target_model_hash": sm.target_model_hash,
@@ -326,7 +323,7 @@ def test_filter_rejects_shadow_models_from_different_population(image_handler: I
     with open(tmp_path / "metadata_0.pkl", "wb") as f:
         pickle.dump(stale_metadata, f)
 
-    all_indices, filtered_indices = sm._filter(data_size=5, online=False)
+    all_indices, filtered_indices = sm._filter(data_size=5)
 
     assert all_indices == [0]
     assert filtered_indices == []


### PR DESCRIPTION
## Problem

The `online` flag (online vs. offline shadow model attack mode) was being passed to `ShadowModelHandler.create_shadow_models()` and stored as part of the shadow model cache key. This meant that shadow models trained for an online attack and shadow models trained for an offline attack were treated as incompatible — even though **the training procedure is identical in both cases**. Switching between modes would trigger unnecessary retraining of all shadow models.

The flag was also stored in `ShadowModelTrainingSchema` and threaded through `_filter()`, `_current_training_signature()`, and `_metadata_training_signature()`, adding false complexity to the caching logic.

Additionally, `rmia.py` had `online=True` hardcoded in its `_prepare_shadow_models()` call, meaning shadow model metadata would be tagged as online even when the attack was configured as offline. The `_run_attack` log message also always said "online" regardless of the configured mode.

## Solution

- Removed `online` from `ShadowModelHandler.create_shadow_models()`, `_filter()`, `_current_training_signature()`, and `_metadata_training_signature()`
- Removed the `online` field from `ShadowModelTrainingSchema`
- Removed `online=self.online` / `online=True` call-site arguments across all MIA attack files (`base.py`, `dts.py`, `lira.py`, `multi_signal_lira.py`, `oslo.py`, `rmia.py`, `yoqo.py`)
- Fixed RMIA's hardcoded log message to correctly reflect online vs. offline mode

The `online` config option still exists on each attack class and continues to control scoring behaviour — which shadow model outputs to average over, whether to compute `out_indices`, and whether to apply the offline scale factor. That is the only place where online vs. offline actually matters.

## How Has This Been Tested?

- Existing shadow model handler unit tests updated to reflect the removed parameter
- No change to scoring logic