### PR TITLE
Webapp fix

### DIFF
--- a/examples/mia/celebA_HQ/webapp/celebA_model_handler.py
+++ b/examples/mia/celebA_HQ/webapp/celebA_model_handler.py
@@ -162,16 +162,17 @@ def _train_dpsgd(dataloader, model, criterion, optimizer, epochs,
         cfg = pickle.load(f)
 
     sample_rate = 1 / len(dataloader)
+    _accountant = cfg.get("accountant", "prv")
     noise_multiplier = get_noise_multiplier(
         target_epsilon=cfg["target_epsilon"],
         target_delta=cfg["target_delta"],
         sample_rate=sample_rate,
         epochs=cfg["epochs"],
-        epsilon_tolerance=cfg["epsilon_tolerance"],
-        accountant="prv",
-        eps_error=cfg["eps_error"],
+        epsilon_tolerance=cfg.get("epsilon_tolerance", 0.01),
+        accountant=_accountant,
+        eps_error=cfg.get("eps_error", 0.01),
     )
-    privacy_engine = PrivacyEngine(accountant="prv")
+    privacy_engine = PrivacyEngine(accountant=_accountant)
     model, optimizer, dataloader = privacy_engine.make_private(
         module=model, optimizer=optimizer, data_loader=dataloader,
         noise_multiplier=noise_multiplier, max_grad_norm=cfg["max_grad_norm"],

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -198,8 +198,7 @@ class ResNet18(nn.Module):
 _PRESET_ARCH_IMAGE_PRETRAINED = '''\
 """Preset architecture — ResNet-18 pretrained on ImageNet, frozen backbone.
 
-Only the final classifier trains (~160K params): Dropout(0.3) + Linear.
-Label smoothing (0.1) is applied via the model so the built-in trainer picks it up.
+Only the final FC layer trains (~160K params).
 Best for small datasets (< 100 samples/class). Very DP-SGD friendly.
 """
 import torch.nn as nn
@@ -213,10 +212,7 @@ class ResNet18Pretrained(nn.Module):
         backbone = models.resnet18(weights="IMAGENET1K_V1")
         for p in backbone.parameters():
             p.requires_grad = False          # freeze entire backbone
-        backbone.fc = nn.Sequential(
-            nn.Dropout(0.3),
-            nn.Linear(512, num_classes),
-        )
+        backbone.fc = nn.Linear(backbone.fc.in_features, num_classes)
         self.model = backbone
 
     def forward(self, x):
@@ -894,10 +890,7 @@ async def train_model(job_id: str, params: TrainParams) -> dict:
                 if params.dpsgd:
                     log_q.put(f"[train] DP-SGD: epsilon={params.target_epsilon}, delta={params.target_delta}, max_grad_norm={params.max_grad_norm}, virtual_batch_size={params.virtual_batch_size or 16}")
 
-            _label_smoothing = 0.1 if _pretrained else 0.0
-            criterion = nn.CrossEntropyLoss(label_smoothing=_label_smoothing)
-            if _label_smoothing:
-                log_q.put(f"[train] Using label smoothing={_label_smoothing}")
+            criterion = nn.CrossEntropyLoss()
             if params.optimizer == "sgd":
                 optimizer = optim.SGD(model.parameters(), lr=params.learning_rate, momentum=0.9, weight_decay=5e-4)
             else:

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -198,8 +198,13 @@ class ResNet18(nn.Module):
 _PRESET_ARCH_IMAGE_PRETRAINED = '''\
 """Preset architecture — ResNet-18 pretrained on ImageNet, frozen backbone.
 
-Only the final FC layer trains (~160K params).
-Best for small datasets (< 100 samples/class). Very DP-SGD friendly.
+Only the final FC head trains (512 * num_classes params; e.g. ~5K for 10 classes).
+Best for small datasets (< 100 samples/class).
+
+Note: under DP-SGD, Opacus's ModuleValidator replaces every BatchNorm with
+GroupNorm. This drops the pretrained ImageNet normalization stats, and the new
+GroupNorm affine params are trainable, so DP-SGD trains the FC head plus all
+GroupNorm params -- not the FC head alone.
 """
 import torch.nn as nn
 import torchvision.models as models

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -84,16 +84,17 @@ def _default_train(loader, model, criterion, optimizer, epochs,
             cfg = pickle.load(f)
 
         sample_rate = 1 / len(loader)
+        _accountant = cfg.get("accountant", "prv")
         noise_multiplier = get_noise_multiplier(
             target_epsilon=cfg["target_epsilon"],
             target_delta=cfg["target_delta"],
             sample_rate=sample_rate,
             epochs=cfg["epochs"],
-            epsilon_tolerance=cfg["epsilon_tolerance"],
-            accountant="prv",
-            eps_error=cfg["eps_error"],
+            epsilon_tolerance=cfg.get("epsilon_tolerance", 0.01),
+            accountant=_accountant,
+            eps_error=cfg.get("eps_error", 0.01),
         )
-        privacy_engine = PrivacyEngine(accountant="prv")
+        privacy_engine = PrivacyEngine(accountant=_accountant)
         model, optimizer, loader = privacy_engine.make_private(
             module=model, optimizer=optimizer, data_loader=loader,
             noise_multiplier=noise_multiplier, max_grad_norm=cfg["max_grad_norm"],
@@ -194,9 +195,38 @@ class ResNet18(nn.Module):
         return self.model(x)
 '''
 
+_PRESET_ARCH_IMAGE_PRETRAINED = '''\
+"""Preset architecture — ResNet-18 pretrained on ImageNet, frozen backbone.
+
+Only the final classifier trains (~160K params): Dropout(0.3) + Linear.
+Label smoothing (0.1) is applied via the model so the built-in trainer picks it up.
+Best for small datasets (< 100 samples/class). Very DP-SGD friendly.
+"""
+import torch.nn as nn
+import torchvision.models as models
+
+
+class ResNet18Pretrained(nn.Module):
+    def __init__(self, num_classes=10):
+        super().__init__()
+        self.num_classes = num_classes
+        backbone = models.resnet18(weights="IMAGENET1K_V1")
+        for p in backbone.parameters():
+            p.requires_grad = False          # freeze entire backbone
+        backbone.fc = nn.Sequential(
+            nn.Dropout(0.3),
+            nn.Linear(512, num_classes),
+        )
+        self.model = backbone
+
+    def forward(self, x):
+        return self.model(x)
+'''
+
 _PRESET_ARCHS: dict[str, str] = {
-    "cifar_wrn":   _PRESET_ARCH_IMAGE,
-    "cifar_image": _PRESET_ARCH_IMAGE,
+    "cifar_wrn":        _PRESET_ARCH_IMAGE,
+    "cifar_image":      _PRESET_ARCH_IMAGE,
+    "image_pretrained": _PRESET_ARCH_IMAGE_PRETRAINED,
 }
 
 from .checker import run_check
@@ -856,13 +886,18 @@ async def train_model(job_id: str, params: TrainParams) -> dict:
                 _arch_src = (job_dir / "arch.py").read_text()
                 _pretrained = (
                     ("ResNet18_Weights" in _arch_src and "weights=None" not in _arch_src) or
-                    ("pretrained=True" in _arch_src)
+                    ("pretrained=True" in _arch_src) or
+                    ('weights="IMAGENET' in _arch_src) or
+                    ("weights='IMAGENET" in _arch_src)
                 )
                 log_q.put(f"[train] Model: {_arch_cls.__name__}(num_classes={_num_classes_data}, pretrained={'yes' if _pretrained else 'no'})")
                 if params.dpsgd:
                     log_q.put(f"[train] DP-SGD: epsilon={params.target_epsilon}, delta={params.target_delta}, max_grad_norm={params.max_grad_norm}, virtual_batch_size={params.virtual_batch_size or 16}")
 
-            criterion = nn.CrossEntropyLoss()
+            _label_smoothing = 0.1 if _pretrained else 0.0
+            criterion = nn.CrossEntropyLoss(label_smoothing=_label_smoothing)
+            if _label_smoothing:
+                log_q.put(f"[train] Using label smoothing={_label_smoothing}")
             if params.optimizer == "sgd":
                 optimizer = optim.SGD(model.parameters(), lr=params.learning_rate, momentum=0.9, weight_decay=5e-4)
             else:
@@ -873,13 +908,14 @@ async def train_model(job_id: str, params: TrainParams) -> dict:
             _vbs = params.virtual_batch_size or 16
             if params.dpsgd:
                 import pickle as _pkl
+                _accountant = params.accountant if params.accountant in ("prv", "rdp") else "prv"
                 _dpsgd_meta = {
                     "target_epsilon":    params.target_epsilon or 10.0,
                     "target_delta":      params.target_delta if params.target_delta is not None else 1e-5,
                     "sample_rate":       1.0 / len(loader),
                     "epochs":            params.epochs,
                     "epsilon_tolerance": 0.01,
-                    "accountant":        "prv",
+                    "accountant":        _accountant,
                     "eps_error":         0.01,
                     "max_grad_norm":     params.max_grad_norm or 1.0,
                 }

--- a/leakpro/webapp/backend/models.py
+++ b/leakpro/webapp/backend/models.py
@@ -80,6 +80,7 @@ class TrainParams(BaseModel):
     target_delta: float | None = None
     max_grad_norm: float | None = None
     virtual_batch_size: int | None = None
+    accountant: str = "prv"          # "prv" | "rdp"
 
 
 class ModelInfo(BaseModel):

--- a/leakpro/webapp/frontend/src/api.ts
+++ b/leakpro/webapp/frontend/src/api.ts
@@ -144,6 +144,7 @@ export interface TrainParams {
   target_delta?: number;
   max_grad_norm?: number;
   virtual_batch_size?: number;
+  accountant?: string;
 }
 
 export interface AttackParams {

--- a/leakpro/webapp/frontend/src/components/steps/Step3Setup.tsx
+++ b/leakpro/webapp/frontend/src/components/steps/Step3Setup.tsx
@@ -183,12 +183,25 @@ const PRESETS: Array<{
 }> = [
   {
     id: "cifar_image",
-    label: "Image",
+    label: "Image (scratch)",
     icon: "image",
-    desc: "ResNet-18 trained from scratch on your dataset. Works for any 3-channel images — num_classes detected automatically. Upload your own arch.py to use pretrained weights.",
+    desc: "ResNet-18 trained from scratch on your dataset. Works for any 3-channel images — num_classes detected automatically. Best when you have plenty of data (500+ samples/class).",
     types: ["image"],
     details: {
-      architecture: "ResNet-18 (random init) — ~11M params",
+      architecture: "ResNet-18 (random init) — ~11M trainable params",
+      optimizer: "Adam (default) or SGD",
+      learning_rate: "0.001",
+      scheduler: "none",
+    },
+  },
+  {
+    id: "image_pretrained",
+    label: "Image (pretrained)",
+    icon: "auto_awesome",
+    desc: "ResNet-18 pretrained on ImageNet — backbone fully frozen, only Dropout(0.3) + FC layer trains (~160K params). Label smoothing 0.1 applied. Best for small datasets and DP-SGD.",
+    types: ["image"],
+    details: {
+      architecture: "ResNet-18 (ImageNet weights, frozen) — ~160K trainable params",
       optimizer: "Adam (default) or SGD",
       learning_rate: "0.001",
       scheduler: "none",

--- a/leakpro/webapp/frontend/src/components/steps/Step3Setup.tsx
+++ b/leakpro/webapp/frontend/src/components/steps/Step3Setup.tsx
@@ -198,10 +198,10 @@ const PRESETS: Array<{
     id: "image_pretrained",
     label: "Image (pretrained)",
     icon: "auto_awesome",
-    desc: "ResNet-18 pretrained on ImageNet — backbone fully frozen, only Dropout(0.3) + FC layer trains (~160K params). Label smoothing 0.1 applied. Best for small datasets and DP-SGD.",
+    desc: "ResNet-18 pretrained on ImageNet — backbone fully frozen, only the final FC layer trains (~160K params). Best for small datasets (< 100 samples/class) and DP-SGD.",
     types: ["image"],
     details: {
-      architecture: "ResNet-18 (ImageNet weights, frozen) — ~160K trainable params",
+      architecture: "ResNet-18 (ImageNet weights, frozen backbone) — ~160K trainable params",
       optimizer: "Adam (default) or SGD",
       learning_rate: "0.001",
       scheduler: "none",

--- a/leakpro/webapp/frontend/src/components/steps/Step3Setup.tsx
+++ b/leakpro/webapp/frontend/src/components/steps/Step3Setup.tsx
@@ -175,6 +175,7 @@ interface PresetDetail {
   optimizer: string;
   learning_rate: string;
   scheduler: string;
+  note?: string;
 }
 
 const PRESETS: Array<{
@@ -198,13 +199,14 @@ const PRESETS: Array<{
     id: "image_pretrained",
     label: "Image (pretrained)",
     icon: "auto_awesome",
-    desc: "ResNet-18 pretrained on ImageNet — backbone fully frozen, only the final FC layer trains (~160K params). Best for small datasets (< 100 samples/class) and DP-SGD.",
+    desc: "ResNet-18 pretrained on ImageNet, fine-tuned on your dataset. Best for small datasets (< 100 samples/class) and DP-SGD.",
     types: ["image"],
     details: {
-      architecture: "ResNet-18 (ImageNet weights, frozen backbone) — ~160K trainable params",
+      architecture: "ResNet-18 (ImageNet weights), frozen backbone — only the FC head trains (512 × num_classes params, e.g. ~5K for 10 classes)",
       optimizer: "Adam (default) or SGD",
       learning_rate: "0.001",
       scheduler: "none",
+      note: "Under DP-SGD, Opacus replaces every BatchNorm with GroupNorm. This drops the pretrained ImageNet normalization stats, and the new GroupNorm affine params become trainable — so DP-SGD trains the FC head plus all GroupNorm params, not the FC head alone.",
     },
   },
   {
@@ -371,6 +373,12 @@ export default function Step3Setup({ jobId, handlerConfig, onDone, initialArch }
                     <DetailRow label="Optimizer" value={p.details.optimizer} />
                     <DetailRow label="Learning rate" value={p.details.learning_rate} />
                     <DetailRow label="Scheduler" value={p.details.scheduler} />
+                    {p.details.note && (
+                      <div className="flex items-start gap-1.5 mt-1 rounded-lg bg-amber-50 dark:bg-amber-950/30 px-2.5 py-2">
+                        <span className="material-symbols-outlined text-sm text-amber-600 dark:text-amber-400 shrink-0">info</span>
+                        <span className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed">{p.details.note}</span>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/leakpro/webapp/frontend/src/components/steps/Step4Models.tsx
+++ b/leakpro/webapp/frontend/src/components/steps/Step4Models.tsx
@@ -611,6 +611,17 @@ function TrainCard({ params, onChange, onRemove }: {
           <NumberField label="Target δ" value={params.target_delta ?? 1e-5} min={1e-7} max={0.1} step={1e-6} onChange={(v) => onChange({ target_delta: v })} />
           <NumberField label="Max Grad Norm" value={params.max_grad_norm ?? 1.0} min={0.01} max={10} step={0.01} onChange={(v) => onChange({ max_grad_norm: v })} />
           <NumberField label="Virtual Batch Size" value={params.virtual_batch_size ?? 16} min={1} max={512} step={1} onChange={(v) => onChange({ virtual_batch_size: v })} />
+          <div>
+            <label className="text-xs font-semibold text-slate-500 mb-1 block">Accountant</label>
+            <select
+              value={params.accountant ?? "prv"}
+              onChange={(e) => onChange({ accountant: e.target.value })}
+              className="w-full rounded border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm px-3 py-2"
+            >
+              <option value="prv">PRV (recommended)</option>
+              <option value="rdp">RDP</option>
+            </select>
+          </div>
         </div>
       )}
     </div>
@@ -727,5 +738,6 @@ function defaultParams(n: number): TrainParams {
     f_train: 0.5,
     f_test: 0.5,
     dpsgd: false,
+    accountant: "prv",
   };
 }


### PR DESCRIPTION
# Webapp fix

## Summary

Two improvements to the webapp training flow:

**1. Configurable DP-SGD accountant (PRV / RDP)**

The accountant type was hardcoded to `"prv"` everywhere. This PR exposes a PRV/RDP dropdown in the Step 4 DP-SGD config, threads the choice through `TrainParams` on both the backend (`models.py`) and frontend (`api.ts`), and updates the CelebA model handler examples to match.

Also hardens DP-SGD config loading by switching to `.get()` with safe defaults for `epsilon_tolerance` and `eps_error`, preventing `KeyError` on older config files that don't include these fields.

**2. Pretrained image preset (ResNet-18 ImageNet, frozen backbone)**

Adds an "Image (pretrained)" option in Step 3 alongside the existing "Image (scratch)" preset. Uses ResNet-18 with a fully frozen ImageNet backbone — only the final FC layer trains (~160K params vs 11M). Best for small datasets (< 100 samples/class) and DP-SGD runs. Also improves pretrained weight detection to recognise `weights="IMAGENET..."` syntax.

## Changes

- `leakpro/webapp/backend/main.py` — configurable accountant in training loop; new `_PRESET_ARCH_IMAGE_PRETRAINED` architecture; improved pretrained detection
- `leakpro/webapp/backend/models.py` — `accountant: str = "prv"` field on `TrainParams`
- `leakpro/webapp/frontend/src/api.ts` — `accountant?: string` on `TrainParams` interface
- `leakpro/webapp/frontend/src/components/steps/Step3Setup.tsx` — "Image (pretrained)" preset card
- `leakpro/webapp/frontend/src/components/steps/Step4Models.tsx` — accountant dropdown in DP-SGD config
- `examples/mia/celebA_HQ/celebA_model_handler_dpsgd.py` — configurable accountant + safe config defaults
- `examples/mia/celebA_HQ/webapp/celebA_model_handler.py` — same

## How Has This Been Tested?

- Webapp run end-to-end with both PRV and RDP accountant on the CelebA example
- Legacy DP-SGD config (missing `epsilon_tolerance`/`eps_error`) loads without error
- "Image (pretrained)" preset trains successfully on a small dataset with DP-SGD enabled

## Related Pull Requests

- #423 (tabular webapp LoS example)