### PR TITLE
fix: distill label-only loss trajectory on teacher labels, not ground truth

### DIFF
--- a/leakpro/attacks/utils/distillation_model_handler.py
+++ b/leakpro/attacks/utils/distillation_model_handler.py
@@ -10,7 +10,7 @@ import pickle
 import numpy as np
 import torch.nn.functional as F  # noqa: N812
 from torch import cat, cuda, device, save, sigmoid
-from torch.nn import CrossEntropyLoss, KLDivLoss, Module
+from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, KLDivLoss, Module
 from tqdm import tqdm
 
 from leakpro.attacks.utils.model_handler import ModelHandler
@@ -117,12 +117,12 @@ class DistillationModelHandler(ModelHandler):
         for d in range(num_trajectory_epochs):
             epoch_loss = 0
 
-            # Loop over the training set
-            for data, target_labels in tqdm(data_loader, desc=f"Epoch {d+1}/{num_trajectory_epochs}"):
+            # Loop over the training set. Ground-truth labels are deliberately unused:
+            # the student must only learn from the teacher, in both distillation modes.
+            for data, _ in tqdm(data_loader, desc=f"Epoch {d+1}/{num_trajectory_epochs}"):
 
                 # Move data to the device
                 data = data.to(gpu_or_cpu, non_blocking=True)
-                target_labels = target_labels.to(gpu_or_cpu, non_blocking=True)
 
                 # Output of the distillation model
                 output_student = student_model(data)
@@ -142,7 +142,13 @@ class DistillationModelHandler(ModelHandler):
 
                 # TODO: add hopskipjump distance here
                 if label_only:
-                    loss = CrossEntropyLoss()(output_student, target_labels) # TODO: I think this is wrong (teacher?)
+                    # Label-only mode: distill on the teacher's predicted (hard) labels.
+                    if output_teacher.shape[1] == 1:
+                        teacher_labels = (output_teacher.detach() > 0).float()
+                        loss = BCEWithLogitsLoss()(output_student, teacher_labels)
+                    else:
+                        teacher_labels = output_teacher.detach().argmax(dim=1)
+                        loss = CrossEntropyLoss()(output_student, teacher_labels)
                 else:
                     loss = KLDivLoss(reduction="batchmean")(student_signal, teacher_signal)
                 optimizer.zero_grad(set_to_none=True)

--- a/leakpro/tests/mia_attacks/utils/test_distillation_model_handler.py
+++ b/leakpro/tests/mia_attacks/utils/test_distillation_model_handler.py
@@ -1,0 +1,89 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Test the distillation model handler module."""
+
+import numpy as np
+import torch
+from dotmap import DotMap
+from torch import Tensor, nn
+
+from leakpro.attacks.utils.distillation_model_handler import DistillationModelHandler
+from leakpro.tests.input_handler.image_input_handler import ImageInputHandler
+from leakpro.tests.input_handler.tabular_input_handler import TabularInputHandler
+
+# The target's optimizer (lr=0.001) is too slow to converge within a test budget,
+# so the distillation student gets its own optimizer config.
+DISTILLATION_CONFIG = DotMap({"optimizer": {"name": "sgd", "params": {"lr": 0.1, "momentum": 0.9}}})
+
+
+class ConstantTeacher(nn.Module):
+    """Teacher that predicts the same class for every input, regardless of the true label."""
+
+    def __init__(self, num_outputs: int, constant_class: int) -> None:
+        super().__init__()
+        self.num_outputs = num_outputs
+        self.constant_class = constant_class
+        # Unused parameter so optimizers/device moves treat this as a normal model
+        self._dummy = nn.Parameter(torch.zeros(1), requires_grad=False)
+
+    def forward(self, x: Tensor) -> Tensor:  # noqa: D102
+        logits = torch.full((x.shape[0], self.num_outputs), -5.0, device=x.device)
+        if self.num_outputs == 1:
+            # Single-logit binary model: constant_class 1 -> positive logit
+            logits[:, 0] = 5.0 if self.constant_class == 1 else -5.0
+        else:
+            logits[:, self.constant_class] = 5.0
+        return logits
+
+
+def _student_predictions(student: nn.Module, handler: ImageInputHandler, indices: np.ndarray) -> np.ndarray:
+    student = student.cpu()
+    student.eval()
+    data_loader = handler.get_dataloader(indices, batch_size=64)
+    preds = []
+    with torch.no_grad():
+        for data, _ in data_loader:
+            output = student(data)
+            if output.shape[1] == 1:
+                preds.append((output[:, 0] > 0).long().numpy())
+            else:
+                preds.append(output.argmax(dim=1).numpy())
+    return np.concatenate(preds)
+
+
+def test_label_only_distillation_follows_teacher_not_ground_truth(image_handler: ImageInputHandler) -> None:
+    """Label-only distillation must learn the teacher's predicted labels, not the dataset labels."""
+    image_handler.configs.distillation_model = DISTILLATION_CONFIG
+    dm = DistillationModelHandler(image_handler)
+
+    constant_class = 3
+    teacher = ConstantTeacher(num_outputs=12, constant_class=constant_class)
+    dm.add_student_teacher_pair("label_only_multiclass", teacher)
+
+    indices = np.array(image_handler.test_indices)
+    checkpoints = dm.distill_model("label_only_multiclass", 20, indices, label_only=True)
+    assert len(checkpoints) == 20
+
+    preds = _student_predictions(checkpoints[-1], image_handler, indices)
+    teacher_match = np.mean(preds == constant_class)
+
+    # The fixture spreads ground-truth labels over 12 classes, so a student that
+    # (incorrectly) distills on ground truth cannot collapse onto the teacher's class.
+    assert teacher_match >= 0.8
+
+
+def test_label_only_distillation_binary_follows_teacher(tabular_handler: TabularInputHandler) -> None:
+    """Label-only distillation on a single-logit model must use the teacher's hard labels."""
+    tabular_handler.configs.distillation_model = DISTILLATION_CONFIG
+    dm = DistillationModelHandler(tabular_handler)
+
+    teacher = ConstantTeacher(num_outputs=1, constant_class=1)
+    dm.add_student_teacher_pair("label_only_binary", teacher)
+
+    indices = np.array(tabular_handler.test_indices)
+    checkpoints = dm.distill_model("label_only_binary", 20, indices, label_only=True)
+
+    preds = _student_predictions(checkpoints[-1], tabular_handler, indices)
+    assert np.mean(preds == 1) >= 0.8


### PR DESCRIPTION
Closes #146.

## Problem

In label-only mode, the distillation student was trained with `CrossEntropyLoss` against the dataset's **ground-truth labels** (`distillation_model_handler.py`), so the distilled trajectory tracked the data rather than the teacher model being attacked. The `# TODO: I think this is wrong (teacher?)` on that line already suspected this.

## Fix

- Label-only distillation now targets the **teacher's predicted hard labels**: `argmax` of the teacher logits for multiclass, sign of the logit with `BCEWithLogitsLoss` for single-logit binary models (consistent with the binary handling added in #434).
- Ground-truth labels no longer enter distillation in either mode (the KL mode never used them).

## Tests

New `test_distillation_model_handler.py` distills a student from a constant-prediction teacher and asserts the student collapses onto the teacher's class instead of the dataset labels — for both the multiclass and single-logit paths. Both tests fail on the old code. `test_all_attacks_end_to_end.py -k loss_traj` passes.

Note: #76 (estimating the true class logit via HopSkipJump) is a further improvement on top of this and stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4j7ifPMD8R2Mgd7om97F2