### PR TITLE
Scaffold tabular reconstruction attack (MCR)

### DIFF
--- a/examples/minv/tabular_reconstruction/exp1_xk_reachability.py
+++ b/examples/minv/tabular_reconstruction/exp1_xk_reachability.py
@@ -1,0 +1,215 @@
+"""Exp 1 - x_k reachability (validation gate for sensitive-attribute mode).
+
+Question this answers
+---------------------
+The sensitive-attribute attack assumes the generator's latent space is rich
+enough that SOME z reproduces a real member's *known* (non-sensitive) features
+x_k. If it cannot, the recovered sensitive part x_s is meaningless and the whole
+sensitive mode is blocked - so this is a go/no-go check to run BEFORE building
+the full attack.
+
+What it does
+------------
+1. Build a small tabular dataset (continuous features + a pseudo_label column).
+2. Train a conditional CustomCTGAN on it.
+3. For real rows, designate the first K continuous columns as "known" (x_k) and
+   the rest as "sensitive" (x_s).
+4. Optimize z (white-box, differentiable path) to make the generated record
+   match x_k, then measure the residual on x_k.
+5. PASS if the known-feature residual is driven small; FAIL otherwise.
+
+Notes
+-----
+- Runnable as a self-contained smoke test on SYNTHETIC data. To run the REAL
+  validation, swap `make_synthetic_data()` for your dataset (keep `pseudo_label`
+  as the last, discrete column) and set KNOWN_COLS accordingly.
+- Designed against `utils/CTGAN_extended.py::CustomCTGAN`.
+- Not executed in this environment - run inside the `leakpro_py311` conda env
+  (needs `ctgan`, `torch`). Tune the small TODOs (epochs, K) to your data.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+
+from utils.CTGAN_extended import CustomCTGAN
+
+# --------------------------------------------------------------------------- #
+# Config                                                                       #
+# --------------------------------------------------------------------------- #
+SEED = 0
+N_ROWS = 2000
+N_CONT_FEATURES = 8          # continuous features
+N_CLASSES = 4                # pseudo_label cardinality
+N_KNOWN = 4                  # first N_KNOWN continuous cols are "known" (x_k)
+
+DIM_Z = 32                   # latent dim (tabular: small, per design doc)
+GEN_EPOCHS = 150             # TODO: raise for real data
+BATCH_SIZE = 200
+
+N_TARGETS = 64               # how many real rows to test reachability on
+Z_ITERS = 800                # latent-optimization iterations per target
+Z_LR = 5e-2
+
+# Pass criterion: median relative residual on known features must be below this
+# (residual measured in units of each feature's std, so it is scale-free).
+PASS_THRESHOLD = 0.15
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+# --------------------------------------------------------------------------- #
+# Data                                                                         #
+# --------------------------------------------------------------------------- #
+def make_synthetic_data() -> tuple[pd.DataFrame, list[str]]:
+    """Continuous features + a discrete `pseudo_label` (last column).
+
+    Each class is a Gaussian blob so the generator has clear class structure to
+    learn - a fair best case for the reachability check.
+    """
+    rng = np.random.default_rng(SEED)
+    centers = rng.normal(0, 4, size=(N_CLASSES, N_CONT_FEATURES))
+    labels = rng.integers(0, N_CLASSES, size=N_ROWS)
+    X = centers[labels] + rng.normal(0, 1, size=(N_ROWS, N_CONT_FEATURES))
+
+    cols = [f"f{i}" for i in range(N_CONT_FEATURES)]
+    df = pd.DataFrame(X, columns=cols)
+    df["pseudo_label"] = labels.astype(int)   # MUST be last + discrete
+    return df, cols
+
+
+# --------------------------------------------------------------------------- #
+# A tiny differentiable target model                                           #
+# --------------------------------------------------------------------------- #
+class TinyTarget(nn.Module):
+    """Minimal pytorch_tabular-style model: takes a {"continuous": ...} batch,
+    returns {"logits": ...}. Only needed so CustomCTGAN.fit() can run; the
+    reachability test itself does not depend on its quality.
+    """
+
+    def __init__(self, n_cont: int, n_classes: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(nn.Linear(n_cont, 64), nn.ReLU(), nn.Linear(64, n_classes))
+
+    def forward(self, batch: dict) -> dict:
+        return {"logits": self.net(batch["continuous"].float())}
+
+
+# --------------------------------------------------------------------------- #
+# Train the conditional generator                                              #
+# --------------------------------------------------------------------------- #
+def train_generator(df: pd.DataFrame) -> CustomCTGAN:
+    gen = CustomCTGAN(
+        embedding_dim=DIM_Z,
+        num_classes=N_CLASSES,
+        batch_size=BATCH_SIZE,
+        epochs=GEN_EPOCHS,
+        pac=10,
+        verbose=True,
+        cuda=torch.cuda.is_available(),
+    )
+    target = TinyTarget(N_CONT_FEATURES, N_CLASSES).to(device)
+
+    # Self-contained losses (avoid coupling to gan_losses signatures):
+    #   WGAN-style generator loss, cross-entropy inversion loss.
+    def gen_criterion(y_fake):          # noqa: ANN001, ANN202
+        return -y_fake.mean()
+
+    def inv_criterion(logits, y):       # noqa: ANN001, ANN202
+        return torch.nn.functional.cross_entropy(logits, y)
+
+    gen.fit(
+        train_data=df,
+        target_model=target,
+        num_classes=N_CLASSES,
+        inv_criterion=inv_criterion,
+        gen_criterion=gen_criterion,
+        dis_criterion=None,             # unused by fit() (WGAN D-step is internal)
+        n_iter=GEN_EPOCHS,
+        n_dis=1,
+        alpha=0.1,
+        discrete_columns=("pseudo_label",),
+        use_inv_loss=True,              # keeps inv_loss in the graph (fit asserts this)
+    )
+    gen.eval()
+    return gen
+
+
+# --------------------------------------------------------------------------- #
+# The reachability test                                                        #
+# --------------------------------------------------------------------------- #
+def reachability(gen: CustomCTGAN, df: pd.DataFrame, cont_cols: list[str]) -> None:
+    """Optimize z so the generated record matches each target's known features."""
+    # Sample real targets
+    sample = df.sample(n=min(N_TARGETS, len(df)), random_state=SEED)
+    y = torch.tensor(sample["pseudo_label"].to_numpy(), dtype=torch.long, device=device)
+    x_true = torch.tensor(sample[cont_cols].to_numpy(), dtype=torch.float32, device=device)  # [B, n_cont]
+
+    known_idx = list(range(N_KNOWN))
+    x_k = x_true[:, known_idx]                                  # [B, K]
+
+    # Per-feature std for scale-free residuals
+    feat_std = torch.tensor(df[cont_cols].std(ddof=0).to_numpy(), dtype=torch.float32, device=device)
+    feat_std = feat_std.clamp(min=1e-6)
+
+    # Optimize one z per target (batched)
+    z = torch.randn(len(sample), gen.dim_z, device=device, requires_grad=True)
+    opt = torch.optim.Adam([z], lr=Z_LR)
+
+    for it in range(Z_ITERS):
+        fakeact, _ = gen.forward_fakeact_with_labels(z, y)     # differentiable
+        x_cont, _, _ = gen._pack_for_gandalf(fakeact)          # [B, n_cont], schema order
+        gen_known = x_cont[:, known_idx]
+        # scale-free MSE on known features
+        loss = (((gen_known - x_k) / feat_std[known_idx]) ** 2).mean()
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        if (it + 1) % 100 == 0:
+            print(f"  iter {it + 1:4d}  known-feature loss (std units): {loss.item():.4f}")
+
+    # --- Report ---
+    with torch.no_grad():
+        fakeact, _ = gen.forward_fakeact_with_labels(z, y)
+        x_cont, _, _ = gen._pack_for_gandalf(fakeact)
+        # relative residual per known feature, per row
+        rel = ((x_cont[:, known_idx] - x_k).abs() / feat_std[known_idx])
+        rel_per_row = rel.mean(dim=1).cpu().numpy()
+        median_res = float(np.median(rel_per_row))
+
+        # bonus context: residual on the *sensitive* (unknown) cols vs truth
+        sens_idx = list(range(N_KNOWN, len(cont_cols)))
+        if sens_idx:
+            sens_rel = ((x_cont[:, sens_idx] - x_true[:, sens_idx]).abs()
+                        / feat_std[sens_idx]).mean().item()
+        else:
+            sens_rel = float("nan")
+
+    print("\n================ Exp 1 results ================")
+    print(f"targets tested            : {len(sample)}")
+    print(f"known features (x_k)       : {known_idx}")
+    print(f"median rel. residual (x_k) : {median_res:.4f}  (std units; lower = better)")
+    print(f"pass threshold             : {PASS_THRESHOLD}")
+    print(f"sensitive residual (x_s)   : {sens_rel:.4f}  (context only, not the gate)")
+    verdict = "PASS - x_k reachable; sensitive mode is viable" if median_res < PASS_THRESHOLD \
+        else "FAIL - latent cannot reproduce known features; rethink generator / dim_z"
+    print(f"VERDICT                    : {verdict}")
+    print("===============================================")
+
+
+def main() -> None:
+    torch.manual_seed(SEED)
+    np.random.seed(SEED)
+    print(f"device: {device}")
+    df, cont_cols = make_synthetic_data()
+    print(f"data: {df.shape[0]} rows, {len(cont_cols)} continuous features, {N_CLASSES} classes")
+    print("training conditional generator ...")
+    gen = train_generator(df)
+    print("running x_k reachability optimization ...")
+    reachability(gen, df, cont_cols)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/minv/tabular_reconstruction/utils/CTGAN_extended.py
+++ b/examples/minv/tabular_reconstruction/utils/CTGAN_extended.py
@@ -1,0 +1,688 @@
+
+import numpy as np
+import pandas as pd
+import torch
+from ctgan import CTGAN
+from ctgan.data_sampler import DataSampler
+from ctgan.data_transformer import DataTransformer
+from ctgan.synthesizers.ctgan import Discriminator, Generator
+from torch import optim
+from tqdm import tqdm
+
+
+class CustomCTGAN(CTGAN):
+    def __init__(self,
+                 embedding_dim=256,
+                 generator_dim=(256, 256),
+                 discriminator_dim=(256, 256),
+                 generator_lr = 2e-4,
+                 generator_decay=1e-6,
+                 discriminator_lr=2e-5,
+                 discriminator_decay=1e-7,
+                 num_classes=5088,
+                 batch_size=500,
+                 discriminator_steps=5,
+                 log_frequency=True,
+                 verbose=False,
+                 epochs=300,
+                 pac=10,
+                 only_pseudo_label_conditioning=True,
+                 cuda=True) -> None:
+
+        self.dim_z = embedding_dim
+
+        super().__init__(embedding_dim, generator_dim, discriminator_dim,
+                         generator_lr, generator_decay, discriminator_lr,
+                         discriminator_decay, batch_size, discriminator_steps,
+                         log_frequency, verbose, epochs, pac, cuda)
+        self.gumbel_seed = 1234
+        self._transformer = DataTransformer()
+
+        self.only_psuedo_label_conditioning = only_pseudo_label_conditioning
+
+    def to(self, device) -> None:
+        self._device = device
+        self._generator.to(device)
+
+
+    def eval(self) -> None:
+        self._generator.eval()
+
+    def __call__(self, z=None, y=None, df_conv =None):
+        """Sample data similar to the training data.
+
+        Choosing a condition_column and condition_value will increase the probability of the
+        discrete condition_value happening in the condition_column.
+
+        Args:
+            n (int):
+                Number of rows to sample.
+            condition_column (string):
+                Name of a discrete column.
+            condition_value (string):
+                Name of the category in the condition_column which we wish to increase the
+                probability of happening.
+
+        Returns:
+            numpy.ndarray or pandas.DataFrame
+
+        """
+        if self._transformer is None:
+            raise ValueError("The transformer has not been initialized. Please call the `fit` method first.")
+
+        if y is not None:
+            # TODO: If desired, support for conditioning on other discrete
+            # columns than pseudo-labels can be implemented here for correct sampling.
+
+            # Batch size is length of y
+            bs = y.shape[0]
+            condition_values = y.detach().cpu().numpy()
+
+            discrete_column_id = np.array([self._data_sampler._n_discrete_columns-1]*bs)
+            cond = np.zeros((bs, self._data_sampler._n_categories), dtype="float32")
+            category_id = self._data_sampler._discrete_column_cond_st[discrete_column_id] + condition_values
+            cond[np.arange(bs), category_id] = 1
+            c1 = cond
+
+        else:
+            bs = z.shape[0]
+            c1 = self._data_sampler.sample_original_condvec(bs)
+
+        c1 = torch.from_numpy(c1).to(self._device)
+
+        # if z is None:
+        #     mean = torch.zeros(bs, self._embedding_dim)
+        #     std = mean + 1
+        #     fakez = torch.normal(mean=mean, std=std).to(self._device)
+        # else:
+        #     fakez = z
+
+
+        fakez = torch.cat([z, c1], dim=1)
+
+        fake = self._generator(fakez)
+        fakeact = self._apply_activate(fake)
+
+        # if df_conv:
+        samples = self._transformer.inverse_transform(fakeact.detach().cpu().numpy())
+        # else:
+        #     self._transformer_only_con = DataTransformerContinuousOnly()
+        #     samples_dis = self._transformer_only_con.inverse_transform_continuous_only(fakeact)
+
+        """
+        for condition_value in condition_values:
+            if condition_column is not None and condition_value is not None:
+                try:
+                    condition_info = self._transformer.convert_column_name_value_to_id(
+                        condition_column, condition_value
+                    )
+                    global_condition_vec = self._data_sampler.generate_cond_from_condition_column_info(
+                        condition_info, bs
+                    )
+                except ValueError:
+                    # If the transformer has not seen the condition value in training, it will raise a ValueError
+                    # We still want to be able to sample, so we set the global_condition_vec to None
+                    global_condition_vec = None
+            else:
+                global_condition_vec = None
+
+            data = []
+            if z is None:
+                mean = torch.zeros(bs, self._embedding_dim)
+                std = mean + 1
+                fakez = torch.normal(mean=mean, std=std).to(self._device)
+            else:
+                fakez = z
+
+
+            if global_condition_vec is not None:
+                condvec = global_condition_vec.copy()
+            else:
+                condvec = self._data_sampler.sample_original_condvec(bs)
+
+            if condvec is None:
+                pass
+            else:
+                c1 = condvec
+                c1 = torch.from_numpy(c1).to(self._device)
+                fakez = torch.cat([fakez, c1], dim=1)
+
+            fake = self._generator(fakez)
+            fakeact = self._apply_activate(fake)
+            data.append(fakeact.detach().cpu().numpy())
+
+            data = np.concatenate(data, axis=0)
+
+            sample = self._transformer.inverse_transform(data)
+            # add row to samples
+            samples = pd.concat([samples, sample])
+
+        """
+        return samples
+
+    def sample_condvec(self, batch):
+        """Generate the conditional vector for training. Supports conditioning on all discrete columns or only the pseudo label column.
+
+        Args:
+            batch (int):
+                The batch size.
+            only_pseudo_label_conditioning (bool):
+                If True, only sample the pseudo label column.
+                If False, sample all discrete columns.
+
+        Returns:
+            cond (batch x #categories):
+                The conditional vector.
+            mask (batch x #discrete columns):
+                A one-hot vector indicating the selected discrete column.
+            discrete column id (batch):
+                Integer representation of mask.
+            category_id_in_col (batch):
+                Selected category in the selected discrete column.
+
+        """
+        if self._data_sampler._n_discrete_columns == 0:
+            return None
+
+        if self.only_psuedo_label_conditioning:
+            discrete_column_id = np.array([self._data_sampler._n_discrete_columns-1]*batch)
+        else:
+            discrete_column_id = np.random.choice(np.arange(self._data_sampler._n_discrete_columns), batch)
+
+        cond = np.zeros((batch, self._data_sampler._n_categories), dtype="float32")
+        mask = np.zeros((batch, self._data_sampler._n_discrete_columns), dtype="float32")
+        mask[np.arange(batch), discrete_column_id] = 1
+        category_id_in_col = self._data_sampler._random_choice_prob_index(discrete_column_id)
+        category_id = self._data_sampler._discrete_column_cond_st[discrete_column_id] + category_id_in_col
+        cond[np.arange(batch), category_id] = 1
+
+        return cond, mask, discrete_column_id, category_id_in_col
+
+
+    def fit(self, train_data, target_model, num_classes, inv_criterion, gen_criterion, dis_criterion, n_iter, n_dis, alpha = 0.1, discrete_columns=(), use_inv_loss=True) -> None:
+        """Fit the CTGAN model to the training data using pseudo-labeled guidance as in the PLG-MI attack.
+
+        Args:
+            train_data (pandas.DataFrame):
+                Training data.
+            target_model (torch.nn.Module):
+                Target model.
+            num_classes (int):
+                Number of classes.
+            inv_criterion (callable):
+                Inversion criterion.
+            gen_criterion (callable):
+                Generator criterion.
+            dis_criterion (callable):
+                Discriminator criterion.
+            alpha (float):
+                Alpha value for the inversion loss.
+            discrete_columns (list of str):
+                List of column names that are discrete.
+
+        """
+
+        # --- setup once ---
+        self._validate_discrete_columns(train_data, discrete_columns)
+        self._validate_null_data(train_data, discrete_columns)
+        mat = self._prepare_training(train_data, discrete_columns, num_classes)
+
+        # target LightningModule (pytorch_tabular)
+        mdl = target_model.model if hasattr(target_model, "model") else target_model
+        mdl = mdl.to(self._device).eval()
+
+        self.loss_values = pd.DataFrame(columns=["Epoch","Generator Loss","Discriminator Loss","Inversion Loss","Conditioning Loss (CE)","Accuracy"])
+        steps_per_epoch = max(len(mat) // self._batch_size, 1)
+
+        for epoch in tqdm(range(n_iter), disable=(not self._verbose)):
+            for _ in range(steps_per_epoch):
+
+                # --- D updates ---
+                for _ in range(n_dis):
+                    fakez, real, c1, m1, c2 = self._sample_batch(mat)
+                    fake   = self._generator(fakez)
+                    fakeact= self._apply_activate(fake)
+                    loss_d = self._d_step(fakeact, real, c1, c2)
+
+                # --- G update ---
+                fakez, _, c1, m1, _ = self._sample_batch(mat)
+                fake    = self._generator(fakez)
+                fakeact = self._apply_activate(fake)
+                y_fake  = self._discriminator(torch.cat([fakeact, c1], dim=1) if c1 is not None else fakeact)
+
+                # pack inputs for GANDALF (pure torch)
+                x_cont, x_cat, pseudo = self._pack_for_gandalf(fakeact)
+                batch = {}
+                if x_cont is not None: batch["continuous"]  = x_cont.float().to(self._device)
+                if x_cat  is not None: batch["categorical"] = x_cat.long().to(self._device)
+                T_logits = mdl(batch)["logits"]
+
+                # Inversion loss: only if we're using it AND we sampled a condition (c1)
+                if use_inv_loss and c1 is not None:
+                    inv_loss = inv_criterion(T_logits, pseudo.to(self._device))
+                else:
+                    inv_loss = torch.zeros((), device=self._device, dtype=y_fake.dtype)
+
+                # Conditioning loss (CTGAN): only if we sampled a condition
+                if c1 is not None:
+                    ce_loss = self._cond_loss(fake, c1, m1)
+                else:
+                    ce_loss = torch.zeros((), device=self._device, dtype=y_fake.dtype)
+
+
+                loss_g   = gen_criterion(y_fake) + ce_loss
+                loss_all = loss_g + alpha * inv_loss
+
+                # Log once in a while
+                if (epoch % 100 == 0):  # or every N steps
+                    # ---- sanity check: does inv_loss contribute gradients to G? ----
+                    # 1) Grad norm of G params with the inversion term
+                    grads_with = torch.autograd.grad(
+                        loss_all,                      # includes alpha * inv_loss
+                        self._generator.parameters(),
+                        retain_graph=True,
+                        allow_unused=True
+                    )
+                    torch.sqrt(sum((g.detach()**2).sum() for g in grads_with if g is not None)).item()
+
+                    # 2) Grad norm of G params without the inversion term (alpha=0)
+                    grads_wo = torch.autograd.grad(
+                        loss_g,                        # just gen + CE (no inversion)
+                        self._generator.parameters(),
+                        retain_graph=True,
+                        allow_unused=True
+                    )
+                    torch.sqrt(sum((g.detach()**2).sum() for g in grads_wo if g is not None)).item()
+
+                    # (Optional) also see if inv_loss is connected at all
+                    assert inv_loss.requires_grad, "inv_loss is detached from the graph."
+                    # -----------------------------------------------------------------
+
+
+
+
+                self.optG.zero_grad(set_to_none=False)
+                loss_all.backward()
+                self.optG.step()
+
+
+            # --- metrics/logging from tensors ---
+            with torch.no_grad():
+                preds = T_logits.argmax(dim=1)
+                acc   = (preds == pseudo).float().mean().item()
+
+            row = dict(Epoch=epoch,
+                    **{"Generator Loss": loss_g.detach().cpu().item(),
+                        "Discriminator Loss": loss_d.detach().cpu().item(),
+                        "Inversion Loss": inv_loss.detach().cpu().item() if use_inv_loss else 0.0,
+                        "Conditioning Loss (CE)": ce_loss.detach().cpu().item() if c1 is not None else 0.0,
+                        "Accuracy": acc})
+            self.loss_values = pd.concat([self.loss_values, pd.DataFrame([row])], ignore_index=True)
+
+            if (epoch % 50 == 0):
+                tqdm.write(f"Gen {row['Generator Loss']:.2f} | Dis {row['Discriminator Loss']:.2f} | "
+                        f"Inv {row['Inversion Loss']:.2f} | CE {row['Conditioning Loss (CE)']:.2f} | "
+                        f"Acc {acc:.2f}")
+
+
+    def build_schema_and_params(self, transformer, device, weight_threshold=0.005):
+        import warnings
+
+        import numpy as np
+        import torch
+
+        def _find_bgm_model(host):
+            """Return an object that has sklearn-like attrs: means_, covariances_ or precisions_cholesky_, weights_."""
+            # direct hit?
+            for cand in (host, getattr(host, "_bgm_transformer", None)):
+                if cand is None:
+                    continue
+                # common inner names
+                for name in ("model", "_model", "bgm", "_bgm", "gmm", "_gmm"):
+                    m = getattr(cand, name, None)
+                    if m is not None and (
+                        hasattr(m, "means_") or hasattr(m, "covariances_") or hasattr(m, "precisions_cholesky_")
+                    ):
+                        return m
+                # sometimes the transformer itself is the sklearn model
+                if hasattr(cand, "means_") or hasattr(cand, "covariances_") or hasattr(cand, "precisions_cholesky_"):
+                    return cand
+            return None
+
+        def _get_valid_mask_from_attr(gm):
+            for name in ("valid_component_indicator", "_valid_component_indicator"):
+                if hasattr(gm, name):
+                    return np.asarray(getattr(gm, name), dtype=bool).reshape(-1)
+            return None
+
+        def _get_weights(gm):
+            m = _find_bgm_model(gm)
+            if m is None:
+                return None
+            for n in ("weights_", "_weights", "mixing_weights_"):
+                if hasattr(m, n):
+                    w = getattr(m, n)
+                    return np.asarray(w, dtype="float32").reshape(-1)
+            return None
+
+        def _extract_gmm_params(gm, expected_K=None):
+            """Return (means, stds) as float32 arrays, after applying either:
+            - gm.valid_component_indicator (if present), else
+            - weights_ > weight_threshold (if weights exist)
+            Finally, ensure the number of kept components matches expected_K (β dim).
+            """
+            means = stds = None
+
+            # Older RDT shallow attrs
+            for n in ("_means", "means_", "means"):
+                if hasattr(gm, n):
+                    means = getattr(gm, n)
+                    break
+            for n in ("_stds", "stds_", "stds"):
+                if hasattr(gm, n):
+                    stds = getattr(gm, n)
+                    break
+
+            # Newer: pull from inner BGMM/GMM
+            if means is None or stds is None:
+                m = _find_bgm_model(gm)
+                if m is not None:
+                    if hasattr(m, "means_"):
+                        means = np.asarray(m.means_).reshape(-1)
+                    if hasattr(m, "covariances_"):
+                        cov = np.asarray(m.covariances_)
+                        var = cov[:, 0, 0] if cov.ndim == 3 else cov.reshape(-1)
+                        stds = np.sqrt(var)
+                    elif hasattr(m, "precisions_cholesky_"):
+                        pc = np.asarray(m.precisions_cholesky_).reshape(-1)
+                        var = 1.0 / (pc ** 2)
+                        stds = np.sqrt(var)
+
+            if means is None or stds is None:
+                raise AttributeError(
+                    "Could not locate GMM means/stds on ClusterBasedNormalizer. "
+                    f"Available attrs on inner model: {sorted([a for a in dir(getattr(gm,'_bgm_transformer',gm)) if not a.startswith('__')])}"
+                )
+
+            means = np.asarray(means, dtype="float32").reshape(-1)
+            stds  = np.asarray(stds,  dtype="float32").reshape(-1)
+
+            # 1) Prefer explicit valid mask if present
+            valid = _get_valid_mask_from_attr(gm)
+            # 2) Else derive from weights_ and threshold (if weights exist)
+            if valid is None and weight_threshold is not None and weight_threshold > 0.0:
+                weights = _get_weights(gm)
+                if weights is not None:
+                    K = min(len(weights), len(means), len(stds))
+                    weights = weights[:K]; means = means[:K]; stds = stds[:K]
+                    valid = weights > float(weight_threshold)
+
+            # Apply mask if we have one
+            if valid is not None:
+                K = min(valid.size, means.size, stds.size)
+                valid = valid[:K]
+                means = means[:K][valid]
+                stds  = stds[:K][valid]
+
+            # Align to expected_K (the β softmax size from output_info_list)
+            if expected_K is not None:
+                if len(means) > expected_K:
+                    # Too many kept; keep the top-expected_K by weight if possible, else trim head
+                    weights = _get_weights(gm)
+                    if weights is not None and len(weights) >= len(means):
+                        # Build an index set of the currently kept comps
+                        if valid is not None:
+                            kept_idx = np.flatnonzero(valid[:len(weights)])
+                        else:
+                            kept_idx = np.arange(len(means))  # already trimmed to len(means)
+                        # sort kept by descending weight
+                        sub_w = weights[kept_idx]
+                        order = kept_idx[np.argsort(-sub_w)][:expected_K]
+                        means = means[order - kept_idx.min()] if kept_idx.min() != 0 else means[order]
+                        stds  = stds[ order - kept_idx.min()] if kept_idx.min() != 0 else stds[order]
+                    else:
+                        warnings.warn(
+                            f"Kept {len(means)} components but β span expects {expected_K}; trimming to first {expected_K}.", stacklevel=2
+                        )
+                        means = means[:expected_K]
+                        stds  = stds[:expected_K]
+                elif len(means) < expected_K:
+                    # Not enough kept; warn and fall back to using the top-weighted components to reach expected_K
+                    warnings.warn(
+                        f"Kept {len(means)} components but β span expects {expected_K}; "
+                        f"padding by selecting top-weighted components.", stacklevel=2
+                    )
+                    m = _find_bgm_model(gm)
+                    weights = _get_weights(gm)
+                    if (weights is not None) and (m is not None):
+                        # choose top expected_K overall, aligned with original order
+                        K_all = min(len(weights), len(getattr(m, "means_", means)))
+                        idx = np.argsort(-weights[:K_all])[:expected_K]
+                        all_means = np.asarray(getattr(m, "means_", means)).reshape(-1)[:K_all].astype("float32")
+                        if hasattr(m, "covariances_"):
+                            cov = np.asarray(m.covariances_)[:K_all]
+                            var = cov[:, 0, 0] if cov.ndim == 3 else cov.reshape(-1)
+                            all_stds = np.sqrt(var).astype("float32")
+                        else:
+                            all_stds = stds  # best effort
+                        means = all_means[idx]
+                        stds  = all_stds[idx]
+                    else:
+                        # last resort: tile last component
+                        means = np.pad(means, (0, expected_K - len(means)), mode="edge")
+                        stds  = np.pad(stds,  (0, expected_K - len(stds)),  mode="edge")
+
+            return means, stds
+
+        schema = []
+        st = 0
+        for info in transformer._column_transform_info_list:
+            dim = info.output_dimensions  # for continuous: 1 + K ; for categorical: #cats
+            entry = {"name": info.column_name, "type": info.column_type, "st": st, "dim": dim}
+            if info.column_type == "continuous":
+                gm = info.transform  # ClusterBasedNormalizer
+                # expected_K = size of β softmax block for this column
+                expected_K = dim - 1
+                mu_np, sigma_np = _extract_gmm_params(gm, expected_K=expected_K)
+                entry["mu"]         = torch.as_tensor(mu_np,    dtype=torch.float32, device=device)   # [K]
+                entry["sigma"]      = torch.as_tensor(sigma_np, dtype=torch.float32, device=device)   # [K]
+                entry["alpha_idx"]  = st
+                entry["beta_slice"] = slice(st + 1, st + dim)  # K-wide softmax block
+            else:
+                entry["onehot_slice"] = slice(st, st + dim)
+            schema.append(entry)
+            st += dim
+
+        # ensure pseudo_label exists
+        assert any(c["type"] == "discrete" and c["name"] == "pseudo_label" for c in schema), \
+            "pseudo_label span not found in transformer schema"
+
+        return schema
+
+
+
+
+    def _prepare_training(self, train_df, discrete_columns, num_classes):
+        assert train_df.columns[-1] == "pseudo_label"
+        self._transformer.fit(train_df, discrete_columns)
+
+        # schema with GMM params and span indices
+        self._schema = self.build_schema_and_params(self._transformer, self._device)
+
+        # (optional) cont scaler to match target training
+        cont_cols = [c for c in train_df.columns if c != "pseudo_label" and c not in discrete_columns]
+        self._cont_mean = torch.tensor(train_df[cont_cols].mean().to_numpy(), dtype=torch.float32, device=self._device)
+        self._cont_std  = torch.tensor(train_df[cont_cols].std(ddof=0).replace(0,1).to_numpy(), dtype=torch.float32, device=self._device)
+
+        mat = self._transformer.transform(train_df)  # ndarray
+        self._data_sampler = DataSampler(mat, self._transformer.output_info_list, self._log_frequency)
+        data_dim = self._transformer.output_dimensions
+
+        self._generator = Generator(self._embedding_dim + self._data_sampler.dim_cond_vec(),
+                                    self._generator_dim, data_dim).to(self._device)
+        self._discriminator = Discriminator(data_dim + self._data_sampler.dim_cond_vec(),
+                                            self._discriminator_dim, pac=self.pac).to(self._device)
+
+        self.optG = optim.Adam(self._generator.parameters(), lr=self._generator_lr, betas=(0.5, 0.9),
+                            weight_decay=self._generator_decay)
+        self.optD = optim.Adam(self._discriminator.parameters(), lr=self._discriminator_lr, betas=(0.5, 0.9),
+                            weight_decay=self._discriminator_decay)
+
+        self._z_mean = torch.zeros(self._batch_size, self._embedding_dim, device=self._device)
+        self._z_std  = self._z_mean + 1
+        self.num_classes = num_classes
+        return mat  # transformed train matrix
+
+    def _sample_batch(self, mat):
+        """Sample real and condition, prepare fakez (+cond), all on device."""
+        fakez = torch.normal(mean=self._z_mean, std=self._z_std)
+        condvec = self.sample_condvec(self._batch_size)
+        if condvec is None:
+            c1 = m1 = col = opt = None
+            real = self._data_sampler.sample_data(mat, self._batch_size, col, opt)
+            c2 = None
+        else:
+            c1, m1, col, opt = condvec
+            c1 = torch.from_numpy(c1).to(self._device)
+            m1 = torch.from_numpy(m1).to(self._device)
+            fakez = torch.cat([fakez, c1], dim=1)
+            perm = np.random.permutation(self._batch_size)
+            real = self._data_sampler.sample_data(mat, self._batch_size, col[perm], opt[perm])
+            c2 = c1[perm]
+        real = torch.from_numpy(real.astype("float32")).to(self._device)
+        return fakez, real, c1, m1, c2
+
+    def _d_step(self, fakeact, real, c1, c2):
+        """One discriminator update (WGAN-GP)."""
+        if c1 is not None:
+            fake_cat = torch.cat([fakeact, c1], dim=1)
+            real_cat = torch.cat([real,   c2], dim=1)
+        else:
+            fake_cat, real_cat = fakeact, real
+        y_fake = self._discriminator(fake_cat)
+        y_real = self._discriminator(real_cat)
+        pen = self._discriminator.calc_gradient_penalty(real_cat, fake_cat, self._device, self.pac)
+        loss_d = -(torch.mean(y_real) - torch.mean(y_fake))  # WGAN loss
+        self.optD.zero_grad(set_to_none=False)
+        pen.backward(retain_graph=True)
+        loss_d.backward()
+        self.optD.step()
+        return loss_d
+
+    def _atanh_clamped(self, a, eps=1e-6):
+        a = a.clamp(min=-1+eps, max=1-eps)
+        return 0.5 * (torch.log1p(a) - torch.log1p(-a))
+
+    def _invert_continuous_columns_torch(self, fakeact, scale=4.0):
+        xs = []
+        for col in self._schema:
+            if col["type"] != "continuous": continue
+            alpha = fakeact[:, col["alpha_idx"]:col["alpha_idx"]+1]
+            beta  = fakeact[:, col["beta_slice"]]
+            mu    = col["mu"].view(1, -1)
+            sigma = col["sigma"].view(1, -1)
+            # u     = self._atanh_clamped(alpha)
+            u     = torch.tanh(alpha)
+            x_k   = mu + scale * sigma * u
+            x     = (beta * x_k).sum(dim=1, keepdim=True)
+            xs.append(x)
+        return torch.cat(xs, dim=1) if xs else None
+
+    def _pack_for_gandalf(self, fakeact):
+        """Build pytorch-tabular inputs: continuous tensor, categorical indices, and pseudo labels."""
+        # pseudo_label from its one-hot
+        pl = next(c for c in self._schema if c["type"]=="discrete" and c["name"]=="pseudo_label")
+        pseudo = fakeact[:, pl["st"]:pl["st"]+pl["dim"]].argmax(dim=1).long()  # [B]
+
+        # continuous raw (optionally standardize to match target training)
+        x_cont = self._invert_continuous_columns_torch(fakeact, scale=4.0)
+        # if x_cont is not None and (getattr(self, "_cont_mean", None) is not None) and (getattr(self, "_cont_std", None) is not None):
+        #     x_cont = (x_cont - self._cont_mean) / (self._cont_std + 1e-6)
+
+        # categoricals as indices (excluding pseudo_label)
+        idxs = []
+        for col in self._schema:
+            if col["type"]=="discrete" and col["name"]!="pseudo_label":
+                idxs.append(fakeact[:, col["onehot_slice"]].argmax(dim=1))
+        x_cat = torch.stack(idxs, dim=1) if idxs else None
+        return x_cont, x_cat, pseudo
+
+    def forward_fakeact_with_labels(self, z: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """Differentiable forward:
+        - builds the correct one-hot condition vector for the pseudo_label column
+        - concatenates with z
+        - returns fakeact (after _apply_activate), still a torch tensor
+        Shapes:
+        z: [B, self._embedding_dim]   (or self.dim_z)
+        y: [B] long, class ids in [0, num_classes-1].
+        """
+        assert hasattr(self, "_data_sampler"), "Call _prepare_training(...) before using this."
+
+        device = self._device
+        y = y.view(-1).long().to(device)
+        B = y.size(0)
+
+        # Build cond one-hot in torch for the *last* discrete column (pseudo_label)
+        n_cats_total = int(self._data_sampler._n_categories)
+        cond = torch.zeros(B, n_cats_total, device=device)
+
+        # Start offset of the pseudo_label block inside the concatenated cond vector
+        pl_col_id = int(self._data_sampler._n_discrete_columns - 1)
+        start_idx = int(self._data_sampler._discrete_column_cond_st[pl_col_id])
+
+        idx = start_idx + y                       # [B] long
+        cond.scatter_(1, idx.view(-1, 1), 1.0)    # one-hot
+
+        # Concatenate noise + condition and run the generator
+        fakez = torch.cat([z, cond], dim=1)       # [B, embed + cond]
+        fake   = self._generator(fakez)
+        fakeact= self._apply_activate(fake)       # stays in torch (differentiable)
+
+        return fakeact, cond
+
+    # def _apply_activate(self, data):
+    #     """Apply proper activation function to the output of the generator."""
+    #     data_t = []
+    #     st = 0
+    #     for column_info in self._transformer.output_info_list:
+    #         for span_info in column_info:
+    #             if span_info.activation_fn == 'tanh':
+    #                 ed = st + span_info.dim
+    #                 data_t.append(torch.tanh(data[:, st:ed]))
+    #                 st = ed
+    #             elif span_info.activation_fn == 'softmax':
+    #                 ed = st + span_info.dim
+    #                 transformed = self._gumbel_softmax(data[:, st:ed], tau=0.2)
+    #                 data_t.append(transformed)
+    #                 st = ed
+    #             else:
+    #                 raise ValueError(f'Unexpected activation function {span_info.activation_fn}.')
+
+    #     return torch.cat(data_t, dim=1)
+
+    def _gumbel_softmax(self,logits, tau=1, hard=False, eps=1e-10, dim=-1):
+        """Deterministic when `seed` is provided; otherwise unchanged behavior."""
+        seed_attr = getattr(self, "gumbel_seed", None)
+        if seed_attr is not None:
+            # seeded path: sample Gumbel noise ourselves with a fixed generator
+            gen = torch.Generator(device=logits.device)
+            gen.manual_seed(int(seed_attr))
+            for _ in range(10):
+                U = torch.rand(logits.shape,generator=gen,device=logits.device,dtype=logits.dtype).clamp_(min=eps, max=1.0 - eps)
+                g = -torch.log(-torch.log(U))
+                y = torch.softmax((logits + g) / max(tau, eps), dim=dim)
+                if hard:
+                    idx = y.argmax(dim=dim, keepdim=True)
+                    y_hard = torch.zeros_like(y).scatter_(dim, idx, 1.0)
+                    y = y_hard - y.detach() + y
+                if not torch.isnan(y).any():
+                    return y
+            raise ValueError("gumbel_softmax returning NaN (seeded).")
+
+        # original path (non-deterministic unless you set global seeds)
+        for _ in range(10):
+            transformed = torch.nn.functional.gumbel_softmax(logits, tau=tau, hard=hard, eps=eps, dim=dim)
+            if not torch.isnan(transformed).any():
+                return transformed
+
+        raise ValueError("gumbel_softmax returning NaN.")

--- a/leakpro/attacks/minv_attacks/mcr.py
+++ b/leakpro/attacks/minv_attacks/mcr.py
@@ -1,0 +1,159 @@
+"""Membership-Calibrated Reconstruction (MCR) attack on tabular data.
+
+Reconstructs training records from a target model by searching a conditional
+generator's latent space, where the search is narrowed at two levels:
+
+    L1 (class)      - pseudo-label conditioning (idea borrowed from PLG-MI)
+    L2 (individual) - known-feature constraint (sensitive mode) OR
+                      sparse sub-cluster targeting (outlier mode)
+
+The L1 <-> L2 balance is arbitrated *inside the objective* by a membership-
+inference calibration signal (RMIA-style population of reference models), so the
+search pulls toward individual-specific features only where the target model
+actually memorized.
+
+Design doc: plans/tabular-reconstruction-attack-design.md (in the workspace repo)
+
+Status: STUB. Interface + structure only; method bodies are not implemented.
+"""
+from typing import Any, Dict, Optional
+
+import torch
+from pydantic import BaseModel, Field
+
+from leakpro.attacks.minv_attacks.abstract_minv import AbstractMINV
+from leakpro.input_handler.minv_handler import MINVHandler
+from leakpro.reporting.minva_result import MinvResult
+from leakpro.utils.import_helper import Self
+from leakpro.utils.logger import logger
+
+
+class AttackMCR(AbstractMINV):
+    """Membership-Calibrated Reconstruction attack (tabular, white-box)."""
+
+    class AttackConfig(BaseModel):
+        """Configuration for the MCR attack."""
+
+        # --- General ---
+        batch_size: int = Field(32, ge=1, description="Batch size for training/evaluation")
+        mode: str = Field("sensitive", description="Reconstruction mode: 'sensitive' or 'outlier'")
+
+        # --- L1: pseudo-labeling (search-space restriction by class) ---
+        top_n: int = Field(10, ge=1, description="Pseudo-labels selected per class")
+
+        # --- Latent search ---
+        dim_z: int = Field(32, ge=1, description="Latent dimension (tabular: likely << image default of 128)")
+        z_optimization_iter: int = Field(1000, ge=1, description="Iterations for latent optimization")
+        z_optimization_lr: float = Field(2e-4, ge=0.0, description="Learning rate for latent optimization")
+
+        # --- L2: individual restriction ---
+        lambda_known: float = Field(1.0, ge=0.0, description="Weight on the known-feature (x_k) constraint (sensitive mode)")
+
+        # --- MIA calibration (reference-model population) ---
+        n_reference_models: int = Field(64, ge=1, description="Reference models for RMIA-style calibration")
+
+        # --- Generator ---
+        generator: Dict[str, Any] = Field(default_factory=dict, description="Generator (CustomCTGAN) configuration")
+
+    def __init__(self: Self, handler: MINVHandler, configs: dict) -> None:
+        """Initialize the MCR attack."""
+        logger.info("Configuring MCR attack")
+        self.configs = self.AttackConfig() if configs is None else self.AttackConfig(**configs)
+        super().__init__(handler)
+        for key, value in self.configs.model_dump().items():
+            setattr(self, key, value)
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        # TODO: self.num_classes = self.handler.get_num_classes()
+
+    def description(self: Self) -> dict:
+        """Return a description of the attack."""
+        return {
+            "title_str": "Membership-Calibrated Reconstruction (MCR)",
+            "reference": "Design doc: plans/tabular-reconstruction-attack-design.md",
+            "summary": "Tabular data reconstruction via two-level latent search "
+                       "(pseudo-label class restriction + individual restriction) "
+                       "calibrated by membership-inference statistics.",
+            "detailed": "White-box reconstruction attack. Trains a conditional generator on "
+                        "pseudo-labeled public data (L1), then searches the latent space for "
+                        "records the target model memorized (L2), using an RMIA-style membership "
+                        "likelihood ratio as the in-loop arbiter and targeting signal. Two modes: "
+                        "sensitive-attribute reconstruction (known x_k given) and outlier reconstruction.",
+        }
+
+    # ------------------------------------------------------------------ #
+    # L1: pseudo-labeling                                                 #
+    # ------------------------------------------------------------------ #
+    def pseudo_label_selection(self: Self) -> None:
+        """L1 restriction: top-n pseudo-label selection on public data via the target model."""
+        raise NotImplementedError("TODO: port + clean top_n_selection from the old plgmi.py")
+
+    # ------------------------------------------------------------------ #
+    # MIA bridge: reference-model population + calibrated membership      #
+    # ------------------------------------------------------------------ #
+    def build_reference_population(self: Self) -> None:
+        """Train/load the reference-model population for RMIA-style calibration.
+
+        Cheap for tabular (models are small) - this is the 'tabular is the right
+        place for this' argument.
+        """
+        raise NotImplementedError("TODO: wire to main's RMIA / shadow_model_handler")
+
+    def membership_score(self: Self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """Calibrated membership likelihood ratio Lambda(x) (RMIA population variant).
+
+        Used both as the per-target L1<->L2 throttle and as the outlier targeting signal.
+        """
+        raise NotImplementedError("TODO: RMIA-style population likelihood ratio")
+
+    # ------------------------------------------------------------------ #
+    # Attack lifecycle                                                    #
+    # ------------------------------------------------------------------ #
+    def prepare_attack(self: Self) -> None:
+        """Train the conditional generator (CustomCTGAN) and reference population."""
+        raise NotImplementedError("TODO: pseudo-labeling -> train CustomCTGAN -> build reference population")
+
+    def run_attack(self: Self) -> MinvResult:
+        """Run reconstruction in the configured mode and return results."""
+        if self.mode == "sensitive":
+            return self._run_sensitive_mode()
+        if self.mode == "outlier":
+            return self._run_outlier_mode()
+        raise ValueError(f"Unknown mode: {self.mode}")
+
+    # ------------------------------------------------------------------ #
+    # L2 mode A: sensitive-attribute reconstruction                      #
+    # ------------------------------------------------------------------ #
+    def _run_sensitive_mode(self: Self) -> MinvResult:
+        """Recover x_s for known members given x_k.
+
+        argmin_z  -log Lambda(G(z,c))  +  lambda_known * || Pi_k(G(z,c)) - x_k ||^2
+        then read off  x_s = Pi_s(G(z*, c)).
+        """
+        raise NotImplementedError("TODO: constrained latent search (see Exp 1 for the reachability core)")
+
+    # ------------------------------------------------------------------ #
+    # L2 mode B: outlier reconstruction                                  #
+    # ------------------------------------------------------------------ #
+    def _run_outlier_mode(self: Self) -> MinvResult:
+        """Recover atypical / highly-memorized members.
+
+        argmin_z  -log Lambda(G(z,c)),  restricted to sparse sub-clusters.
+        """
+        raise NotImplementedError("TODO: membership-ranked latent search over sparse clusters")
+
+    # ------------------------------------------------------------------ #
+    # Shared: latent search primitive                                     #
+    # ------------------------------------------------------------------ #
+    def optimize_z(
+        self: Self,
+        y: torch.Tensor,
+        x_k: Optional[torch.Tensor] = None,
+        iter_times: int = 1000,
+    ) -> torch.Tensor:
+        """White-box latent optimization through the differentiable CTGAN path.
+
+        Uses generator.forward_fakeact_with_labels + generator._pack_for_gandalf so
+        gradients flow from the target model back to z. When x_k is given, adds the
+        L2 known-feature constraint.
+        """
+        raise NotImplementedError("TODO: implement; Exp 1 prototypes the x_k-constraint core")


### PR DESCRIPTION
  Branch off main for the membership-calibrated tabular data reconstruction
  attack (diverged from PLG-MI). Adds:
  - mcr.py: clean AttackMINV stub (two-level L1/L2 search, MIA-calibrated arbiter, sensitive + outlier modes)
  - ported CustomCTGAN (self-contained white-box differentiable path)
  - Exp-1 x_k-reachability validation script (sensitive-mode go/no-go)

# Description

Summary of changes

* ... 
* ...

## Resolved Issues

- [ ] fixes #Issue

## How Has This Been Tested?

## Related Pull Requests

- #PR
