### PR TITLE
fixing sampling in rmia

### DIFF
--- a/examples/mia/celebA_HQ/utils/celeb_hq_model.py
+++ b/examples/mia/celebA_HQ/utils/celeb_hq_model.py
@@ -19,6 +19,7 @@ from leakpro.schemas import MIAMetaDataSchema, OptimizerConfig, LossConfig
 class ResNet18(nn.Module):
     def __init__(self, num_classes):
         super().__init__()
+        self.num_classes = num_classes
         self.model = resnet18(weights = ResNet18_Weights.IMAGENET1K_V1)
         self.model.fc = nn.Linear(self.model.fc.in_features, num_classes)
         self.init_params = {"num_classes": num_classes}

--- a/examples/mia/cifar/audit.yaml
+++ b/examples/mia/cifar/audit.yaml
@@ -57,7 +57,7 @@ audit:  # Configurations for auditing
 target:
   # Target model path
   module_path: "./target_model_class.py"
-  model_class: "ResNet18" #"WideResNet" #"ResNet18" 
+  model_class: "WideResNet" #"WideResNet" #"ResNet18" 
   target_folder: "./target"
   # Data paths
   data_path: "./data/cifar10.pkl" #"./data/cifar100.pkl"

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -151,18 +151,19 @@ class AttackRMIA(AbstractMIA):
             for indx in self.shadow_model_indices:
                 self.logits_shadow_models.append(ShadowModelHandler().load_logits(indx=indx))
 
-        # collect the softmax output of the correct class
-        n_attack_points = self.z_data_sample_fraction * len(self.handler.population) # points to compute p(z)
+        # Sample z from test_indices only — these are known non-members (per RMIA paper, z must be
+        # drawn from outside the target model's training set) and always present in the logit cache.
+        # Logit rows are ordered as [train_indices | test_indices], so test rows start at offset n_train.
+        n_train = len(self.handler.train_indices)
+        n_test = len(self.handler.test_indices)
+        n_attack_points = int(self.z_data_sample_fraction * (n_train + n_test))
+        n_z = min(n_attack_points, n_test)
 
-        # Logit cache rows are positional (0..N-1 matching train_indices + test_indices order).
-        # z_indices are raw population indices, so map them to row positions before indexing.
-        all_cached_indices = np.concatenate((self.handler.train_indices, self.handler.test_indices))
-        logit_row = {int(idx): i for i, idx in enumerate(all_cached_indices)}
-
-        # pick random indices sampled from the attack data
-        z_indices = np.random.choice(self.attack_data_indices, size=int(n_attack_points), replace=False)
+        # Sample row positions within the test block (no global index mapping needed)
+        z_local = np.random.choice(n_test, size=n_z, replace=False)
+        z_rows = n_train + z_local  # absolute row in logits_theta
+        z_indices = self.handler.test_indices[z_local]
         z_labels = self.handler.get_labels(z_indices)
-        z_rows = np.array([logit_row[int(idx)] for idx in z_indices])
 
         p_z_given_theta = softmax_logits(self.logits_theta, self.temperature)[z_rows, z_labels]
         p_z_given_theta = np.atleast_2d(p_z_given_theta)

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -11,6 +11,8 @@ from leakpro.attacks.utils.shadow_model_handler import ShadowModelHandler
 from leakpro.attacks.utils.utils import softmax_logits
 from leakpro.input_handler.mia_handler import MIAHandler
 from leakpro.reporting.mia_result import MIAResult
+from leakpro.signals.signal import ModelLogits
+from leakpro.signals.signal_extractor import PytorchModel
 from leakpro.utils.import_helper import Self
 from leakpro.utils.logger import logger
 
@@ -116,6 +118,31 @@ class AttackRMIA(AbstractMIA):
             "detailed": detailed_str,
         }
 
+    def _get_z_logits(self:Self,
+                      logits_cached: np.ndarray,
+                      model,  # noqa: ANN001
+                      z_indices: np.ndarray,
+                      cached_mask: np.ndarray,
+                      logit_row: dict) -> np.ndarray:
+        """Return logits for z_indices, reading from cache where available and computing on-the-fly otherwise."""
+        n = len(z_indices)
+        logits = np.zeros((n, logits_cached.shape[1]))
+
+        if cached_mask.any():
+            rows = np.array([logit_row[int(idx)] for idx in z_indices[cached_mask]])
+            logits[cached_mask] = logits_cached[rows]
+
+        if (~cached_mask).any():
+            criterion = self.handler.get_criterion()
+            unc = np.array(ModelLogits()(
+                [PytorchModel(model, criterion)],
+                self.handler,
+                z_indices[~cached_mask],
+            )).squeeze()
+            logits[~cached_mask] = np.atleast_2d(unc)
+
+        return logits
+
     def _prepare_shadow_models(self:Self) -> None:
 
         # Shadow models are trained on all data points in pairs.
@@ -151,27 +178,38 @@ class AttackRMIA(AbstractMIA):
             for indx in self.shadow_model_indices:
                 self.logits_shadow_models.append(ShadowModelHandler().load_logits(indx=indx))
 
-        # Sample z from test_indices only — these are known non-members (per RMIA paper, z must be
-        # drawn from outside the target model's training set) and always present in the logit cache.
-        # Logit rows are ordered as [train_indices | test_indices], so test rows start at offset n_train.
-        test_indices = np.asarray(self.handler.test_indices)
-        n_train = len(self.handler.train_indices)
-        n_test = len(test_indices)
-        n_attack_points = int(self.z_data_sample_fraction * (n_train + n_test))
-        n_z = min(n_attack_points, n_test)
+        # Sample z from full population per Algorithm 1 of the RMIA paper.
+        # Build a cache lookup (global index → row) once — identical for target and all shadow models.
+        all_cached = np.concatenate([
+            np.asarray(self.handler.train_indices),
+            np.asarray(self.handler.test_indices),
+        ])
+        logit_row = {int(idx): i for i, idx in enumerate(all_cached)}
 
-        # Sample row positions within the test block (no global index mapping needed)
-        z_local = np.random.choice(n_test, size=n_z, replace=False)
-        z_rows = n_train + z_local  # absolute row in logits_theta
-        z_indices = test_indices[z_local]
+        n_z = int(self.z_data_sample_fraction * len(self.attack_data_indices))
+        z_indices = np.random.choice(self.attack_data_indices, size=n_z, replace=False)
         z_labels = self.handler.get_labels(z_indices)
 
-        p_z_given_theta = softmax_logits(self.logits_theta, self.temperature)[z_rows, z_labels]
+        # cached_mask is True for z-points present in the logit cache (train+test).
+        # Auxiliary population points not in the cache are computed on-the-fly.
+        # For configs where f_train + f_test = 1.0 this mask is all-True and no forward pass is needed.
+        cached_mask = np.array([int(idx) in logit_row for idx in z_indices])
+
+        # p(z | target model)
+        logits_z_theta = self._get_z_logits(
+            self.logits_theta, self.handler.target_model, z_indices, cached_mask, logit_row)
+        p_z_given_theta = softmax_logits(logits_z_theta, self.temperature)[np.arange(n_z), z_labels]
         p_z_given_theta = np.atleast_2d(p_z_given_theta)
 
-        # collect the softmax output of the correct class for each shadow model
-        sm_logits_shadow_models = [softmax_logits(x, self.temperature) for x in self.logits_shadow_models]
-        p_z_given_shadow_models = np.array([x[z_rows, z_labels] for x in sm_logits_shadow_models])
+        # p(z | each shadow model)
+        sm_logits_shadow_models = [
+            softmax_logits(
+                self._get_z_logits(sm_logits, sm, z_indices, cached_mask, logit_row),
+                self.temperature,
+            )
+            for sm, sm_logits in zip(self.shadow_models, self.logits_shadow_models)
+        ]
+        p_z_given_shadow_models = np.array([x[np.arange(n_z), z_labels] for x in sm_logits_shadow_models])
 
         # evaluate the marginal p(z)
         if self.online is True:

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -133,9 +133,10 @@ class AttackRMIA(AbstractMIA):
             logits[cached_mask] = logits_cached[rows]
 
         if (~cached_mask).any():
-            criterion = self.handler.get_criterion()
+            # Shadow models are already PytorchModel wrappers; target model is a raw nn.Module.
+            model_wrapped = model if isinstance(model, PytorchModel) else PytorchModel(model, self.handler.get_criterion())
             unc = np.array(ModelLogits()(
-                [PytorchModel(model, criterion)],
+                [model_wrapped],
                 self.handler,
                 z_indices[~cached_mask],
             )).squeeze()

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -154,15 +154,16 @@ class AttackRMIA(AbstractMIA):
         # Sample z from test_indices only — these are known non-members (per RMIA paper, z must be
         # drawn from outside the target model's training set) and always present in the logit cache.
         # Logit rows are ordered as [train_indices | test_indices], so test rows start at offset n_train.
+        test_indices = np.asarray(self.handler.test_indices)
         n_train = len(self.handler.train_indices)
-        n_test = len(self.handler.test_indices)
+        n_test = len(test_indices)
         n_attack_points = int(self.z_data_sample_fraction * (n_train + n_test))
         n_z = min(n_attack_points, n_test)
 
         # Sample row positions within the test block (no global index mapping needed)
         z_local = np.random.choice(n_test, size=n_z, replace=False)
         z_rows = n_train + z_local  # absolute row in logits_theta
-        z_indices = self.handler.test_indices[z_local]
+        z_indices = test_indices[z_local]
         z_labels = self.handler.get_labels(z_indices)
 
         p_z_given_theta = softmax_logits(self.logits_theta, self.temperature)[z_rows, z_labels]


### PR DESCRIPTION
## Summary

- Fixed `IndexError` / `KeyError` crash in RMIA when z-points from `attack_data_indices` fell outside the logit cache (which only covers `[train_indices | test_indices]`)
- Fixed statistically incorrect z-sampling — previous partial fix restricted z to test set only, diverging from Algorithm 1 which samples z from the full population

## What changed

Replaced the z-sampling block in `prepare_attack()` with a **hybrid cache + on-the-fly** approach:

- z is now sampled from `attack_data_indices` (full population) per Algorithm 1 of the RMIA paper
- A `logit_row` lookup maps global indices → cache rows (same for all models since all caches cover `[train | test]`)
- Points in the cache → logits read directly (zero overhead)
- Auxiliary population points not in the cache → logits computed on-the-fly via forward pass

Added `_get_z_logits()` helper that handles both cases for any model (target or shadow).

> For configs where `f_train + f_test = 1.0` (the common case), all z-points are cached — no forward pass is triggered and performance is identical to before.
