### PR TITLE
fix: RMIA, BASE, and loss_trajectory attacks crash on single-logit (binary) models

### DIFF
--- a/leakpro/attacks/mia_attacks/base.py
+++ b/leakpro/attacks/mia_attacks/base.py
@@ -6,14 +6,12 @@
 
 import numpy as np
 from pydantic import BaseModel, Field
-from scipy.special import (
-    log_softmax,
-    logsumexp,
-)
+from scipy.special import logsumexp
 from tqdm import tqdm
 
 from leakpro.attacks.mia_attacks.abstract_mia import AbstractMIA
 from leakpro.attacks.utils.shadow_model_handler import ShadowModelHandler
+from leakpro.attacks.utils.utils import softmax_logits
 from leakpro.input_handler.abstract_input_handler import AbstractInputHandler
 from leakpro.reporting.mia_result import MIAResult
 from leakpro.signals.signal import ModelLogits
@@ -84,6 +82,19 @@ class AttackBASE(AbstractMIA):
             "detailed": detailed_str,
         }
 
+    def _log_conf(self:Self, logits: np.ndarray, ground_truth_indices: np.ndarray) -> np.ndarray:
+        """Log-confidence of the correct class, for either multi-class or single-logit (binary) logits.
+
+        Raw logits can't be fed straight into scipy's log_softmax when the model has a single
+        output unit (binary classification): log_softmax over one column is always 0, and indexing
+        with a ground-truth label of 1 raises an IndexError. softmax_logits() already knows how to
+        expand a single logit into [1-p, p] via sigmoid before applying temperature scaling, so we
+        reuse it here (same helper RMIA uses) and take the log ourselves.
+        """
+        n_points = logits.shape[0]
+        probs = softmax_logits(logits, self.temperature)
+        return np.log(probs + self.epsilon)[np.arange(n_points), ground_truth_indices]
+
     def prepare_attack(self:Self) -> None:
         """Prepare data needed for running the attack on the target model and dataset.
 
@@ -124,13 +135,13 @@ class AttackBASE(AbstractMIA):
         ground_truth_indices = dataloader.dataset.targets.numpy()
         assert n_points == len(ground_truth_indices), "Number of points and labels must be the same"
         logger.info(f"Scoring {n_points} points with BASE attack")
-        logits_target = np.array(ModelLogits()([self.target_model], None, None, dataloader)).squeeze()
-        log_conf_target = log_softmax(logits_target / self.temperature, axis=-1)[np.arange(n_points), ground_truth_indices]
+        logits_target = np.array(ModelLogits()([self.target_model], None, None, dataloader)).squeeze(axis=0)
+        log_conf_target = self._log_conf(logits_target, ground_truth_indices)
         # run points through shadow models and collect the log confidence values
         logits_sm = []
         for m in tqdm(self.shadow_models, desc="Scoring with shadow models"):
-            logits_sm.append( np.array(ModelLogits()([m], self.handler, None, dataloader)).squeeze() )
-        log_conf_shadow_models = np.array([log_softmax(x / self.temperature, axis=-1)[np.arange(n_points), ground_truth_indices] for x in logits_sm])  # noqa: E501
+            logits_sm.append( np.array(ModelLogits()([m], self.handler, None, dataloader)).squeeze(axis=0) )
+        log_conf_shadow_models = np.array([self._log_conf(x, ground_truth_indices) for x in logits_sm])
 
         if self.online is True:
             threshold = logsumexp(log_conf_shadow_models, axis=0) - np.log(self.num_shadow_models)
@@ -166,17 +177,16 @@ class AttackBASE(AbstractMIA):
 
         # Load the logits for the target model and shadow models
         ground_truth_indices = self.handler.get_labels(self.audit_dataset["data"])
-        n_audit_points = len(self.audit_dataset["data"])
         logits_target = ShadowModelHandler().load_logits(name=f"target_{ShadowModelHandler().target_model_hash}")
         logits_shadow_models = []
         for indx in self.shadow_model_indices:
             logits_shadow_models.append(ShadowModelHandler().load_logits(indx=indx))
 
         # collect the log confidence output of the correct class (which is the negative cross-entropy loss)
-        log_conf_target = log_softmax(logits_target / self.temperature, axis=-1)[np.arange(n_audit_points),ground_truth_indices]
+        log_conf_target = self._log_conf(logits_target, ground_truth_indices)
 
         # run points through shadow models and collect the log confidence values
-        log_conf_shadow_models = np.array([log_softmax(x / self.temperature, axis=-1)[np.arange(n_audit_points),ground_truth_indices] for x in logits_shadow_models])  # noqa: E501
+        log_conf_shadow_models = np.array([self._log_conf(x, ground_truth_indices) for x in logits_shadow_models])
 
         if self.online is True:
             threshold = logsumexp(log_conf_shadow_models, axis=0) - np.log(self.num_shadow_models)

--- a/leakpro/attacks/mia_attacks/loss_trajectory.py
+++ b/leakpro/attacks/mia_attacks/loss_trajectory.py
@@ -248,6 +248,12 @@ class AttackLossTrajectory(AbstractMIA):
             # Calculate the losses for the distilled student models
             #---------------------------------------------------------------------
             criterion = DistillationModelHandler().get_criterion()
+            # BCEWithLogitsLoss (single-logit/binary models) requires a float target of the same
+            # dtype as the model output; CrossEntropyLoss requires the original Long class index.
+            # `target` comes out of the dataloader as Long, so cast only in the binary case —
+            # otherwise BCE raises "result type Float can't be cast to the desired output type Long".
+            is_binary_criterion = isinstance(criterion, nn.BCEWithLogitsLoss)
+            target_for_loss = target.float() if is_binary_criterion else target
             trajectory_current = np.array([])
             for d in range(self.number_of_traj) :
                 distill_model[d].to(gpu_or_cpu)
@@ -258,7 +264,7 @@ class AttackLossTrajectory(AbstractMIA):
 
                 # Calculate the loss
                 loss = []
-                for logit_target_i, target_i in zip(distill_model_soft_output, target):
+                for logit_target_i, target_i in zip(distill_model_soft_output, target_for_loss):
                     loss_i = criterion(logit_target_i, target_i)
                     loss.append(loss_i)
                 loss = np.array([loss_i.detach().cpu().numpy() for loss_i in loss]).reshape(-1, 1)
@@ -271,7 +277,7 @@ class AttackLossTrajectory(AbstractMIA):
             batch_logit_target = teacher_model(data).squeeze() # TODO: replace with hopskipjump for label only
             batch_loss_teacher = []
 
-            for (batch_logit_target_i, target_i) in zip(batch_logit_target, target):
+            for (batch_logit_target_i, target_i) in zip(batch_logit_target, target_for_loss):
                 loss = criterion(batch_logit_target_i, target_i)
                 batch_loss_teacher.append(loss)
             batch_loss_teacher = np.array([batch_loss_teacher_i.cpu().detach().numpy() for batch_loss_teacher_i in

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -135,12 +135,17 @@ class AttackRMIA(AbstractMIA):
         if (~cached_mask).any():
             # Shadow models are already PytorchModel wrappers; target model is a raw nn.Module.
             model_wrapped = model if isinstance(model, PytorchModel) else PytorchModel(model, self.handler.get_criterion())
+            # squeeze(axis=0) drops only the single-model axis ModelLogits() always adds.
+            # A bare .squeeze() also collapses the num_classes axis for single-logit (binary)
+            # models, turning (n_uncached, 1) into (n_uncached,) and making np.atleast_2d
+            # reshape it to (1, n_uncached) instead of (n_uncached, 1) — the shape mismatch
+            # the reviewer hit on binary/tabular models.
             unc = np.array(ModelLogits()(
                 [model_wrapped],
                 self.handler,
                 z_indices[~cached_mask],
-            )).squeeze()
-            logits[~cached_mask] = np.atleast_2d(unc)
+            )).squeeze(axis=0)
+            logits[~cached_mask] = unc
 
         return logits
 


### PR DESCRIPTION
# Description

Fixes three pre-existing bugs in `AttackRMIA`, `AttackBASE`, and `AttackLossTrajectory` that crash when the target model has a single-logit (binary) output instead of a multi-class one. Split out of #423, where these were surfaced during review of the tabular/LoS webapp support — but the bugs themselves are independent of the webapp and already exist on `main`.

* **RMIA** — `_get_z_logits()`'s on-the-fly logit path used a bare `.squeeze()`, which collapses the num_classes axis along with the num_models axis when both are size 1. Fixed to `.squeeze(axis=0)`, matching the convention already used by `cache_logits()` elsewhere.
* **BASE** — `run_attack()`/`score_samples()` indexed raw logits assuming a column per class; a single-logit model has only column 0, so indexing label `1` raised `IndexError`. Fixed by routing through the existing `softmax_logits()` helper (same one RMIA already uses), which sigmoid-expands single-logit output before any indexing.
* **loss_trajectory** — `_prepare_mia_data()` fed Long-dtype labels into `BCEWithLogitsLoss`, which requires float targets. Fixed to cast based on the actual criterion in use (`isinstance(criterion, nn.BCEWithLogitsLoss)`), leaving `CrossEntropyLoss`'s Long requirement untouched.

None of these are regressions from binary support being added — they're old code paths (RMIA's on-the-fly branch was added in a recent, separate correctness fix; BASE and loss_trajectory's LOS-audit configs never even included those attacks before) that had simply never been exercised against a single-logit model until now.

## How Has This Been Tested?

* Full `leakpro/tests/mia_attacks/` suite: 47/47 pass, unchanged from `main` — confirms no regression to the existing multi-class path.
* Root-caused each crash against the actual tracebacks reported in #423's review (RMIA shape mismatch, BASE `IndexError`, loss_trajectory `RuntimeError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)