### PR TITLE
Add a leakage risk assessment model, replacing the AUC risk bands

### DIFF
--- a/examples/mia/cifar/audit.yaml
+++ b/examples/mia/cifar/audit.yaml
@@ -65,3 +65,45 @@ target:
 shadow_model:
 
 distillation_model:
+
+# Optional. Declares the deployment context so `leakpro.risk.assess_risk` can turn measured attack
+# success into a risk statement. Omitting the block changes nothing: the audit runs as before and
+# `leakpro.use_case_profile` is simply None. Declaring it does NOT run an assessment either — that is
+# an explicit call after run_audit, see the notebook.
+#
+# Factor names follow the Loss Magnitude decomposition of Sion et al. (IWPE 2019),
+# LM = DTS x NR x DST x NDS. LeakPro measures the Vulnerability term; you supply the rest.
+use_case:
+  # Operating point: the false-positive rate the attacker is assumed to tolerate. Required, no
+  # default. Keep 0.01 unless you have a reason to go lower — a stricter FPR needs a larger audit
+  # set to be measurable at all (you need at least 1/alpha non-members).
+  tolerated_fpr: 0.01
+
+  # pi: share of the attacker's candidate pool that really are members. 0.5 is the balanced-audit
+  # assumption behind every TPR and AUC LeakPro reports, and it overstates precision badly for
+  # realistic pools. Declare what your threat model actually implies.
+  attacker_prior: 0.01
+
+  # NDS: data subjects in the training population. Commented out here so the assessment falls back
+  # to the target's num_train. Set it when subjects and training records are not the same thing.
+  # n_subjects: 50000
+
+  # NR: records of this data type per subject. Fractions are allowed.
+  records_per_subject: 1.0
+
+  # DTS: sensitivity of the leaked data type, on a scale you choose. 1.0 is neutral. The CNIL PIA
+  # severity levels are a defensible starting point: 1 negligible, 2 limited, 3 significant,
+  # 4 maximum. CIFAR-10 is public benchmark data, so 1.0 is honest here.
+  data_type_sensitivity: 1.0
+
+  # DST: weight for the data subject type. Raise it for vulnerable subjects such as minors.
+  subject_type_weight: 1.0
+
+  # Optional. Left unset, no monetary figure is reported at all, rather than a fabricated one.
+  # cost_per_exposed_subject: 250.0
+
+  # Scale the exposed-record count from the audit set up to the training population. Off by default:
+  # per-record vulnerability is strongly non-uniform, so it is an estimate, not a measurement.
+  extrapolate_to_population: false
+
+  notes: "CIFAR-10 benchmark run. Public data, so sensitivity is neutral."

--- a/examples/mia/cifar/cifar_main.ipynb
+++ b/examples/mia/cifar/cifar_main.ipynb
@@ -246,6 +246,46 @@
     "\n",
     "mia_results = leakpro.run_audit(create_pdf=True)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Risk assessment\n",
+    "\n",
+    "The audit measures how often an attack succeeds. Turning that into a risk statement needs one\n",
+    "thing LeakPro cannot observe: how much a success would cost the people in the training data.\n",
+    "\n",
+    "`assess_risk` is a separate call on purpose. `run_audit` is expensive; re-assessing under a\n",
+    "different operating point or attacker prior is nearly free, and those are exactly the parameters\n",
+    "you want to vary. The profile below comes from the `use_case:` block in `audit.yaml`, but you can\n",
+    "build a `UseCaseProfile(...)` in Python instead.\n",
+    "\n",
+    "Every figure in the output is either measured (from this audit) or declared (by you). The\n",
+    "`assumptions` list names the assumption behind each derived number, including the two inherited\n",
+    "from the published model: a single attack attempt, and independence of the harm factors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from leakpro.risk import UseCaseProfile, assess_risk, to_markdown\n",
+    "\n",
+    "# Declared in audit.yaml under `use_case:`. Or build one here:\n",
+    "#   profile = UseCaseProfile(tolerated_fpr=0.01, attacker_prior=0.01, data_type_sensitivity=3.0)\n",
+    "profile = leakpro.use_case_profile\n",
+    "\n",
+    "assessment = assess_risk(\n",
+    "    mia_results,\n",
+    "    profile,\n",
+    "    num_train=leakpro.handler.target_model_metadata.num_train,\n",
+    ")\n",
+    "assessment.save(f\"{leakpro.report_dir}/risk_assessment.json\")\n",
+    "print(to_markdown(assessment))"
+   ]
   }
  ],
  "metadata": {

--- a/leakpro/leakpro.py
+++ b/leakpro/leakpro.py
@@ -59,6 +59,10 @@ class LeakPro:
         except FileNotFoundError as e:
             raise FileNotFoundError(f"File {configs_path} not found") from e
 
+        # Deployment context for risk assessment, when declared in the config. Nothing is computed
+        # here: pass it to leakpro.risk.assess_risk together with the results of run_audit().
+        self.use_case_profile = configs.use_case
+
         # Create report directory
         self.report_dir = f"{configs.audit.output_dir}/results"
         Path(self.report_dir).mkdir(parents=True, exist_ok=True)

--- a/leakpro/reporting/report_handler.py
+++ b/leakpro/reporting/report_handler.py
@@ -8,10 +8,12 @@ import subprocess
 
 from leakpro.metrics.attack_result import GIAResults
 from leakpro.reporting.mia_result import MIAResult
+from leakpro.risk.render import to_latex
+from leakpro.risk.schemas import RiskAssessment
 from leakpro.synthetic_data_attacks.inference_utils import InferenceResults
 from leakpro.synthetic_data_attacks.linkability_utils import LinkabilityResults
 from leakpro.synthetic_data_attacks.singling_out_utils import SinglingOutResults
-from leakpro.utils.import_helper import Self, Union
+from leakpro.utils.import_helper import Optional, Self, Union
 from leakpro.utils.logger import logger
 
 ResultList = Union[list[MIAResult],
@@ -25,11 +27,17 @@ ResultList = Union[list[MIAResult],
 class ReportHandler():
     """Implementation of the report handler."""
 
-    def __init__(self:Self, results:ResultList, report_dir: str) -> None:
+    def __init__(self:Self, results:ResultList, report_dir: str,
+                 risk_assessment: Optional[RiskAssessment] = None) -> None:
         logger.info("Initializing report handler...")
 
         self.report_dir = report_dir
         logger.info(f"report_dir set to: {self.report_dir}")
+
+        # Optional use-case risk assessment, produced by leakpro.risk.assess_risk. run_audit builds
+        # its own ReportHandler and knows nothing about risk, so this is only populated when the
+        # caller constructs the handler directly.
+        self.risk_assessment = risk_assessment
 
         self.pdf_results = {}
         self.leakpro_types = {"MIAResult" : MIAResult,
@@ -81,6 +89,10 @@ class ReportHandler():
 
         # Create initial part of the document.
         self._init_pdf()
+
+        # Risk assessment first: it frames the attack results that follow.
+        if self.risk_assessment is not None:
+            self.latex_content += to_latex(self.risk_assessment)
 
         # Append all results to the document
         for result_type in self.leakpro_types:

--- a/leakpro/risk/__init__.py
+++ b/leakpro/risk/__init__.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Leakage risk assessment: from measured attack success to a use-case risk statement.
+
+The audit measures how well an attack succeeds. Turning that into risk needs one thing LeakPro cannot
+observe: how bad a successful attack would be for the people in the training data. This package keeps
+those two halves visibly separate and combines them without inventing weights.
+
+Usage::
+
+    from leakpro import LeakPro
+    from leakpro.risk import UseCaseProfile, assess_risk
+
+    leakpro = LeakPro(MyHandler, "audit.yaml")
+    results = leakpro.run_audit()
+
+    profile = UseCaseProfile(tolerated_fpr=0.01, attacker_prior=0.01, data_type_sensitivity=3.0)
+    assessment = assess_risk(results, profile, num_train=leakpro.handler.target_model_metadata.num_train)
+    assessment.save(f"{leakpro.report_dir}/risk_assessment.json")
+
+A profile declared in ``audit.yaml`` under a top-level ``use_case:`` block is available as
+``leakpro.use_case_profile``. Assessment is always an explicit call: ``run_audit`` neither computes
+nor writes it.
+
+Version 1 covers membership inference only. Model inversion, gradient inversion and synthetic data
+each need their own definition of attack success before they can produce a
+:class:`~leakpro.risk.schemas.VulnerabilityMeasurement`.
+"""
+
+from leakpro.risk.assessment import assess_risk, loss_magnitude, positive_predictive_value
+from leakpro.risk.policy import (
+    POLICY_VERSION,
+    SUGGESTED_SENSITIVITY_SCALE,
+    VULNERABILITY_BANDS,
+    resolve_vulnerability_band,
+)
+from leakpro.risk.render import to_latex, to_markdown
+from leakpro.risk.schemas import (
+    CombinedRisk,
+    DeclaredInputs,
+    MiaVulnerability,
+    RiskAssessment,
+    UseCaseProfile,
+    VulnerabilityMeasurement,
+)
+from leakpro.risk.vulnerability import (
+    InvertedResultError,
+    NoUsableResultError,
+    UnresolvableOperatingPointError,
+    measure_mia,
+    result_from_mapping,
+    strongest_for_risk,
+)
+
+__all__ = [
+    "POLICY_VERSION",
+    "SUGGESTED_SENSITIVITY_SCALE",
+    "VULNERABILITY_BANDS",
+    "CombinedRisk",
+    "DeclaredInputs",
+    "InvertedResultError",
+    "MiaVulnerability",
+    "NoUsableResultError",
+    "RiskAssessment",
+    "UnresolvableOperatingPointError",
+    "UseCaseProfile",
+    "VulnerabilityMeasurement",
+    "assess_risk",
+    "loss_magnitude",
+    "measure_mia",
+    "positive_predictive_value",
+    "resolve_vulnerability_band",
+    "result_from_mapping",
+    "strongest_for_risk",
+    "to_latex",
+    "to_markdown",
+]

--- a/leakpro/risk/assessment.py
+++ b/leakpro/risk/assessment.py
@@ -1,0 +1,294 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Combination of measured vulnerability with declared harm parameters.
+
+The structure follows Sion et al. (*Privacy Risk Assessment for Data Subject-aware Threat Modeling*,
+IWPE 2019, doi:10.1109/SPW.2019.00023):
+
+.. code-block:: text
+
+    Risk = LM x LEF
+    LM   = DTS x NR x DST x NDS          all four declared by the data controller
+    LEF  = V x (RP x TEF)                V is the probability of a successful attack
+
+LeakPro's contribution is that ``V`` is *measured* rather than elicited from experts: it is the true
+positive rate of the strongest attack at the operating point the user chose. ``RP x TEF`` (retention
+period times threat event frequency) is assumed to be 1, i.e. a single attack attempt against a
+retained model, because LeakPro cannot observe adversary behaviour. That assumption is recorded in
+the output rather than hidden.
+
+Precision is reported per Jayaraman et al. (*Revisiting Membership Inference Under Realistic
+Assumptions*, PoPETs 2021, Theorem 4.2): ``PPV = TPR / (TPR + gamma * FPR)`` with
+``gamma = (1 - pi) / pi``. Reporting it is not optional decoration. A balanced audit implies
+``pi = 0.5``, and at realistic priors the same measurement can mean a very different threat.
+
+Nothing in this module imports from ``leakpro.attacks``; it consumes the family-agnostic measured
+block so that other attack families can feed the same combination later.
+"""
+
+from leakpro.risk.policy import POLICY_VERSION, resolve_vulnerability_band
+from leakpro.risk.schemas import (
+    CombinedRisk,
+    DeclaredInputs,
+    MiaVulnerability,
+    RiskAssessment,
+    UseCaseProfile,
+)
+from leakpro.risk.vulnerability import measure_mia, strongest_for_risk
+from leakpro.utils.import_helper import Any, List, Optional, Tuple
+
+LEAKPRO_VERSION = "0.1.0"
+
+_BALANCED_PRIOR = 0.5
+
+
+def positive_predictive_value(success_rate: float, alpha: float, prior: float) -> float:
+    """Return the attacker's precision at a given membership prior.
+
+    Implements ``PPV = TPR / (TPR + gamma * alpha)`` with ``gamma = (1 - prior) / prior``
+    (Jayaraman et al., PoPETs 2021, Theorem 4.2). Algebraically identical to
+    ``prior * TPR / (prior * TPR + (1 - prior) * alpha)``.
+
+    Args:
+    ----
+        success_rate: True positive rate at the operating point, as a fraction.
+        alpha: Operating point (false-positive rate), as a fraction.
+        prior: Probability that a candidate record is a member.
+
+    Returns:
+    -------
+        Precision in [0, 1]. Zero when the attack flags nothing.
+
+    """
+    gamma = (1.0 - prior) / prior
+    denominator = success_rate + gamma * alpha
+    if denominator <= 0.0:
+        return 0.0
+    return success_rate / denominator
+
+
+def loss_magnitude(profile: UseCaseProfile, n_subjects: Optional[int]) -> Optional[float]:
+    """Return Sion's Loss Magnitude, ``DTS x NR x DST x NDS``.
+
+    Args:
+    ----
+        profile: The declared use-case profile.
+        n_subjects: Resolved number of data subjects (NDS), or None when unknown.
+
+    Returns:
+    -------
+        The product, or None when the number of subjects is unknown.
+
+    """
+    if n_subjects is None:
+        return None
+    return (profile.data_type_sensitivity
+            * profile.records_per_subject
+            * profile.subject_type_weight
+            * float(n_subjects))
+
+
+def _resolve_n_subjects(profile: UseCaseProfile, num_train: Optional[int]) -> Tuple[Optional[int], str]:
+    """Decide how many data subjects the assessment scales to, and say where the number came from.
+
+    Args:
+    ----
+        profile: The declared use-case profile.
+        num_train: Training-set size of the target model, when the caller supplied it.
+
+    Returns:
+    -------
+        ``(n_subjects, source)``.
+
+    """
+    if profile.n_subjects is not None:
+        return profile.n_subjects, "declared"
+    if num_train is not None:
+        return int(num_train), "target num_train"
+    return None, "unavailable"
+
+
+def _build_assumptions(profile: UseCaseProfile,
+                       measured: MiaVulnerability,
+                       n_subjects_source: str,
+                       extrapolated: Optional[float]) -> List[str]:
+    """Collect one assumption string per derived figure or degraded path.
+
+    Args:
+    ----
+        profile: The declared use-case profile.
+        measured: The measured block.
+        n_subjects_source: Where the subject count came from.
+        extrapolated: The extrapolated exposed-record count, when one was produced.
+
+    Returns:
+    -------
+        The assumption strings, in reporting order.
+
+    """
+    assumptions = [
+        f"Vulnerability is measured: TPR={measured.success_rate:.4f} at FPR={measured.operating_point} from attack "
+        f"'{measured.attack_name}'.",
+        "Loss Event Frequency equals the measured success rate: Sion's retention period times threat event frequency "
+        "(RP x TEF) is assumed to be 1, i.e. a single attack attempt against a retained model. LeakPro cannot observe "
+        "adversary behaviour, so raise this factor yourself if repeated attempts are plausible.",
+        "Risk = LM x LEF treats the four Loss Magnitude factors as independent. Sion et al. section VI-B flags this as "
+        "a simplification of reality.",
+        f"Precision (PPV) is reported at the declared attacker prior pi={profile.attacker_prior}. The audit protocol "
+        f"itself is balanced, which corresponds to pi=0.5 and is reported separately as ppv_balanced.",
+        f"Number of data subjects: {n_subjects_source}.",
+    ]
+    if profile.cost_per_exposed_subject is None:
+        assumptions.append("No cost per exposed subject was declared, so no monetary figure is reported. This is "
+                           "deliberate: a default cost would be fabricated.")
+    if measured.n_exposed_audit is None:
+        assumptions.append("The result carries no per-record signal values, so the exposed-member count could not be "
+                           "computed. Rates are reported without absolute counts.")
+    if extrapolated is not None:
+        assumptions.append(
+            f"Extrapolation from {measured.n_members_audit} audited members to the training population assumes the "
+            "audit sample is representative. Per-record vulnerability is strongly non-uniform (the privacy onion "
+            "effect), so treat the extrapolated count as an estimate, not a measurement."
+        )
+    return assumptions
+
+
+def _build_warnings(profile: UseCaseProfile, measured: MiaVulnerability, skipped: List[str]) -> List[str]:
+    """Collect conditions that make the assessment unsafe to quote without qualification.
+
+    Args:
+    ----
+        profile: The declared use-case profile.
+        measured: The measured block.
+        skipped: Reasons emitted while selecting the strongest attack.
+
+    Returns:
+    -------
+        The warning strings.
+
+    """
+    warnings = list(skipped)
+    if not measured.resolvable:
+        warnings.append(
+            f"alpha={measured.operating_point} is finer than the audit set can resolve (minimum "
+            f"{measured.min_resolvable_fpr:.2e} with {measured.n_non_members_audit} non-members). Derived figures are "
+            "withheld: a TPR of 0 here means 'not measurable', not 'no leakage'."
+        )
+    if profile.attacker_prior == _BALANCED_PRIOR:
+        warnings.append(
+            "The attacker prior is 0.5, the balanced-audit assumption. Real candidate pools are usually far more "
+            "skewed, and precision falls steeply with the prior. Declare a realistic pi before quoting these figures."
+        )
+    if measured.n_exposed_audit is not None and 0 < measured.n_exposed_audit <= 5:
+        warnings.append(
+            f"Only {measured.n_exposed_audit} members were flagged at this operating point. High precision over a "
+            "handful of records is a weak basis for a risk statement."
+        )
+    return warnings
+
+
+def assess_risk(results: Any,
+                profile: UseCaseProfile,
+                *,
+                num_train: Optional[int] = None,
+                train_test_gap: Optional[float] = None,
+                dp_epsilon: Optional[float] = None,
+                bands: Optional[List[Tuple[float, str]]] = None,
+                strict: bool = True) -> RiskAssessment:
+    """Assess use-case risk for a set of MIA results.
+
+    Called explicitly after ``LeakPro.run_audit`` rather than from inside it, so that one expensive
+    audit can be re-assessed cheaply under different operating points and priors::
+
+        results = leakpro.run_audit()
+        assessment = assess_risk(results, profile, num_train=leakpro.handler.target_model_metadata.num_train)
+        assessment.save("risk_assessment.json")
+
+    Args:
+    ----
+        results: A ``MIAResult`` or a list of them.
+        profile: Declared harm parameters.
+        num_train: Training-set size of the target model. Without it the assessment reports audit-set
+            figures only rather than guessing a population size.
+        train_test_gap: Optional context: target train accuracy minus test accuracy.
+        dp_epsilon: Optional context: DP-SGD epsilon of the target model.
+        bands: Optional override for the advisory vulnerability bands.
+        strict: When True, an operating point the audit set cannot resolve raises. When False, the
+            assessment is returned with derived figures withheld and a warning attached.
+
+    Returns:
+    -------
+        The full assessment.
+
+    """
+    candidates = list(results) if isinstance(results, (list, tuple)) else [results]
+    best, skipped = strongest_for_risk(candidates, profile.tolerated_fpr)
+    measured = measure_mia(best,
+                           alpha=profile.tolerated_fpr,
+                           strict=strict,
+                           train_test_gap=train_test_gap,
+                           dp_epsilon=dp_epsilon)
+
+    n_subjects, n_subjects_source = _resolve_n_subjects(profile, num_train)
+    magnitude = loss_magnitude(profile, n_subjects)
+
+    # Derived figures are withheld entirely when the operating point was not measurable, because a
+    # success rate of 0.0 there is an absence of measurement rather than an absence of leakage.
+    if measured.resolvable:
+        ppv = positive_predictive_value(measured.success_rate, measured.operating_point, profile.attacker_prior)
+        ppv_balanced = positive_predictive_value(measured.success_rate, measured.operating_point, _BALANCED_PRIOR)
+        risk = magnitude * measured.success_rate if magnitude is not None else None
+        expected_exposed = measured.success_rate * n_subjects if n_subjects is not None else None
+        band = resolve_vulnerability_band(measured.lift, bands)
+    else:
+        ppv, ppv_balanced, risk, expected_exposed, band = None, None, None, None, None
+
+    expected_cost = None
+    if expected_exposed is not None and profile.cost_per_exposed_subject is not None:
+        expected_cost = expected_exposed * profile.cost_per_exposed_subject
+
+    extrapolated = None
+    if (profile.extrapolate_to_population
+            and measured.resolvable
+            and measured.n_exposed_audit is not None
+            and measured.n_members_audit > 0
+            and num_train is not None):
+        extrapolated = measured.n_exposed_audit * (float(num_train) / measured.n_members_audit)
+
+    combined = CombinedRisk(
+        ppv=ppv,
+        ppv_balanced=ppv_balanced,
+        gamma=(1.0 - profile.attacker_prior) / profile.attacker_prior,
+        loss_magnitude=magnitude,
+        loss_event_frequency=measured.success_rate,
+        risk=risk,
+        expected_exposed_subjects=expected_exposed,
+        expected_cost=expected_cost,
+        extrapolated_exposed_records=extrapolated,
+        vulnerability_band=band,
+    )
+
+    declared = DeclaredInputs(
+        tolerated_fpr=profile.tolerated_fpr,
+        attacker_prior=profile.attacker_prior,
+        n_subjects=n_subjects,
+        n_subjects_source=n_subjects_source,
+        records_per_subject=profile.records_per_subject,
+        data_type_sensitivity=profile.data_type_sensitivity,
+        subject_type_weight=profile.subject_type_weight,
+        cost_per_exposed_subject=profile.cost_per_exposed_subject,
+        extrapolate_to_population=profile.extrapolate_to_population,
+        notes=profile.notes,
+    )
+
+    return RiskAssessment(
+        measured=measured,
+        declared=declared,
+        combined=combined,
+        assumptions=_build_assumptions(profile, measured, n_subjects_source, extrapolated),
+        warnings=_build_warnings(profile, measured, skipped),
+        policy_version=POLICY_VERSION,
+        leakpro_version=LEAKPRO_VERSION,
+    )

--- a/leakpro/risk/policy.py
+++ b/leakpro/risk/policy.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Advisory policy data for the risk layer, with the provenance of every value.
+
+Two things live here, and neither is a measurement.
+
+**Suggested sensitivity scale.** Sion et al. (*Privacy Risk Assessment for Data Subject-aware Threat
+Modeling*, IWPE 2019, doi:10.1109/SPW.2019.00023) define Loss Magnitude as a product of numeric
+factors but deliberately supply no values for them: section III-G states every input is an analyst
+estimate, and section VI-A points at "GDPR sensitivity interpretations" and "the severity scale from
+the CNIL PIA knowledge bases" as sources for reusable sensitivity values. :data:`SUGGESTED_SENSITIVITY_SCALE`
+reproduces the CNIL PIA severity levels (PIA-3, *Knowledge Bases*, February 2018 edition: negligible,
+limited, significant, maximum) as a starting point. It is a suggestion, not a default: the profile
+field defaults to a neutral 1.0 and users are expected to substitute their own scale.
+
+**Vulnerability bands.** :data:`VULNERABILITY_BANDS` label the measured lift (TPR at alpha divided by
+alpha). They are ``heuristic``: no published source defines thresholds for this quantity, and we do
+not pretend otherwise. They exist so a UI can colour a card, and they deliberately describe *only*
+the measured side.
+
+There is no combined risk band. A label over the combination of a measurement and a value judgement
+would require weights nobody has published, which is exactly the failure mode this module replaces.
+Report :attr:`leakpro.risk.schemas.CombinedRisk.risk` and the expected exposure count as numbers,
+next to the inputs that produced them.
+"""
+
+from leakpro.utils.import_helper import Dict, List, Optional, Tuple
+
+POLICY_VERSION = "2026-08-17.1"
+
+# CNIL PIA-3 "Knowledge Bases" (Feb 2018) severity levels, offered as a starting scale for the
+# Data Type Sensitivity (DTS) and Data Subject Type (DST) factors. Sourced, not invented, but still
+# a policy choice: substitute your own scale when you have one.
+SUGGESTED_SENSITIVITY_SCALE: Dict[str, float] = {
+    "negligible": 1.0,
+    "limited": 2.0,
+    "significant": 3.0,
+    "maximum": 4.0,
+}
+SUGGESTED_SENSITIVITY_SOURCE = (
+    "CNIL, Privacy Impact Assessment (PIA-3): Knowledge Bases, February 2018 - severity scale "
+    "(negligible / limited / significant / maximum), as recommended by Sion et al. IWPE 2019 SVI-A."
+)
+
+# (lower bound on lift, inclusive) -> label. Heuristic: see the module docstring.
+VULNERABILITY_BANDS: List[Tuple[float, str]] = [
+    (100.0, "SEVERE"),
+    (10.0, "HIGH"),
+    (3.0, "MODERATE"),
+    (1.0, "LOW"),
+    (0.0, "NONE"),
+]
+VULNERABILITY_BANDS_SOURCE = (
+    "heuristic - no published thresholds exist for TPR/alpha lift. Round numbers chosen so that "
+    "'NONE' means no better than random at the operating point and 'SEVERE' means two orders of "
+    "magnitude better. Override with your own bands rather than treating these as calibrated."
+)
+
+
+def resolve_vulnerability_band(lift: float, bands: Optional[List[Tuple[float, str]]] = None) -> str:
+    """Return the advisory band label for a measured lift.
+
+    Args:
+    ----
+        lift: Measured TPR at alpha divided by alpha.
+        bands: Optional override, as ``(lower_bound, label)`` pairs sorted from highest bound down.
+
+    Returns:
+    -------
+        The label of the first band whose lower bound the lift meets.
+
+    """
+    table = bands if bands is not None else VULNERABILITY_BANDS
+    for lower_bound, label in table:
+        if lift >= lower_bound:
+            return label
+    return table[-1][1]

--- a/leakpro/risk/render.py
+++ b/leakpro/risk/render.py
@@ -1,0 +1,199 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Rendering of a risk assessment to markdown and LaTeX.
+
+Both renderers follow the same rule: a band or a derived number never appears without the inputs that
+produced it. The assumption list and the policy version are part of the output, not an appendix.
+"""
+
+from leakpro.risk.policy import VULNERABILITY_BANDS_SOURCE
+from leakpro.risk.schemas import RiskAssessment
+from leakpro.utils.import_helper import Optional
+
+
+def _fmt(value: Optional[float], digits: int = 4) -> str:
+    """Format an optional float for display.
+
+    Args:
+    ----
+        value: The value, possibly None.
+        digits: Decimal places.
+
+    Returns:
+    -------
+        The formatted value, or an em dash placeholder when absent.
+
+    """
+    if value is None:
+        return "not reported"
+    return f"{value:.{digits}f}"
+
+
+def _fmt_count(value: Optional[float]) -> str:
+    """Format an optional count for display.
+
+    Args:
+    ----
+        value: The count, possibly None or fractional.
+
+    Returns:
+    -------
+        The formatted count, or a placeholder when absent.
+
+    """
+    if value is None:
+        return "not reported"
+    return f"{value:,.1f}" if value % 1 else f"{int(value):,}"
+
+
+def to_markdown(assessment: RiskAssessment) -> str:
+    """Render an assessment as markdown.
+
+    Args:
+    ----
+        assessment: The assessment to render.
+
+    Returns:
+    -------
+        A markdown document.
+
+    """
+    m, d, c = assessment.measured, assessment.declared, assessment.combined
+    lines = [
+        "# Leakage risk assessment",
+        "",
+        f"Attack: **{m.attack_name}** · operating point alpha = **{d.tolerated_fpr}** · "
+        f"policy {assessment.policy_version} · LeakPro {assessment.leakpro_version}",
+        "",
+        "## Measured (reproducible from the audit)",
+        "",
+        "| Quantity | Value |",
+        "|---|---|",
+        f"| TPR at alpha | {_fmt(m.success_rate)} |",
+        f"| Advantage (TPR - alpha) | {_fmt(m.advantage)} |",
+        f"| Lift (TPR / alpha) | {_fmt(m.lift, 1)}x |",
+        f"| Members flagged at alpha | {_fmt_count(m.n_exposed_audit)} of {m.n_members_audit} audited members |",
+        f"| Audit set | {m.n_members_audit} members, {m.n_non_members_audit} non-members |",
+        f"| Finest resolvable FPR | {m.min_resolvable_fpr:.2e} |",
+        f"| ROC AUC (context only) | {_fmt(m.roc_auc)} |",
+        f"| Train-test gap (context only) | {_fmt(m.train_test_gap)} |",
+        f"| DP-SGD epsilon (context only) | {_fmt(m.dp_epsilon)} |",
+        "",
+        "## Declared (your inputs, not measured)",
+        "",
+        "| Factor | Value |",
+        "|---|---|",
+        f"| Attacker prior pi | {d.attacker_prior} (gamma = {_fmt(c.gamma, 2)}) |",
+        f"| Data subjects (NDS) | {_fmt_count(d.n_subjects)} ({d.n_subjects_source}) |",
+        f"| Records per subject (NR) | {d.records_per_subject} |",
+        f"| Data type sensitivity (DTS) | {d.data_type_sensitivity} |",
+        f"| Subject type weight (DST) | {d.subject_type_weight} |",
+        f"| Cost per exposed subject | {_fmt(d.cost_per_exposed_subject, 2)} |",
+        "",
+        "## Combined",
+        "",
+        "| Quantity | Value |",
+        "|---|---|",
+        f"| Attacker precision at your pi | {_fmt(c.ppv)} |",
+        f"| Attacker precision at pi = 0.5 | {_fmt(c.ppv_balanced)} (the audit protocol's own assumption) |",
+        f"| Loss Magnitude (DTS x NR x DST x NDS) | {_fmt_count(c.loss_magnitude)} |",
+        f"| Loss Event Frequency | {_fmt(c.loss_event_frequency)} |",
+        f"| Risk (LM x LEF) | {_fmt_count(c.risk)} sensitivity-weighted expected exposed records |",
+        f"| Expected exposed subjects | {_fmt_count(c.expected_exposed_subjects)} |",
+        f"| Expected cost | {_fmt(c.expected_cost, 2)} |",
+        f"| Extrapolated exposed records | {_fmt_count(c.extrapolated_exposed_records)} |",
+        f"| Vulnerability band (advisory) | {c.vulnerability_band or 'not reported'} |",
+        "",
+        f"Band provenance: {VULNERABILITY_BANDS_SOURCE}",
+        "",
+        "## Assumptions",
+        "",
+    ]
+    lines += [f"{i}. {a}" for i, a in enumerate(assessment.assumptions, start=1)]
+    if assessment.warnings:
+        lines += ["", "## Warnings", ""]
+        lines += [f"- {w}" for w in assessment.warnings]
+    if d.notes:
+        lines += ["", "## Notes", "", d.notes]
+    return "\n".join(lines) + "\n"
+
+
+def _tex_escape(text: str) -> str:
+    """Escape LaTeX special characters in free text.
+
+    Args:
+    ----
+        text: Raw text.
+
+    Returns:
+    -------
+        Text safe to inline in a LaTeX document.
+
+    """
+    for char, replacement in (("\\", r"\textbackslash{}"), ("&", r"\&"), ("%", r"\%"), ("$", r"\$"),
+                              ("#", r"\#"), ("_", r"\_"), ("{", r"\{"), ("}", r"\}"),
+                              ("~", r"\textasciitilde{}"), ("^", r"\textasciicircum{}")):
+        text = text.replace(char, replacement)
+    return text
+
+
+def to_latex(assessment: RiskAssessment) -> str:
+    """Render an assessment as a LaTeX section for the PDF report.
+
+    Args:
+    ----
+        assessment: The assessment to render.
+
+    Returns:
+    -------
+        LaTeX markup, suitable for appending to the report document body.
+
+    """
+    m, d, c = assessment.measured, assessment.declared, assessment.combined
+    rows = [
+        ("TPR at alpha", _fmt(m.success_rate)),
+        ("Advantage", _fmt(m.advantage)),
+        ("Lift", f"{_fmt(m.lift, 1)}x"),
+        ("Members flagged", f"{_fmt_count(m.n_exposed_audit)} of {m.n_members_audit}"),
+        ("Attacker precision at declared prior", _fmt(c.ppv)),
+        ("Attacker precision at prior 0.5", _fmt(c.ppv_balanced)),
+        ("Loss Magnitude", _fmt_count(c.loss_magnitude)),
+        ("Risk (LM x LEF)", _fmt_count(c.risk)),
+        ("Expected exposed subjects", _fmt_count(c.expected_exposed_subjects)),
+        ("Expected cost", _fmt(c.expected_cost, 2)),
+        ("Vulnerability band (advisory)", c.vulnerability_band or "not reported"),
+    ]
+    body = "\n".join(f"        {_tex_escape(label)} & {_tex_escape(value)} \\\\" for label, value in rows)
+    assumptions = "\n".join(f"        \\item {_tex_escape(a)}" for a in assessment.assumptions)
+    latex = f"""
+        \\section{{Risk assessment}}
+        Attack {_tex_escape(m.attack_name)}, operating point $\\alpha = {d.tolerated_fpr}$,
+        declared attacker prior $\\pi = {d.attacker_prior}$, policy {_tex_escape(assessment.policy_version)}.
+
+        \\begin{{tabularx}}{{\\textwidth}}{{lX}}
+        \\hline
+{body}
+        \\hline
+        \\end{{tabularx}}
+
+        \\subsection*{{Assumptions}}
+        \\begin{{enumerate}}
+{assumptions}
+        \\end{{enumerate}}
+        """
+    if assessment.warnings:
+        warnings = "\n".join(f"        \\item {_tex_escape(w)}" for w in assessment.warnings)
+        latex += f"""
+        \\subsection*{{Warnings}}
+        \\begin{{itemize}}
+{warnings}
+        \\end{{itemize}}
+        """
+    if d.notes:
+        latex += f"""
+        \\subsection*{{Notes}}
+        {_tex_escape(d.notes)}
+        """
+    return latex

--- a/leakpro/risk/schemas.py
+++ b/leakpro/risk/schemas.py
@@ -1,0 +1,205 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Schemas for the leakage risk assessment layer.
+
+The assessment is reported as three blocks that are never collapsed into a single opaque score:
+
+* :class:`VulnerabilityMeasurement` (and its MIA subclass) holds what the audit *measured*. Every
+  field is reproducible by re-running the audit.
+* :class:`DeclaredInputs` echoes what the data controller *declared*. None of it is measurable by
+  LeakPro, and it is reproduced verbatim in the output so a reader can see what was assumed.
+* :class:`CombinedRisk` holds figures derived from the two blocks above. Every one of them is
+  traceable to measured or declared inputs, and :attr:`RiskAssessment.assumptions` names the
+  assumption behind each derived quantity.
+
+See ``leakpro/risk/policy.py`` for the provenance of the advisory bands and the suggested
+sensitivity scale.
+"""
+
+import json
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from leakpro.utils.import_helper import List, Optional, Self
+
+
+class UseCaseProfile(BaseModel):
+    """Harm parameters declared by the data controller.
+
+    These cannot be measured by LeakPro: they describe the deployment context, not the model. The
+    factor names follow the Loss Magnitude decomposition of Sion et al. (IWPE 2019,
+    doi:10.1109/SPW.2019.00023), ``LM = DTS x NR x DST x NDS``, so that a reader can map each field
+    onto the published model. That paper deliberately supplies no numeric values for the factors;
+    see :data:`leakpro.risk.policy.SUGGESTED_SENSITIVITY_SCALE` for a cited starting point.
+    """
+
+    tolerated_fpr: float = Field(..., gt=0.0, lt=1.0,
+                                 description="Operating point alpha: the false-positive rate the attacker is assumed to "
+                                             "tolerate. Required on purpose - it changes the headline number and the "
+                                             "choice belongs to you. Use 0.01 unless you have a reason to go lower; "
+                                             "smaller values are unresolvable on small audit sets.")
+    attacker_prior: float = Field(default=0.5, gt=0.0, lt=1.0,
+                                  description="pi: probability that a record in the attacker's candidate pool is "
+                                              "actually a member. The default 0.5 is the balanced-audit assumption "
+                                              "baked into every TPR and AUC LeakPro reports, and it overstates "
+                                              "precision for realistic pools (Jayaraman et al., PoPETs 2021).")
+    n_subjects: Optional[int] = Field(default=None, ge=1,
+                                      description="NDS: number of data subjects in the training population. Defaults "
+                                                  "to the target model's num_train when available.")
+    records_per_subject: float = Field(default=1.0, gt=0.0,
+                                       description="NR: records of this data type per data subject. Fractions are "
+                                                   "allowed when only some subjects contribute the data type.")
+    data_type_sensitivity: float = Field(default=1.0, gt=0.0,
+                                         description="DTS: sensitivity of the leaked data type on a numeric scale you "
+                                                     "choose. 1.0 is neutral. See policy.SUGGESTED_SENSITIVITY_SCALE.")
+    subject_type_weight: float = Field(default=1.0, gt=0.0,
+                                       description="DST: weight for the data subject type, capturing vulnerable "
+                                                   "subjects such as minors or patients. 1.0 is neutral.")
+    cost_per_exposed_subject: Optional[float] = Field(default=None, ge=0.0,
+                                                      description="Cost to the organization per exposed subject, in any "
+                                                                  "unit you choose. Left unset, no monetary figure is "
+                                                                  "reported at all rather than a fabricated one.")
+    extrapolate_to_population: bool = Field(default=False,
+                                            description="Scale the exposed-record count from the audit set up to the "
+                                                        "training population. Off by default: per-record vulnerability "
+                                                        "is strongly non-uniform, so the extrapolation is an estimate "
+                                                        "under an assumption, not a measurement.")
+    notes: str = Field(default="", description="Free text kept in the output for the audit trail.")
+
+    model_config = ConfigDict(extra="forbid")  # Prevent extra fields
+
+
+class VulnerabilityMeasurement(BaseModel):
+    """Family-agnostic measured block.
+
+    Any attack family that wants to feed the risk layer produces one of these. Only MIA is
+    implemented in v1 (:class:`MiaVulnerability`); model inversion, gradient inversion and synthetic
+    data each need their own success definition first. Nothing in ``assessment.py`` may depend on
+    fields below this class.
+    """
+
+    attack_name: str = Field(..., description="Attack the measurement came from")
+    operating_point: float = Field(..., gt=0.0, lt=1.0, description="alpha for MIA; family-specific elsewhere")
+    success_rate: float = Field(..., ge=0.0, le=1.0, description="TPR at the operating point for MIA")
+    baseline_rate: float = Field(..., gt=0.0, lt=1.0, description="Random-guess rate at the operating point (alpha)")
+    n_at_risk: int = Field(..., ge=0, description="Records the measurement covers (audit-set members for MIA)")
+    resolvable: bool = Field(..., description="False when the audit set cannot resolve the operating point")
+    provenance: dict = Field(default_factory=dict, description="Attack config and result id")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MiaVulnerability(VulnerabilityMeasurement):
+    """Measured block for membership inference."""
+
+    roc_auc: Optional[float] = Field(default=None, description="Context only. Not used in any risk figure")
+    advantage: float = Field(..., description="TPR(alpha) - alpha: absolute gain over random guessing")
+    lift: float = Field(..., ge=0.0, description="TPR(alpha) / alpha: multiplicative gain over random guessing")
+    n_members_audit: int = Field(..., ge=0, description="Members in the audit set")
+    n_non_members_audit: int = Field(..., ge=0, description="Non-members in the audit set")
+    n_exposed_audit: Optional[int] = Field(default=None, ge=0,
+                                           description="Members flagged at the threshold yielding FPR <= alpha. None "
+                                                       "when the result carries no signal values")
+    exposed_audit_indices: Optional[List[int]] = Field(default=None,
+                                                       description="Dataset indices of the exposed members. Usually None: "
+                                                                   "the live MIAResult does not carry audit indices, so "
+                                                                   "exposed records can be counted but not named")
+    min_resolvable_fpr: float = Field(..., gt=0.0, description="1 / n_non_members_audit: the finest FPR this audit "
+                                                              "set can express")
+    train_test_gap: Optional[float] = Field(default=None, description="Context only: train accuracy minus test accuracy")
+    dp_epsilon: Optional[float] = Field(default=None, description="Context only: DP-SGD epsilon of the target")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class DeclaredInputs(BaseModel):
+    """Verbatim echo of the use-case profile, plus where n_subjects came from."""
+
+    tolerated_fpr: float
+    attacker_prior: float
+    n_subjects: Optional[int] = None
+    n_subjects_source: str = Field(..., description="'declared', 'target num_train', or 'unavailable'")
+    records_per_subject: float
+    data_type_sensitivity: float
+    subject_type_weight: float
+    cost_per_exposed_subject: Optional[float] = None
+    extrapolate_to_population: bool
+    notes: str = ""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class CombinedRisk(BaseModel):
+    """Figures derived from the measured and declared blocks."""
+
+    ppv: Optional[float] = Field(default=None, ge=0.0, le=1.0,
+                                 description="Precision of the attacker at the declared prior: "
+                                             "TPR / (TPR + gamma*alpha) with gamma = (1-pi)/pi. Jayaraman et al. Thm 4.2")
+    ppv_balanced: Optional[float] = Field(default=None, ge=0.0, le=1.0,
+                                          description="Same at pi = 0.5, the assumption built into the audit protocol")
+    gamma: float = Field(..., gt=0.0, description="(1 - attacker_prior) / attacker_prior")
+    loss_magnitude: Optional[float] = Field(default=None, ge=0.0,
+                                            description="Sion LM = DTS x NR x DST x NDS. None without n_subjects")
+    loss_event_frequency: float = Field(..., ge=0.0,
+                                        description="Sion LEF. Equals the measured success rate under the "
+                                                    "single-attempt assumption")
+    risk: Optional[float] = Field(default=None, ge=0.0,
+                                  description="Sion Risk = LM x LEF, in sensitivity-weighted expected exposed records. "
+                                              "With neutral factors this equals expected_exposed_subjects")
+    expected_exposed_subjects: Optional[float] = Field(default=None, ge=0.0,
+                                                       description="success_rate x n_subjects: unweighted and directly "
+                                                                   "interpretable")
+    expected_cost: Optional[float] = Field(default=None, ge=0.0,
+                                           description="Omitted unless a cost per exposed subject was declared")
+    extrapolated_exposed_records: Optional[float] = Field(default=None, ge=0.0,
+                                                          description="Audit-set exposed count scaled to the training "
+                                                                      "population. Only when explicitly requested")
+    vulnerability_band: Optional[str] = Field(default=None,
+                                              description="Advisory label over the measured lift only. Never a "
+                                                          "combined risk label - see policy.py")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class RiskAssessment(BaseModel):
+    """Complete assessment: measured, declared, combined, plus provenance."""
+
+    measured: MiaVulnerability
+    declared: DeclaredInputs
+    combined: CombinedRisk
+    assumptions: List[str] = Field(default_factory=list,
+                                   description="One entry per derived figure or degraded path, naming the assumption")
+    warnings: List[str] = Field(default_factory=list, description="Conditions that make the assessment unsafe to quote")
+    policy_version: str = Field(..., description="Version of the band policy used")
+    leakpro_version: str = Field(..., description="LeakPro version that produced the assessment")
+
+    model_config = ConfigDict(extra="forbid")
+
+    def save(self: Self, path: str) -> None:
+        """Write the assessment to ``path`` as JSON.
+
+        Args:
+        ----
+            path: Destination file path.
+
+        """
+        with open(path, "w") as f:
+            f.write(self.model_dump_json(indent=2))
+
+    @staticmethod
+    def load(path: str) -> "RiskAssessment":
+        """Read an assessment back from a JSON file written by :meth:`save`.
+
+        Args:
+        ----
+            path: Path to the JSON file.
+
+        Returns:
+        -------
+            The deserialized assessment.
+
+        """
+        with open(path) as f:
+            return RiskAssessment(**json.load(f))

--- a/leakpro/risk/vulnerability.py
+++ b/leakpro/risk/vulnerability.py
@@ -1,0 +1,396 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Extraction of the measured block from MIA results.
+
+This module is the only place in the risk layer that knows about membership inference. It turns a
+``MIAResult`` into a :class:`~leakpro.risk.schemas.MiaVulnerability`, enforcing four guards that each
+correspond to a way a naive implementation reports a confidently wrong number:
+
+1. *Resolution.* ``TPR`` at an FPR the audit set cannot express is not zero risk, it is no
+   measurement. An audit with ``n`` non-members cannot resolve an FPR below ``1/n``.
+2. *Orientation.* A result whose ROC AUC is below 0.5 is inverted, so a real leak reads as no leak.
+   Such results are rejected by name rather than folded into an aggregate.
+3. *Selection.* The attack that matters for risk is the one that wins at the user's operating point,
+   which is not always the one with the highest AUC.
+4. *Units.* Everything here is a fraction in [0, 1], validated in exactly one place. The live
+   ``MIAResult`` (``leakpro.reporting.mia_result``) stores ``fixed_fpr_table`` as fractions, while the
+   legacy ``leakpro.metrics.attack_result.find_tpr_at_fpr`` returns percentages. Only the former
+   feeds this module, and the validation catches the day someone wires up the latter.
+
+The TPR-at-alpha lookup is reimplemented locally rather than imported, because
+``leakpro.metrics.attack_result`` pulls in torch, matplotlib and torchvision at import time. The
+semantics are identical: the maximum TPR over ROC points whose FPR does not exceed alpha.
+"""
+
+import numpy as np
+
+from leakpro.risk.schemas import MiaVulnerability
+from leakpro.utils.import_helper import Any, List, Optional, Tuple
+
+# Accepted key spellings per operating point. MIAResult._get_result_fixed_fpr formats the percentage
+# with trailing zeros stripped ("TPR@1%FPR"), while the legacy metrics helper pads them
+# ("TPR@1.0%FPR"). Both are accepted so a saved result from either era can be read.
+_FIXED_FPR_KEYS = {
+    0.1: ("TPR@10%FPR", "TPR@10.0%FPR"),
+    0.01: ("TPR@1%FPR", "TPR@1.0%FPR"),
+    0.001: ("TPR@0.1%FPR",),
+    0.0001: ("TPR@0.01%FPR",),
+}
+
+
+class InvertedResultError(ValueError):
+    """Raised when a result's ROC is inverted, making it unusable for risk assessment."""
+
+
+class UnresolvableOperatingPointError(ValueError):
+    """Raised when the audit set is too small to express the requested false-positive rate."""
+
+
+class NoUsableResultError(ValueError):
+    """Raised when no attack result can support a risk assessment at the requested operating point."""
+
+
+def _as_array(values: Any) -> Optional[np.ndarray]:
+    """Coerce a result field to a 1-D float array, or None when absent.
+
+    Args:
+    ----
+        values: List, array or None as stored on a result object.
+
+    Returns:
+    -------
+        A 1-D array, or None when there is nothing to coerce.
+
+    """
+    if values is None:
+        return None
+    array = np.asarray(values, dtype=float).ravel()
+    return array if array.size else None
+
+
+def _tpr_at_fpr(fpr: np.ndarray, tpr: np.ndarray, alpha: float) -> float:
+    """Return the maximum TPR over ROC points with FPR <= alpha, as a fraction.
+
+    Args:
+    ----
+        fpr: False-positive rates of the ROC curve.
+        tpr: True-positive rates of the ROC curve.
+        alpha: Operating point.
+
+    Returns:
+    -------
+        TPR as a fraction in [0, 1]. Zero when no ROC point satisfies the constraint, which callers
+        must treat as "unmeasurable", not as "no leakage".
+
+    """
+    eligible = np.nonzero(fpr <= alpha)[0]
+    if eligible.size == 0:
+        return 0.0
+    return float(np.max(tpr[eligible]))
+
+
+def _tpr_from_fixed_table(table: dict, alpha: float) -> float:
+    """Read TPR at alpha from a result's fixed-FPR table.
+
+    Args:
+    ----
+        table: The ``fixed_fpr_table`` mapping on a ``MIAResult``, whose values are fractions.
+        alpha: Operating point; must be one of the tabulated rates.
+
+    Returns:
+    -------
+        TPR as a fraction in [0, 1].
+
+    Raises:
+    ------
+        ValueError: When alpha is not tabulated, or the stored value is not a fraction in [0, 1]. The
+            latter catches a percentage-valued table, e.g. one built by the legacy
+            ``leakpro.metrics.attack_result.find_tpr_at_fpr``, instead of silently reporting a TPR of
+            1030%.
+
+    """
+    keys = _FIXED_FPR_KEYS.get(alpha, ())
+    key = next((k for k in keys if k in table), None)
+    if key is None:
+        raise ValueError(
+            f"Cannot read TPR at alpha={alpha} from this result: tabulated operating points are "
+            f"{sorted(_FIXED_FPR_KEYS)} and the table holds {sorted(table)}. Pass a result that still carries its "
+            "fpr/tpr arrays to use other operating points."
+        )
+    value = float(table[key])
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(
+            f"Fixed-FPR table value {value} for {key} is not a fraction in [0, 1]. A percentage-valued table cannot be "
+            "used here: divide by 100 at the source rather than letting the unit error propagate into a risk figure."
+        )
+    return value
+
+
+def _tpr_of(result: Any, alpha: float) -> float:
+    """Return TPR at alpha for a result, from its ROC arrays when present, else its saved table.
+
+    Args:
+    ----
+        result: A ``MIAResult`` (in memory or loaded from disk).
+        alpha: Operating point.
+
+    Returns:
+    -------
+        TPR as a fraction in [0, 1].
+
+    """
+    fpr = _as_array(getattr(result, "fpr", None))
+    tpr = _as_array(getattr(result, "tpr", None))
+    if fpr is not None and tpr is not None and fpr.size == tpr.size:
+        return _tpr_at_fpr(fpr, tpr, alpha)
+    table = getattr(result, "fixed_fpr_table", None)
+    if table:
+        return _tpr_from_fixed_table(table, alpha)
+    raise ValueError(f"Result {getattr(result, 'id', '<unknown>')} carries neither ROC arrays nor a fixed-FPR table.")
+
+
+def _membership_labels(result: Any) -> Optional[np.ndarray]:
+    """Return the membership labels of a result.
+
+    The live ``MIAResult`` (``leakpro.reporting.mia_result``) stores them as ``true``; the legacy
+    class in ``leakpro.metrics.attack_result`` and results loaded from older JSON use
+    ``true_labels``. Both are accepted.
+
+    Args:
+    ----
+        result: A result object.
+
+    Returns:
+    -------
+        The labels as a 1-D array, or None when the result carries none.
+
+    """
+    for attribute in ("true", "true_labels"):
+        labels = _as_array(getattr(result, attribute, None))
+        if labels is not None:
+            return labels
+    return None
+
+
+def _label_counts(true_labels: Optional[np.ndarray]) -> Tuple[int, int]:
+    """Count members and non-members in the audit set.
+
+    Args:
+    ----
+        true_labels: Membership labels, 1 for members.
+
+    Returns:
+    -------
+        ``(n_members, n_non_members)``.
+
+    """
+    if true_labels is None:
+        return 0, 0
+    members = int(np.count_nonzero(true_labels == 1))
+    return members, int(true_labels.size - members)
+
+
+def _exposed_members(signal_values: Optional[np.ndarray],
+                     true_labels: Optional[np.ndarray],
+                     audit_indices: Optional[np.ndarray],
+                     alpha: float) -> Tuple[Optional[int], Optional[List[int]]]:
+    """Count the members an attacker flags at the threshold that yields FPR <= alpha.
+
+    The threshold is taken as the ``1 - alpha`` quantile of the non-member signal, i.e. the strictest
+    threshold that still lets through an alpha fraction of non-members. Orientation is assumed to be
+    higher-is-member, which the caller guarantees by rejecting results with AUC below 0.5.
+
+    Args:
+    ----
+        signal_values: Per-record attack scores.
+        true_labels: Membership labels, 1 for members.
+        audit_indices: Dataset indices of the audited records, when available.
+        alpha: Operating point.
+
+    Returns:
+    -------
+        ``(count, indices)``. Both None when the result carries no signal values; ``indices`` is None
+        when the result carries no audit indices.
+
+    """
+    if signal_values is None or true_labels is None or signal_values.size != true_labels.size:
+        return None, None
+
+    is_member = true_labels == 1
+    non_member_signal = signal_values[~is_member]
+    if non_member_signal.size == 0:
+        return None, None
+
+    threshold = float(np.quantile(non_member_signal, 1.0 - alpha))
+    exposed_mask = is_member & (signal_values > threshold)
+    count = int(np.count_nonzero(exposed_mask))
+
+    if audit_indices is None or audit_indices.size != signal_values.size:
+        return count, None
+    return count, [int(i) for i in audit_indices[exposed_mask]]
+
+
+class _MappingResult:
+    """Duck-typed view over a serialized MIA result, for callers that only have JSON."""
+
+    def __init__(self, payload: dict) -> None:
+        self.result_name = payload.get("attack_name") or payload.get("result_name") or "<unknown>"
+        self.roc_auc = payload.get("roc_auc")
+        self.fpr = payload.get("fpr")
+        self.tpr = payload.get("tpr")
+        self.true = payload.get("true_labels") if payload.get("true_labels") is not None else payload.get("true")
+        self.signal_values = payload.get("signal_values")
+        self.fixed_fpr_table = payload.get("tpr_at_fpr") or payload.get("fixed_fpr_table") or {}
+        self.audit_indices = payload.get("audit_indices")
+        self.id = payload.get("id") or self.result_name
+        self.metadata = payload.get("config") or payload.get("metadata") or {}
+
+
+def result_from_mapping(payload: dict) -> Any:
+    """Adapt a serialized MIA result to the shape this module reads.
+
+    Lets callers that hold JSON rather than live objects (the web app backend, or anything re-reading
+    a finished audit) reuse the same measurement path instead of reimplementing it.
+
+    Args:
+    ----
+        payload: A serialized result, as produced by the web app's ``_serialise_result`` or by
+            ``MIAResult.save``.
+
+    Returns:
+    -------
+        An object exposing the attributes :func:`measure_mia` reads.
+
+    """
+    return _MappingResult(payload)
+
+
+def measure_mia(result: Any,
+                *,
+                alpha: float,
+                strict: bool = True,
+                train_test_gap: Optional[float] = None,
+                dp_epsilon: Optional[float] = None) -> MiaVulnerability:
+    """Extract the measured block from a single MIA result.
+
+    Args:
+    ----
+        result: A ``MIAResult``, in memory or loaded from disk.
+        alpha: Operating point, the false-positive rate the attacker is assumed to tolerate.
+        strict: When True, an operating point the audit set cannot resolve raises. When False, the
+            measurement is returned with ``resolvable=False`` so callers can degrade explicitly.
+        train_test_gap: Optional context: target train accuracy minus test accuracy.
+        dp_epsilon: Optional context: DP-SGD epsilon of the target model.
+
+    Returns:
+    -------
+        The measured block.
+
+    Raises:
+    ------
+        InvertedResultError: When the result's ROC AUC is below 0.5.
+        UnresolvableOperatingPointError: When ``strict`` and alpha is finer than the audit set allows.
+
+    """
+    name = getattr(result, "result_name", None) or getattr(result, "resultname", None) or getattr(result, "id", "<unknown>")
+
+    roc_auc = getattr(result, "roc_auc", None)
+    roc_auc = float(roc_auc) if roc_auc is not None else None
+    if roc_auc is not None and roc_auc < 0.5:
+        raise InvertedResultError(
+            f"Attack '{name}' reports ROC AUC {roc_auc:.4f} < 0.5, so its scores are inverted and a real leak would "
+            "read as no leak. Fix the attack's score orientation before using it for risk assessment; do not average "
+            "it in with correctly oriented attacks."
+        )
+
+    true_labels = _membership_labels(result)
+    n_members, n_non_members = _label_counts(true_labels)
+    if n_non_members == 0:
+        raise ValueError(f"Attack '{name}' has no non-members in its audit set, so no false-positive rate is defined.")
+
+    min_resolvable_fpr = 1.0 / n_non_members
+    resolvable = alpha >= min_resolvable_fpr
+    if not resolvable and strict:
+        raise UnresolvableOperatingPointError(
+            f"alpha={alpha} is finer than attack '{name}' can resolve: {n_non_members} non-members give a minimum "
+            f"expressible FPR of {min_resolvable_fpr:.2e}. TPR at this alpha would read 0.0, which means 'not "
+            f"measurable', not 'no leakage'. Raise alpha to at least {min_resolvable_fpr:.2e} or audit more records."
+        )
+
+    success_rate = _tpr_of(result, alpha)
+    n_exposed, exposed_indices = _exposed_members(
+        _as_array(getattr(result, "signal_values", None)),
+        true_labels,
+        _as_array(getattr(result, "audit_indices", None)),
+        alpha,
+    )
+
+    return MiaVulnerability(
+        attack_name=str(name),
+        operating_point=alpha,
+        success_rate=success_rate,
+        baseline_rate=alpha,
+        n_at_risk=n_members,
+        resolvable=resolvable,
+        provenance={"result_id": str(getattr(result, "id", "") or ""), "config": getattr(result, "metadata", None) or {}},
+        roc_auc=roc_auc,
+        advantage=success_rate - alpha,
+        lift=success_rate / alpha,
+        n_members_audit=n_members,
+        n_non_members_audit=n_non_members,
+        n_exposed_audit=n_exposed,
+        exposed_audit_indices=exposed_indices,
+        min_resolvable_fpr=min_resolvable_fpr,
+        train_test_gap=train_test_gap,
+        dp_epsilon=dp_epsilon,
+    )
+
+
+def strongest_for_risk(results: List[Any], alpha: float) -> Tuple[Any, List[str]]:
+    """Select the attack that performs best at the operating point, not the one with the highest AUC.
+
+    ``MIAResult.get_strongest`` maximizes ROC AUC, which is an average-case measure. For risk the
+    relevant attack is the one that wins at the FPR the attacker tolerates; the two disagree
+    routinely.
+
+    Args:
+    ----
+        results: Candidate MIA results.
+        alpha: Operating point.
+
+    Returns:
+    -------
+        ``(best_result, skipped)`` where ``skipped`` holds one human-readable reason per rejected
+        result, for the caller to surface as warnings.
+
+    Raises:
+    ------
+        NoUsableResultError: When every candidate was rejected.
+
+    """
+    best: Optional[Any] = None
+    best_tpr = -1.0
+    skipped: List[str] = []
+
+    for result in results:
+        name = getattr(result, "result_name", None) or getattr(result, "resultname", None) or getattr(result, "id", "?")
+        roc_auc = getattr(result, "roc_auc", None)
+        if roc_auc is not None and float(roc_auc) < 0.5:
+            skipped.append(f"'{name}' skipped: inverted ROC (AUC {float(roc_auc):.4f} < 0.5)")
+            continue
+        try:
+            tpr = _tpr_of(result, alpha)
+        except ValueError as exc:
+            skipped.append(f"'{name}' skipped: {exc}")
+            continue
+        if tpr > best_tpr:
+            best, best_tpr = result, tpr
+
+    if best is None:
+        raise NoUsableResultError(
+            f"No attack result can support a risk assessment at alpha={alpha}. Reasons: " + "; ".join(skipped)
+            if skipped else f"No attack results were supplied for alpha={alpha}."
+        )
+    return best, skipped

--- a/leakpro/schemas.py
+++ b/leakpro/schemas.py
@@ -11,6 +11,8 @@ import optuna
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from torch.nn import Module
 
+from leakpro.risk.schemas import UseCaseProfile
+
 ArrayOrScalar = Union[np.ndarray, np.integer, int, list]
 
 class OptimizerConfig(BaseModel):
@@ -137,6 +139,9 @@ class LeakProConfig(BaseModel):
     target: TargetConfig
     shadow_model: Optional[ShadowModelConfig] = Field(None, description="Shadow model config")
     distillation_model: Optional[DistillationModelConfig] = Field(None, description="Distillation model config")
+    # Deployment context for risk assessment, not an audit parameter, hence top level. Declaring it
+    # does not trigger anything: assessment is an explicit assess_risk() call on the audit results.
+    use_case: Optional[UseCaseProfile] = Field(None, description="Use-case profile for risk assessment")
     model_config = ConfigDict(extra="forbid")  # Prevent extra fields
 
 

--- a/leakpro/tests/risk/conftest.py
+++ b/leakpro/tests/risk/conftest.py
@@ -1,0 +1,63 @@
+"""Fixtures for the risk layer tests.
+
+Real ``MIAResult`` objects are used wherever possible so the risk layer cannot drift from the class it
+consumes. Duck-typed stubs are only used for cases a real result cannot express, such as a
+percentage-valued fixed-FPR table.
+"""
+
+import numpy as np
+import pytest
+
+from leakpro.reporting.mia_result import MIAResult
+
+
+def make_result(n_members: int = 400,
+                n_non_members: int = 400,
+                separation: float = 1.0,
+                name: str = "lira",
+                seed: int = 0,
+                inverted: bool = False) -> MIAResult:
+    """Build a real MIAResult with a known member/non-member signal separation.
+
+    Args:
+    ----
+        n_members: Number of members in the audit set.
+        n_non_members: Number of non-members in the audit set.
+        separation: Mean shift of the member signal distribution.
+        name: Result name.
+        seed: RNG seed.
+        inverted: When True, members get the *lower* signal, mimicking an attack that passes a raw
+            loss to a "higher is member" comparison.
+
+    Returns:
+    -------
+        A MIAResult built from full scores.
+
+    """
+    rng = np.random.default_rng(seed)
+    shift = -separation if inverted else separation
+    labels = np.array([1] * n_members + [0] * n_non_members)
+    signals = np.concatenate([rng.normal(shift, 1.0, n_members), rng.normal(0.0, 1.0, n_non_members)])
+    return MIAResult.from_full_scores(true_membership=labels, signal_values=signals, result_name=name)
+
+
+class StubResult:
+    """Minimal duck-typed stand-in for cases a real MIAResult cannot express."""
+
+    def __init__(self, result_name: str, roc_auc: float = 0.8, fixed_fpr_table: dict = None,
+                 fpr: list = None, tpr: list = None, true: list = None, signal_values: list = None) -> None:
+        self.result_name = result_name
+        self.roc_auc = roc_auc
+        self.fixed_fpr_table = fixed_fpr_table
+        self.fpr = np.array(fpr) if fpr is not None else None
+        self.tpr = np.array(tpr) if tpr is not None else None
+        self.true = np.array(true) if true is not None else np.array([1] * 400 + [0] * 400)
+        self.signal_values = np.array(signal_values) if signal_values is not None else None
+        self.id = result_name
+        self.metadata = {}
+
+
+@pytest.fixture
+def result() -> MIAResult:
+    """Return a well-behaved real result: 400 members, 400 non-members, clear separation."""
+    return make_result()

--- a/leakpro/tests/risk/test_assessment.py
+++ b/leakpro/tests/risk/test_assessment.py
@@ -1,0 +1,157 @@
+"""Tests for the combination of measured vulnerability with declared harm parameters."""
+
+import pytest
+
+from leakpro.risk.assessment import assess_risk, loss_magnitude, positive_predictive_value
+from leakpro.risk.schemas import UseCaseProfile
+from leakpro.tests.risk.conftest import make_result
+
+
+class TestPositivePredictiveValue:
+    """PPV per Jayaraman et al. (PoPETs 2021) Theorem 4.2."""
+
+    @pytest.mark.parametrize(("prior", "expected"), [
+        # PPV = TPR / (TPR + gamma*alpha), gamma = (1-p)/p, with TPR = 0.10 and alpha = 0.01.
+        (0.5, 0.10 / (0.10 + 1.0 * 0.01)),          # gamma = 1     -> 0.9091
+        (0.01, 0.10 / (0.10 + 99.0 * 0.01)),        # gamma = 99    -> 0.0917
+        (0.001, 0.10 / (0.10 + 999.0 * 0.01)),      # gamma = 999   -> 0.0099
+    ])
+    def test_should_match_hand_computed_precision_at_each_prior(self, prior: float, expected: float) -> None:
+        """Precision collapses as the prior skews, which is the entire point of reporting it."""
+        assert positive_predictive_value(0.10, 0.01, prior) == pytest.approx(expected)
+
+    def test_should_equal_the_equivalent_prior_weighted_form(self) -> None:
+        """The gamma form and the prior-weighted form are algebraically identical."""
+        tpr, alpha, prior = 0.25, 0.001, 0.02
+        weighted = prior * tpr / (prior * tpr + (1 - prior) * alpha)
+        assert positive_predictive_value(tpr, alpha, prior) == pytest.approx(weighted)
+
+    def test_should_be_zero_when_the_attack_flags_nothing(self) -> None:
+        """A zero success rate yields zero precision rather than a division error."""
+        assert positive_predictive_value(0.0, 0.01, 0.5) == 0.0
+
+
+class TestLossMagnitude:
+    """Sion et al. LM = DTS x NR x DST x NDS."""
+
+    def test_should_multiply_all_four_declared_factors(self) -> None:
+        """The product is exactly the published decomposition, with no extra scaling."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, records_per_subject=2.0,
+                                 data_type_sensitivity=3.0, subject_type_weight=4.0)
+        assert loss_magnitude(profile, 1000) == pytest.approx(3.0 * 2.0 * 4.0 * 1000)
+
+    def test_should_reduce_to_the_subject_count_with_neutral_factors(self) -> None:
+        """Neutral factors leave the interpretable special case: one unit of harm per subject."""
+        assert loss_magnitude(UseCaseProfile(tolerated_fpr=0.01), 500) == pytest.approx(500.0)
+
+    def test_should_be_unavailable_without_a_subject_count(self) -> None:
+        """No population size means no loss magnitude, rather than a guessed one."""
+        assert loss_magnitude(UseCaseProfile(tolerated_fpr=0.01), None) is None
+
+
+class TestAssessRisk:
+    """End-to-end combination on real results."""
+
+    def test_should_derive_risk_as_loss_magnitude_times_success_rate(self, result) -> None:
+        """Risk is Sion's LM x LEF, with LEF the measured success rate."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=10_000, data_type_sensitivity=3.0)
+        assessment = assess_risk([result], profile)
+        expected = 3.0 * 1.0 * 1.0 * 10_000 * assessment.measured.success_rate
+        assert assessment.combined.risk == pytest.approx(expected)
+        assert assessment.combined.loss_event_frequency == pytest.approx(assessment.measured.success_rate)
+
+    def test_should_report_expected_exposed_subjects_unweighted(self, result) -> None:
+        """The interpretable count ignores the sensitivity weights on purpose."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=10_000, data_type_sensitivity=3.0)
+        assessment = assess_risk([result], profile)
+        assert assessment.combined.expected_exposed_subjects == pytest.approx(
+            assessment.measured.success_rate * 10_000)
+
+    def test_should_report_both_declared_and_balanced_precision(self, result) -> None:
+        """The balanced value is the audit protocol's own assumption and travels alongside."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, attacker_prior=0.001))
+        assert assessment.combined.ppv < assessment.combined.ppv_balanced
+        assert assessment.combined.gamma == pytest.approx(999.0)
+
+    def test_should_omit_cost_entirely_when_none_was_declared(self, result) -> None:
+        """No declared cost means no monetary figure, not a zero that reads as "no impact"."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, n_subjects=100))
+        assert assessment.combined.expected_cost is None
+        assert any("no monetary figure" in a for a in assessment.assumptions)
+
+    def test_should_compute_cost_when_one_was_declared(self, result) -> None:
+        """Cost scales the expected exposure by the declared per-subject cost."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=100, cost_per_exposed_subject=250.0)
+        assessment = assess_risk([result], profile)
+        assert assessment.combined.expected_cost == pytest.approx(
+            assessment.combined.expected_exposed_subjects * 250.0)
+
+    def test_should_take_the_subject_count_from_num_train_when_not_declared(self, result) -> None:
+        """The target's training-set size is the natural default, and its use is recorded."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01), num_train=1234)
+        assert assessment.declared.n_subjects == 1234
+        assert assessment.declared.n_subjects_source == "target num_train"
+
+    def test_should_report_audit_set_figures_only_without_a_population_size(self, result) -> None:
+        """Absent num_train and a declared count, population figures are withheld, not invented."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01))
+        assert assessment.declared.n_subjects_source == "unavailable"
+        assert assessment.combined.expected_exposed_subjects is None
+        assert assessment.combined.risk is None
+        assert assessment.combined.ppv is not None, "measured-side figures must survive"
+
+    def test_should_prefer_a_declared_subject_count_over_num_train(self, result) -> None:
+        """An explicit declaration wins: subjects and training records are not the same thing."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=50)
+        assessment = assess_risk([result], profile, num_train=99_999)
+        assert (assessment.declared.n_subjects, assessment.declared.n_subjects_source) == (50, "declared")
+
+    def test_should_extrapolate_only_when_requested_and_flag_the_assumption(self, result) -> None:
+        """Extrapolation is opt-in and always carries its representativeness caveat."""
+        off = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01), num_train=4000)
+        assert off.combined.extrapolated_exposed_records is None
+        assert not any("Extrapolation" in a for a in off.assumptions)
+
+        on = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, extrapolate_to_population=True),
+                         num_train=4000)
+        expected = on.measured.n_exposed_audit * (4000 / on.measured.n_members_audit)
+        assert on.combined.extrapolated_exposed_records == pytest.approx(expected)
+        assert any("privacy onion" in a for a in on.assumptions)
+
+    def test_should_warn_when_the_prior_is_the_balanced_default(self, result) -> None:
+        """Quoting balanced-prior precision as real-world risk is the mistake to flag."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01))
+        assert any("balanced-audit assumption" in w for w in assessment.warnings)
+
+    def test_should_record_the_single_attempt_and_independence_assumptions(self, result) -> None:
+        """Both simplifications inherited from the published model must be stated, not hidden."""
+        assumptions = " ".join(assess_risk([result], UseCaseProfile(tolerated_fpr=0.01)).assumptions)
+        assert "single attack attempt" in assumptions
+        assert "independent" in assumptions
+
+    def test_should_withhold_derived_figures_when_the_operating_point_is_unresolvable(self) -> None:
+        """A non-strict assessment degrades explicitly instead of reporting zero risk."""
+        small = make_result(n_members=200, n_non_members=200)
+        assessment = assess_risk([small], UseCaseProfile(tolerated_fpr=0.001, n_subjects=100),
+                                 strict=False)
+        assert assessment.measured.resolvable is False
+        assert (assessment.combined.ppv, assessment.combined.risk) == (None, None)
+        assert assessment.combined.vulnerability_band is None
+        assert any("not measurable" in w for w in assessment.warnings)
+
+    def test_should_accept_a_single_result_as_well_as_a_list(self, result) -> None:
+        """Callers should not have to wrap one result in a list."""
+        assert assess_risk(result, UseCaseProfile(tolerated_fpr=0.01)).measured.attack_name == "lira"
+
+    def test_should_be_deterministic_for_identical_inputs(self, result) -> None:
+        """The scored output carries no timestamps or randomness, so it must be byte-identical."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=1000, notes="run twice")
+        first = assess_risk([result], profile, num_train=1000)
+        second = assess_risk([result], profile, num_train=1000)
+        assert first.model_dump_json() == second.model_dump_json()
+
+    def test_should_carry_policy_and_version_provenance(self, result) -> None:
+        """Any band that is emitted must be traceable to a policy version."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01))
+        assert assessment.policy_version
+        assert assessment.leakpro_version

--- a/leakpro/tests/risk/test_e2e_risk.py
+++ b/leakpro/tests/risk/test_e2e_risk.py
@@ -1,0 +1,124 @@
+"""End-to-end wiring test: real audit -> assess_risk -> JSON and PDF section.
+
+Reuses the tiny-target machinery from the MIA end-to-end suite so this exercises the real attack
+pipeline rather than synthetic results. The audit population is small (72 records, ~32 members), so
+the operating point here is 10% FPR: anything stricter is genuinely unresolvable at that size, which
+is exactly what the resolution guard enforces.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from leakpro import LeakPro
+from leakpro.reporting.report_handler import ReportHandler
+from leakpro.risk import RiskAssessment, UseCaseProfile, assess_risk
+from leakpro.tests.mia_attacks.attacks.test_all_attacks_end_to_end import (
+    TinyImageInputHandler,
+    _clear_global_attack_cache,
+    _create_image_e2e_config,
+    _set_seed,
+)
+
+E2E_ALPHA = 0.1
+
+
+@pytest.fixture
+def audited(monkeypatch, tmp_path):
+    """Run a real LiRA audit on a tiny target and return (leakpro, results)."""
+    _set_seed()
+    with tempfile.TemporaryDirectory(prefix="risk_e2e_") as temp_dir:
+        temp_root = Path(temp_dir)
+        monkeypatch.chdir(temp_root)
+        _clear_global_attack_cache()
+        run_dir = temp_root / "lira"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        config_path = _create_image_e2e_config(run_dir, "lira")
+        leakpro = LeakPro(TinyImageInputHandler, str(config_path))
+        results = leakpro.run_audit(create_pdf=False, use_optuna=False)
+        yield leakpro, results, config_path
+
+
+class TestEndToEnd:
+    """The whole path, on results produced by a real audit."""
+
+    def test_should_assess_risk_on_real_audit_results(self, audited) -> None:
+        """assess_risk must consume what run_audit returns, with no adaptation by the caller."""
+        leakpro, results, _ = audited
+        profile = UseCaseProfile(tolerated_fpr=E2E_ALPHA, attacker_prior=0.01, data_type_sensitivity=3.0)
+        assessment = assess_risk(results, profile,
+                                 num_train=leakpro.handler.target_model_metadata.num_train)
+
+        assert assessment.measured.resolvable is True
+        assert 0.0 <= assessment.measured.success_rate <= 1.0
+        assert assessment.measured.n_members_audit > 0
+        assert assessment.combined.ppv is not None
+        assert assessment.combined.risk is not None
+        assert assessment.declared.n_subjects_source == "target num_train"
+
+    def test_should_write_a_self_contained_json_file(self, audited) -> None:
+        """The saved file is the deliverable: it must carry every block plus provenance."""
+        leakpro, results, _ = audited
+        assessment = assess_risk(results, UseCaseProfile(tolerated_fpr=E2E_ALPHA),
+                                 num_train=leakpro.handler.target_model_metadata.num_train)
+        path = Path(leakpro.report_dir) / "risk_assessment.json"
+        assessment.save(str(path))
+
+        assert path.exists() and path.stat().st_size > 0
+        payload = json.loads(path.read_text())
+        assert set(payload) >= {"measured", "declared", "combined", "assumptions", "warnings",
+                                "policy_version", "leakpro_version"}
+        assert RiskAssessment.load(str(path)).combined.gamma == assessment.combined.gamma
+
+    def test_should_add_a_risk_section_to_the_pdf_report(self, audited) -> None:
+        """A ReportHandler given an assessment emits the Risk section ahead of the attack sections."""
+        leakpro, results, _ = audited
+        assessment = assess_risk(results, UseCaseProfile(tolerated_fpr=E2E_ALPHA, n_subjects=100))
+        handler = ReportHandler(results=results, report_dir=leakpro.report_dir,
+                               risk_assessment=assessment)
+        handler.create_results()
+        handler._init_pdf()
+        from leakpro.risk.render import to_latex
+        handler.latex_content += to_latex(handler.risk_assessment)
+        assert "\\section{Risk assessment}" in handler.latex_content
+
+    def test_should_leave_run_audit_untouched_without_a_use_case_block(self, audited) -> None:
+        """A config with no use_case block must behave exactly as before."""
+        leakpro, results, _ = audited
+        assert leakpro.use_case_profile is None
+        assert isinstance(results, list) and results
+
+    def test_should_expose_a_profile_declared_in_the_audit_config(self, audited) -> None:
+        """A use_case block in audit.yaml is parsed and reachable, but triggers nothing by itself."""
+        _leakpro, _results, config_path = audited
+        config = yaml.safe_load(Path(config_path).read_text())
+        config["use_case"] = {
+            "tolerated_fpr": E2E_ALPHA,
+            "attacker_prior": 0.01,
+            "data_type_sensitivity": 4.0,
+            "notes": "declared in audit.yaml",
+        }
+        with open(config_path, "w") as f:
+            yaml.safe_dump(config, f, sort_keys=False)
+
+        reloaded = LeakPro(TinyImageInputHandler, str(config_path))
+        assert reloaded.use_case_profile is not None
+        assert reloaded.use_case_profile.tolerated_fpr == E2E_ALPHA
+        assert reloaded.use_case_profile.data_type_sensitivity == 4.0
+        assert reloaded.use_case_profile.notes == "declared in audit.yaml"
+
+    def test_should_reject_an_invalid_use_case_block_in_the_config(self, audited) -> None:
+        """A typo in the config must fail validation rather than be ignored."""
+        _leakpro, _results, config_path = audited
+        config = yaml.safe_load(Path(config_path).read_text())
+        config["use_case"] = {"tolerated_fpr": E2E_ALPHA, "sensitivity": "high"}
+        with open(config_path, "w") as f:
+            yaml.safe_dump(config, f, sort_keys=False)
+
+        with pytest.raises(Exception, match="use_case|sensitivity"):
+            LeakPro(TinyImageInputHandler, str(config_path))

--- a/leakpro/tests/risk/test_policy.py
+++ b/leakpro/tests/risk/test_policy.py
@@ -1,0 +1,95 @@
+"""Tests for the advisory policy data and the renderers."""
+
+import pytest
+
+from leakpro.risk.assessment import assess_risk
+from leakpro.risk.policy import (
+    POLICY_VERSION,
+    SUGGESTED_SENSITIVITY_SCALE,
+    VULNERABILITY_BANDS,
+    VULNERABILITY_BANDS_SOURCE,
+    resolve_vulnerability_band,
+)
+from leakpro.risk.render import to_latex, to_markdown
+from leakpro.risk.schemas import UseCaseProfile
+
+
+class TestVulnerabilityBands:
+    """Bands label the measured lift only, and are explicitly advisory."""
+
+    @pytest.mark.parametrize(("lift", "label"), [
+        (0.5, "NONE"), (1.0, "LOW"), (2.9, "LOW"), (3.0, "MODERATE"),
+        (9.9, "MODERATE"), (10.0, "HIGH"), (99.9, "HIGH"), (100.0, "SEVERE"), (5000.0, "SEVERE"),
+    ])
+    def test_should_map_lift_to_the_documented_band(self, lift: float, label: str) -> None:
+        """Boundaries are inclusive at the lower bound, as documented."""
+        assert resolve_vulnerability_band(lift) == label
+
+    def test_should_accept_a_caller_supplied_band_table(self) -> None:
+        """Users must be able to substitute their own policy, since ours is not calibrated."""
+        custom = [(50.0, "UNACCEPTABLE"), (0.0, "ACCEPTABLE")]
+        assert resolve_vulnerability_band(60.0, custom) == "UNACCEPTABLE"
+        assert resolve_vulnerability_band(10.0, custom) == "ACCEPTABLE"
+
+    def test_should_declare_the_bands_as_heuristic(self) -> None:
+        """The provenance string must not claim a source the bands do not have."""
+        assert "heuristic" in VULNERABILITY_BANDS_SOURCE
+
+    def test_should_keep_bands_sorted_from_highest_bound_down(self) -> None:
+        """Resolution walks the table in order, so ordering is a correctness property."""
+        bounds = [bound for bound, _ in VULNERABILITY_BANDS]
+        assert bounds == sorted(bounds, reverse=True)
+
+    def test_should_expose_a_policy_version(self) -> None:
+        """Any emitted band must be traceable to a version of this table."""
+        assert POLICY_VERSION
+
+
+class TestSuggestedSensitivityScale:
+    """The suggested scale is sourced, unlike the bands."""
+
+    def test_should_offer_the_four_cnil_severity_levels(self) -> None:
+        """CNIL PIA-3 defines negligible, limited, significant and maximum."""
+        assert set(SUGGESTED_SENSITIVITY_SCALE) == {"negligible", "limited", "significant", "maximum"}
+
+    def test_should_increase_monotonically_with_severity(self) -> None:
+        """A scale that is not ordered would silently invert the loss magnitude."""
+        values = [SUGGESTED_SENSITIVITY_SCALE[k] for k in ("negligible", "limited", "significant", "maximum")]
+        assert values == sorted(values)
+
+
+class TestRendering:
+    """Both renderers must show the inputs next to any derived figure."""
+
+    def test_markdown_should_show_measured_declared_and_combined_sections(self, result) -> None:
+        """A reader must be able to see which half of the assessment each number came from."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, n_subjects=1000))
+        markdown = to_markdown(assessment)
+        assert "## Measured" in markdown
+        assert "## Declared" in markdown
+        assert "## Combined" in markdown
+        assert "## Assumptions" in markdown
+
+    def test_markdown_should_print_band_provenance_next_to_the_band(self, result) -> None:
+        """A bare band label with no policy is the failure mode this layer replaces."""
+        markdown = to_markdown(assess_risk([result], UseCaseProfile(tolerated_fpr=0.01)))
+        assert "heuristic" in markdown
+
+    def test_markdown_should_label_absent_figures_rather_than_printing_zero(self, result) -> None:
+        """A withheld figure must read as withheld, never as zero risk."""
+        markdown = to_markdown(assess_risk([result], UseCaseProfile(tolerated_fpr=0.01)))
+        assert "not reported" in markdown
+
+    def test_latex_should_produce_a_risk_section_with_assumptions(self, result) -> None:
+        """The PDF section carries the same assumption list as the JSON."""
+        latex = to_latex(assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, n_subjects=10)))
+        assert "\\section{Risk assessment}" in latex
+        assert "\\subsection*{Assumptions}" in latex
+        assert "\\begin{tabularx}" in latex
+
+    def test_latex_should_escape_special_characters_from_free_text(self, result) -> None:
+        """User notes containing LaTeX metacharacters must not break compilation."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, notes="100% of records & 50_000 subjects")
+        latex = to_latex(assess_risk([result], profile))
+        assert "100\\%" in latex or "100\\% of records" in latex
+        assert "50\\_000" in latex

--- a/leakpro/tests/risk/test_schemas.py
+++ b/leakpro/tests/risk/test_schemas.py
@@ -1,0 +1,76 @@
+"""Tests for the risk schemas, including the deliberate absence of defaults."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from leakpro.risk.assessment import assess_risk
+from leakpro.risk.schemas import RiskAssessment, UseCaseProfile
+
+
+class TestUseCaseProfile:
+    """Validation of the declared harm parameters."""
+
+    def test_should_require_the_operating_point(self) -> None:
+        """alpha has no default: the choice changes the headline number and belongs to the user."""
+        with pytest.raises(ValidationError, match="tolerated_fpr"):
+            UseCaseProfile()
+
+    def test_should_reject_unknown_fields(self) -> None:
+        """A typo in a profile must fail rather than be silently ignored."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(tolerated_fpr=0.01, sensitivity="high")
+
+    @pytest.mark.parametrize("alpha", [0.0, 1.0, -0.1, 1.5])
+    def test_should_reject_operating_points_outside_the_open_unit_interval(self, alpha: float) -> None:
+        """An FPR of 0 or 1 is not an operating point an attacker can occupy."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(tolerated_fpr=alpha)
+
+    @pytest.mark.parametrize("prior", [0.0, 1.0, -0.5])
+    def test_should_reject_priors_outside_the_open_unit_interval(self, prior: float) -> None:
+        """A prior of 0 or 1 makes precision undefined or trivial."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(tolerated_fpr=0.01, attacker_prior=prior)
+
+    @pytest.mark.parametrize("field", ["records_per_subject", "data_type_sensitivity", "subject_type_weight"])
+    def test_should_reject_non_positive_loss_magnitude_factors(self, field: str) -> None:
+        """A zero factor would silently zero out the whole loss magnitude product."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(**{"tolerated_fpr": 0.01, field: 0.0})
+
+    def test_should_default_to_neutral_factors_and_a_balanced_prior(self) -> None:
+        """Defaults are neutral, so an unconfigured profile weights nothing invisibly."""
+        profile = UseCaseProfile(tolerated_fpr=0.01)
+        assert (profile.data_type_sensitivity, profile.subject_type_weight, profile.records_per_subject) == (1.0, 1.0, 1.0)
+        assert profile.attacker_prior == 0.5
+        assert profile.cost_per_exposed_subject is None
+        assert profile.extrapolate_to_population is False
+
+    def test_should_reject_a_negative_cost(self) -> None:
+        """A negative cost per exposed subject is not a meaningful input."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(tolerated_fpr=0.01, cost_per_exposed_subject=-1.0)
+
+
+class TestRiskAssessmentSerialisation:
+    """Round-tripping an assessment through disk."""
+
+    def test_should_round_trip_through_json(self, result, tmp_path) -> None:
+        """A saved assessment must reload into an equal object, for later re-reporting."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, n_subjects=100))
+        path = tmp_path / "risk_assessment.json"
+        assessment.save(str(path))
+        assert RiskAssessment.load(str(path)).model_dump_json() == assessment.model_dump_json()
+
+    def test_should_write_all_three_blocks_plus_provenance(self, result, tmp_path) -> None:
+        """The file must be self-contained: measured, declared, combined, assumptions, versions."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01))
+        path = tmp_path / "risk_assessment.json"
+        assessment.save(str(path))
+        with open(path) as f:
+            payload = json.load(f)
+        assert set(payload) >= {"measured", "declared", "combined", "assumptions", "warnings",
+                                "policy_version", "leakpro_version"}
+        assert payload["assumptions"], "an assessment without stated assumptions is not auditable"

--- a/leakpro/tests/risk/test_vulnerability.py
+++ b/leakpro/tests/risk/test_vulnerability.py
@@ -1,0 +1,171 @@
+"""Tests for the measured block and its four guards."""
+
+import numpy as np
+import pytest
+
+from leakpro.risk.vulnerability import (
+    InvertedResultError,
+    NoUsableResultError,
+    UnresolvableOperatingPointError,
+    _tpr_at_fpr,
+    _tpr_from_fixed_table,
+    measure_mia,
+    result_from_mapping,
+    strongest_for_risk,
+)
+from leakpro.tests.risk.conftest import StubResult, make_result
+
+
+class TestMeasurement:
+    """Extraction of measured quantities from a result."""
+
+    def test_should_read_tpr_from_the_fixed_fpr_table_when_alpha_is_tabulated(self, result) -> None:
+        """The measured TPR should equal the result's own tabulated value at that operating point."""
+        measured = measure_mia(result, alpha=0.01)
+        assert measured.success_rate == pytest.approx(float(result.fixed_fpr_table["TPR@1%FPR"]))
+
+    def test_should_derive_advantage_and_lift_from_tpr_and_alpha(self, result) -> None:
+        """Advantage is TPR minus alpha and lift is their ratio."""
+        measured = measure_mia(result, alpha=0.01)
+        assert measured.advantage == pytest.approx(measured.success_rate - 0.01)
+        assert measured.lift == pytest.approx(measured.success_rate / 0.01)
+
+    def test_should_count_members_and_non_members_from_the_true_attribute(self, result) -> None:
+        """The live MIAResult stores membership in `true`, not `true_labels`."""
+        measured = measure_mia(result, alpha=0.01)
+        assert (measured.n_members_audit, measured.n_non_members_audit) == (400, 400)
+        assert measured.n_at_risk == 400
+
+    def test_should_count_exposed_members_at_the_operating_point(self, result) -> None:
+        """The exposed count is members scoring above the alpha quantile of the non-member signal."""
+        measured = measure_mia(result, alpha=0.01)
+        threshold = np.quantile(result.signal_values[result.true == 0], 0.99)
+        expected = int(np.count_nonzero((result.true == 1) & (result.signal_values > threshold)))
+        assert measured.n_exposed_audit == expected
+
+    def test_should_report_no_exposed_count_when_the_result_has_no_signal_values(self) -> None:
+        """A result without per-record scores yields rates but no absolute count."""
+        stub = StubResult("no-signals", fpr=[0.0, 0.01, 1.0], tpr=[0.0, 0.2, 1.0])
+        assert measure_mia(stub, alpha=0.01).n_exposed_audit is None
+
+
+class TestResolutionGuard:
+    """Guard 1: an FPR the audit set cannot express is not a measurement."""
+
+    def test_should_raise_when_alpha_is_finer_than_the_audit_set_can_resolve(self) -> None:
+        """200 non-members cannot express an FPR of 0.001, so asking for it must fail loudly."""
+        small = make_result(n_members=200, n_non_members=200)
+        with pytest.raises(UnresolvableOperatingPointError, match="not measurable"):
+            measure_mia(small, alpha=0.001)
+
+    def test_should_flag_instead_of_raising_when_not_strict(self) -> None:
+        """Non-strict callers get an explicit resolvable=False rather than a silent zero."""
+        small = make_result(n_members=200, n_non_members=200)
+        measured = measure_mia(small, alpha=0.001, strict=False)
+        assert measured.resolvable is False
+        assert measured.min_resolvable_fpr == pytest.approx(1 / 200)
+
+    def test_should_accept_alpha_exactly_at_the_resolution_limit(self) -> None:
+        """The boundary itself is measurable: 200 non-members can express an FPR of 0.005."""
+        small = make_result(n_members=200, n_non_members=200)
+        assert measure_mia(small, alpha=0.005).resolvable is True
+
+
+class TestOrientationGuard:
+    """Guard 2: an inverted ROC turns a real leak into a low-risk reading."""
+
+    def test_should_reject_an_inverted_result_and_name_the_attack(self) -> None:
+        """A result with AUC below 0.5 must be refused, with the attack named in the message."""
+        inverted = make_result(name="population", inverted=True)
+        assert inverted.roc_auc < 0.5
+        with pytest.raises(InvertedResultError, match="population"):
+            measure_mia(inverted, alpha=0.01)
+
+    def test_should_skip_inverted_results_when_selecting_the_strongest(self) -> None:
+        """Selection excludes inverted results instead of treating them as weak evidence."""
+        good = make_result(name="lira")
+        inverted = make_result(name="population", inverted=True)
+        best, skipped = strongest_for_risk([inverted, good], alpha=0.01)
+        assert best is good
+        assert any("population" in reason and "inverted" in reason for reason in skipped)
+
+    def test_should_raise_when_every_candidate_is_unusable(self) -> None:
+        """With nothing usable there is no fallback: refuse rather than report on an inverted result."""
+        with pytest.raises(NoUsableResultError):
+            strongest_for_risk([make_result(name="population", inverted=True)], alpha=0.01)
+
+
+class TestSelectionGuard:
+    """Guard 3: risk cares about the operating point, not average-case AUC."""
+
+    def test_should_prefer_the_attack_with_higher_tpr_at_alpha_over_higher_auc(self) -> None:
+        """A lower-AUC attack that wins at 1% FPR is the relevant one for risk."""
+        # Broad but shallow separation: high AUC, unremarkable at a strict threshold.
+        broad = StubResult("broad-auc", roc_auc=0.90, fpr=[0.0, 0.01, 0.5, 1.0], tpr=[0.0, 0.05, 0.85, 1.0])
+        # Narrow but extreme: lower AUC, far better at 1% FPR.
+        sharp = StubResult("sharp-tail", roc_auc=0.70, fpr=[0.0, 0.01, 0.5, 1.0], tpr=[0.0, 0.40, 0.60, 1.0])
+        best, _ = strongest_for_risk([broad, sharp], alpha=0.01)
+        assert best is sharp, "selection must not fall back to maximising ROC AUC"
+
+
+class TestUnitsGuard:
+    """Guard 4: TPR is a fraction everywhere in this layer."""
+
+    def test_should_read_a_fractional_fixed_fpr_table_unchanged(self) -> None:
+        """The live MIAResult tabulates fractions, which pass through as-is."""
+        assert _tpr_from_fixed_table({"TPR@1%FPR": 0.103}, 0.01) == pytest.approx(0.103)
+
+    def test_should_reject_a_percentage_valued_fixed_fpr_table(self) -> None:
+        """A percentage-valued table must fail rather than inflate the risk figure a hundredfold."""
+        with pytest.raises(ValueError, match="not a fraction"):
+            _tpr_from_fixed_table({"TPR@1%FPR": 10.3}, 0.01)
+
+    def test_should_accept_both_key_spellings_for_one_percent(self) -> None:
+        """Padded legacy keys and stripped live keys mean the same operating point."""
+        assert _tpr_from_fixed_table({"TPR@1.0%FPR": 0.2}, 0.01) == pytest.approx(0.2)
+
+    def test_should_raise_when_the_operating_point_is_not_tabulated(self) -> None:
+        """Asking for an untabulated alpha on a result without ROC arrays must fail explicitly."""
+        with pytest.raises(ValueError, match="tabulated operating points"):
+            _tpr_from_fixed_table({"TPR@1%FPR": 0.2}, 0.002)
+
+
+class TestSerialisedResults:
+    """The adapter used by the web app backend, which holds JSON rather than live objects."""
+
+    def test_should_measure_from_a_serialised_result(self, result) -> None:
+        """A round trip through the web app's serialisation must give the same measurement."""
+        payload = {
+            "attack_name": result.result_name,
+            "roc_auc": float(result.roc_auc),
+            "tpr_at_fpr": {k: float(v) for k, v in result.fixed_fpr_table.items()},
+            "fpr": result.fpr.tolist(),
+            "tpr": result.tpr.tolist(),
+            "signal_values": result.signal_values.tolist(),
+            "true_labels": result.true.tolist(),
+        }
+        direct = measure_mia(result, alpha=0.01)
+        adapted = measure_mia(result_from_mapping(payload), alpha=0.01)
+        assert adapted.success_rate == pytest.approx(direct.success_rate)
+        assert adapted.n_exposed_audit == direct.n_exposed_audit
+        assert adapted.n_members_audit == direct.n_members_audit
+
+    def test_should_reject_an_inverted_serialised_result(self) -> None:
+        """The guards apply to the web app path too, not just to live objects."""
+        payload = {"attack_name": "population", "roc_auc": 0.214, "true_labels": [1] * 10 + [0] * 10}
+        with pytest.raises(InvertedResultError, match="population"):
+            measure_mia(result_from_mapping(payload), alpha=0.01)
+
+
+class TestRocLookup:
+    """The local TPR-at-alpha helper."""
+
+    def test_should_return_the_max_tpr_among_points_within_alpha(self) -> None:
+        """Semantics match the library helper: maximum TPR over points with FPR <= alpha."""
+        fpr = np.array([0.0, 0.005, 0.01, 0.2])
+        tpr = np.array([0.0, 0.30, 0.25, 0.9])
+        assert _tpr_at_fpr(fpr, tpr, 0.01) == pytest.approx(0.30)
+
+    def test_should_return_zero_when_no_point_is_within_alpha(self) -> None:
+        """Zero here means unmeasurable, which is why the resolution guard exists above."""
+        assert _tpr_at_fpr(np.array([0.5, 1.0]), np.array([0.8, 1.0]), 0.001) == 0.0

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -270,6 +270,8 @@ from .models import (
     JobSummary,
     ModelAttackConfig,
     ModelInfo,
+    RiskRequest,
+    RiskResponse,
     TrainParams,
 )
 from .worker import run_audit_job
@@ -1172,6 +1174,56 @@ async def get_results(job_id: str) -> dict:
     for r in results:
         r["job_id"] = job_id
     return {"job_id": job_id, "results": results}
+
+
+@app.post("/jobs/{job_id}/risk", response_model=RiskResponse)
+async def assess_job_risk(job_id: str, req: RiskRequest) -> RiskResponse:
+    """Assess use-case risk for a finished job's attack results.
+
+    All scoring lives in leakpro.risk: this endpoint adapts the stored results, calls the library once
+    per model, and returns the assessments untouched. Nothing here decides what is risky.
+    """
+    from leakpro.risk import UseCaseProfile, assess_risk, result_from_mapping  # noqa: PLC0415
+
+    job = _get_job(job_id)
+    if job["status"] != JobStatus.done:
+        raise HTTPException(status_code=425, detail=f"Job status: {job['status']}")
+
+    profile_fields = req.model_dump(exclude={"model_name"})
+    try:
+        profile = UseCaseProfile(**profile_fields)
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=f"Invalid use-case profile: {e}") from e
+
+    assessments: dict[str, dict] = {}
+    unassessable: dict[str, str] = {}
+    for model in job.get("results", []):
+        name = model.get("model_name", "?")
+        if req.model_name is not None and name != req.model_name:
+            continue
+        results = [result_from_mapping(a) for a in model.get("attacks", [])]
+        if not results:
+            unassessable[name] = "no attack results"
+            continue
+        try:
+            gap = None
+            if model.get("train_accuracy") is not None and model.get("test_accuracy") is not None:
+                gap = float(model["train_accuracy"]) - float(model["test_accuracy"])
+            assessment = assess_risk(
+                results,
+                profile,
+                num_train=model.get("num_train"),
+                train_test_gap=gap,
+                dp_epsilon=model.get("target_epsilon"),
+                strict=False,
+            )
+            assessments[name] = assessment.model_dump()
+        except Exception as e:  # noqa: BLE001 - surfaced per model rather than failing the request
+            unassessable[name] = str(e)
+
+    if not assessments and not unassessable:
+        raise HTTPException(status_code=404, detail="No models found for this job")
+    return RiskResponse(job_id=job_id, assessments=assessments, unassessable=unassessable)
 
 
 @app.get("/jobs/{job_id}/sample_data/{index}")

--- a/leakpro/webapp/backend/models.py
+++ b/leakpro/webapp/backend/models.py
@@ -153,4 +153,37 @@ class ModelResult(BaseModel):
     model_class: str | None = None   # e.g. "ResNet18_DPsgd"
     job_id: str | None = None        # originating job, used for sample image URLs
     train_meta: dict | None = None   # epochs, lr, batch_size, optimizer, data info
+    num_train: int | None = None     # target training-set size, used to scale risk to the population
     attacks: list[AttackResult] = []
+
+
+# ---------------------------------------------------------------------------
+# Risk assessment — see leakpro/risk/. All scoring happens in the library; the
+# frontend posts a use-case profile and renders whatever comes back.
+# ---------------------------------------------------------------------------
+
+class RiskRequest(BaseModel):
+    """A use-case profile plus the model it applies to.
+
+    Field names and semantics mirror leakpro.risk.schemas.UseCaseProfile; validation happens there so
+    there is exactly one definition of a valid profile.
+    """
+
+    model_name: str | None = None    # None assesses every model in the job
+    tolerated_fpr: float             # required, deliberately no default
+    attacker_prior: float = 0.5
+    n_subjects: int | None = None
+    records_per_subject: float = 1.0
+    data_type_sensitivity: float = 1.0
+    subject_type_weight: float = 1.0
+    cost_per_exposed_subject: float | None = None
+    extrapolate_to_population: bool = False
+    notes: str = ""
+
+
+class RiskResponse(BaseModel):
+    """One assessment per model, plus any model that could not be assessed and why."""
+
+    job_id: str
+    assessments: dict[str, dict] = {}   # model_name -> RiskAssessment.model_dump()
+    unassessable: dict[str, str] = {}   # model_name -> reason

--- a/leakpro/webapp/backend/worker.py
+++ b/leakpro/webapp/backend/worker.py
@@ -401,6 +401,14 @@ def run_audit_job(
                     "n_samples":          _dm.get("n_samples"),
                 } if (_tp or _hc or _dm) else None
 
+                # Training-set size of the target, needed by leakpro.risk to scale exposure to the
+                # population. Read from the handler while it is still alive; saved results cannot
+                # recover it.
+                try:
+                    _num_train = int(lp.handler.target_model_metadata.num_train)
+                except Exception:  # noqa: BLE001 - metadata is optional for non-MIA handlers
+                    _num_train = None
+
                 model_results = {
                     "model_name": model_name,
                     "source": model_spec.get("source", "trained"),
@@ -410,6 +418,7 @@ def run_audit_job(
                     "test_accuracy": model_spec.get("test_accuracy"),
                     "model_class": _model_class,
                     "train_meta": _train_meta,
+                    "num_train": _num_train,
                     "attacks": [_serialise_result(r) for r in results],
                 }
                 all_results.append(model_results)

--- a/leakpro/webapp/frontend/src/api.ts
+++ b/leakpro/webapp/frontend/src/api.ts
@@ -84,6 +84,9 @@ export const api = {
 
   // Step 7
   getResults: (id: string) => get<{ job_id: string; results: ModelResult[] }>(`/jobs/${id}/results`),
+  // Risk assessment. All scoring happens in leakpro/risk on the backend; this posts the declared
+  // use-case profile and renders whatever comes back.
+  assessRisk: (id: string, profile: RiskRequest) => post<RiskResponse>(`/jobs/${id}/risk`, profile),
   getSampleData: (jobId: string, index: number) =>
     get<{ index: number; label: number; features: number[]; feature_names?: string[] }>(`/jobs/${jobId}/sample_data/${index}`),
 };
@@ -204,5 +207,67 @@ export interface ModelResult {
   model_class?: string;
   job_id?: string;
   train_meta?: TrainMeta;
+  num_train?: number;
   attacks: AttackResult[];
+}
+
+// ---------------------------------------------------------------------------
+// Risk assessment (mirrors leakpro/risk/schemas.py and backend models.py)
+// ---------------------------------------------------------------------------
+
+/** Declared harm parameters. Field names follow Sion et al.'s Loss Magnitude decomposition. */
+export interface RiskRequest {
+  model_name?: string;
+  tolerated_fpr: number;          // alpha; required on purpose, no default
+  attacker_prior?: number;        // pi
+  n_subjects?: number;            // NDS
+  records_per_subject?: number;   // NR
+  data_type_sensitivity?: number; // DTS
+  subject_type_weight?: number;   // DST
+  cost_per_exposed_subject?: number;
+  extrapolate_to_population?: boolean;
+  notes?: string;
+}
+
+export interface RiskMeasured {
+  attack_name: string;
+  operating_point: number;
+  success_rate: number;
+  advantage: number;
+  lift: number;
+  resolvable: boolean;
+  roc_auc?: number;
+  n_members_audit: number;
+  n_non_members_audit: number;
+  n_exposed_audit?: number;
+  min_resolvable_fpr: number;
+}
+
+export interface RiskCombined {
+  ppv?: number;
+  ppv_balanced?: number;
+  gamma: number;
+  loss_magnitude?: number;
+  loss_event_frequency: number;
+  risk?: number;
+  expected_exposed_subjects?: number;
+  expected_cost?: number;
+  extrapolated_exposed_records?: number;
+  vulnerability_band?: string;
+}
+
+export interface RiskAssessment {
+  measured: RiskMeasured;
+  declared: Record<string, unknown> & { n_subjects?: number; n_subjects_source: string; attacker_prior: number };
+  combined: RiskCombined;
+  assumptions: string[];
+  warnings: string[];
+  policy_version: string;
+  leakpro_version: string;
+}
+
+export interface RiskResponse {
+  job_id: string;
+  assessments: Record<string, RiskAssessment>;
+  unassessable: Record<string, string>;
 }

--- a/leakpro/webapp/frontend/src/components/InfoButton.tsx
+++ b/leakpro/webapp/frontend/src/components/InfoButton.tsx
@@ -79,3 +79,21 @@ export default function InfoButton({
     </>
   );
 }
+
+/**
+ * Progressive disclosure inside an info modal: a one-line lead stays visible, the depth is one click
+ * further in. Native details/summary so there is no state to manage and it stays keyboard-accessible.
+ */
+export function Detail({ children, label = "More detail" }: { children: React.ReactNode; label?: string }) {
+  return (
+    <details className="group">
+      <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden text-xs font-bold text-primary hover:underline">
+        {label}
+        <span className="material-symbols-outlined align-middle text-sm ml-0.5 group-open:rotate-180 transition-transform">
+          expand_more
+        </span>
+      </summary>
+      <div className="mt-2 flex flex-col gap-2 text-slate-500 dark:text-slate-300">{children}</div>
+    </details>
+  );
+}

--- a/leakpro/webapp/frontend/src/components/InfoButton.tsx
+++ b/leakpro/webapp/frontend/src/components/InfoButton.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import ReactDOM from "react-dom";
+
+/**
+ * A small info affordance: an unobtrusive icon that opens a modal with the long explanation.
+ *
+ * The point is to keep prose out of the first view. Anything that would make a panel feel like
+ * documentation belongs behind one of these, not inline.
+ */
+export default function InfoButton({
+  label,
+  title,
+  children,
+  className = "",
+}: {
+  /** Short name of the thing being explained. Used for the tooltip and the aria-label. */
+  label: string;
+  /** Modal heading. Defaults to the label. */
+  title?: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={`About ${label}`}
+        title={label}
+        onClick={(e) => { e.stopPropagation(); setOpen(true); }}
+        className={`material-symbols-outlined align-middle text-slate-400 hover:text-primary transition-colors leading-none ${className}`}
+        style={{ fontSize: "1rem" }}
+      >
+        info
+      </button>
+
+      {open && ReactDOM.createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-white dark:bg-surface rounded-2xl shadow-2xl w-full max-w-2xl flex flex-col overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-surface-border">
+              <h3 className="font-bold text-lg">{title ?? label}</h3>
+              <button
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                className="text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+              >
+                <span className="material-symbols-outlined">close</span>
+              </button>
+            </div>
+            <div className="px-6 py-5 overflow-y-auto max-h-[70vh] text-sm text-slate-600 dark:text-slate-200 flex flex-col gap-3">
+              {children}
+            </div>
+            <div className="flex justify-end px-6 py-4 border-t border-slate-200 dark:border-surface-border">
+              <button
+                onClick={() => setOpen(false)}
+                className="px-5 py-2 rounded-lg bg-slate-700 text-cream border border-primary text-sm font-bold hover:bg-slate-600 transition-colors"
+              >
+                Got it
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/leakpro/webapp/frontend/src/components/results/RiskDiagram.tsx
+++ b/leakpro/webapp/frontend/src/components/results/RiskDiagram.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+
+/**
+ * Schematic of the risk assessment model.
+ *
+ * The one thing the picture has to convey is the split: the left column is measured by this audit and
+ * reproducible, the right column is declared by you and is a value judgement. Everything below is a
+ * product of the two, which is why no single number can stand on its own.
+ *
+ * Structure follows Sion et al., "Privacy Risk Assessment for Data Subject-aware Threat Modeling"
+ * (IWPE 2019). Precision follows Jayaraman et al. (PoPETs 2021), Theorem 4.2.
+ *
+ * Two visual encodings, spelled out in the legend at the foot of the diagram:
+ *   role       dashed border = given value, solid border = computed value
+ *   provenance amber = measured by the audit, grey = declared by the user
+ *
+ * Layout rows (viewBox 720x400), kept disjoint so nothing overlaps at any width:
+ *   52..158  inputs   196..264  intermediate products   318..380  risk   400..411  legend
+ *
+ * Expected exposed subjects and attacker precision are deliberately NOT drawn here: neither is
+ * derived from Risk. Both come off the measured vulnerability directly (with NDS, or with alpha and
+ * pi), so putting them under Risk would assert a dependency the code does not have.
+ */
+export default function RiskDiagram({ className = "" }: { className?: string }) {
+  // Two independent visual encodings, explained by the legend at the foot of the diagram:
+  //   role       dashed border = a value that is given, solid border = a value that is computed
+  //   provenance amber = measured by the audit, grey = declared by the user
+  // Risk is the terminal calculation, so it is solid with a heavier accent stroke.
+  const measuredInput = "fill-amber-50 dark:fill-[#2d5867] stroke-primary";
+  const declaredInput = "fill-slate-50 dark:fill-[#1d3e4a] stroke-slate-400 dark:stroke-[#365d6c]";
+  const computed = "fill-white dark:fill-[#254c5b] stroke-slate-400 dark:stroke-[#365d6c]";
+  const computedFinal = "fill-white dark:fill-[#254c5b] stroke-primary";
+  const DASH = "5 4";
+
+  const heading = "fill-slate-500 dark:fill-slate-300";
+  const body = "fill-slate-700 dark:fill-slate-100";
+  const faint = "fill-slate-400 dark:fill-slate-400";
+  const line = "stroke-slate-400 dark:stroke-slate-500";
+  const tag = "fill-slate-400 dark:fill-slate-400";
+
+  const factors: Array<[string, string, number]> = [
+    ["DTS", "data type sensitivity", 88],
+    ["NR", "records per subject", 106],
+    ["DST", "subject type weight", 124],
+    ["NDS", "number of data subjects", 142],
+  ];
+
+  return (
+    <div className={`w-full overflow-x-auto ${className}`}>
+      <svg
+        viewBox="0 0 720 430"
+        role="img"
+        aria-label="Risk equals loss magnitude times loss event frequency. Loss event frequency comes from the attack success rate measured by this audit; loss magnitude comes from four factors you declare."
+        className="w-full min-w-[560px] h-auto font-display"
+      >
+        <defs>
+          <marker id="rd-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" className="fill-slate-400 dark:fill-slate-500" />
+          </marker>
+        </defs>
+
+        {/* Column headings */}
+        <text x="170" y="20" textAnchor="middle" className={heading} fontSize="12" fontWeight="700" letterSpacing="1.2">
+          MEASURED BY THIS AUDIT
+        </text>
+        <text x="170" y="36" textAnchor="middle" className={faint} fontSize="10.5">
+          re-run it and get the same number
+        </text>
+        <text x="550" y="20" textAnchor="middle" className={heading} fontSize="12" fontWeight="700" letterSpacing="1.2">
+          DECLARED BY YOU
+        </text>
+        <text x="550" y="36" textAnchor="middle" className={faint} fontSize="10.5">
+          your use case, which LeakPro cannot observe
+        </text>
+
+        <line x1="360" y1="46" x2="360" y2="300" className={line} strokeDasharray="4 5" strokeWidth="1" />
+
+        {/* INPUT, measured: vulnerability */}
+        <rect x="55" y="52" width="230" height="106" rx="10" className={measuredInput} strokeWidth="1.5" strokeDasharray={DASH} />
+        <text x="170" y="70" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">INPUT</text>
+        <text x="170" y="99" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Vulnerability (V)</text>
+        <text x="170" y="119" textAnchor="middle" className={body} fontSize="12" fontFamily="monospace">TPR at your chosen α</text>
+        <text x="170" y="137" textAnchor="middle" className={faint} fontSize="10">how often the best attack is right</text>
+
+        {/* INPUTS, declared: the four harm factors */}
+        <rect x="435" y="52" width="230" height="106" rx="10" className={declaredInput} strokeWidth="1.5" strokeDasharray={DASH} />
+        <text x="550" y="68" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">INPUTS</text>
+        {factors.map(([abbr, desc, y]) => (
+          <g key={abbr}>
+            <text x="455" y={y} className={body} fontSize="11.5" fontWeight="700" fontFamily="monospace">{abbr}</text>
+            <text x="497" y={y} className={faint} fontSize="10.5">{desc}</text>
+          </g>
+        ))}
+
+        {/* Down into the two products */}
+        <line x1="170" y1="158" x2="170" y2="194" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
+        <line x1="550" y1="158" x2="550" y2="194" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
+
+        {/* CALCULATED: Loss Event Frequency */}
+        <rect x="55" y="196" width="230" height="68" rx="10" className={computed} strokeWidth="1.5" />
+        <text x="170" y="212" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
+        <text x="170" y="230" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Event Frequency</text>
+        <text x="170" y="247" textAnchor="middle" className={body} fontSize="11.5" fontFamily="monospace">LEF = V × (RP × TEF)</text>
+        <text x="170" y="259" textAnchor="middle" className={faint} fontSize="9.5">RP × TEF assumed 1: a single attempt</text>
+
+        {/* CALCULATED: Loss Magnitude */}
+        <rect x="435" y="196" width="230" height="68" rx="10" className={computed} strokeWidth="1.5" />
+        <text x="550" y="212" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
+        <text x="550" y="230" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Magnitude</text>
+        <text x="550" y="247" textAnchor="middle" className={body} fontSize="11.5" fontFamily="monospace">LM = DTS × NR × DST × NDS</text>
+        <text x="550" y="259" textAnchor="middle" className={faint} fontSize="9.5">factors assumed independent</text>
+
+        {/* Join into risk */}
+        <path d="M 170 264 L 170 292 L 360 292" fill="none" className={line} strokeWidth="1.5" />
+        <path d="M 550 264 L 550 292 L 360 292" fill="none" className={line} strokeWidth="1.5" />
+        <line x1="360" y1="292" x2="360" y2="316" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
+
+        <rect x="245" y="318" width="230" height="62" rx="10" className={computedFinal} strokeWidth="2.5" />
+        <text x="360" y="334" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
+        <text x="360" y="353" textAnchor="middle" className={body} fontSize="14" fontWeight="700">Risk</text>
+        <text x="360" y="371" textAnchor="middle" className={body} fontSize="12" fontFamily="monospace">Risk = LEF × LM</text>
+
+        {/* Legend: the two encodings, role by border and provenance by colour */}
+        <rect x="118" y="400" width="16" height="11" rx="3" className={measuredInput} strokeWidth="1.5" strokeDasharray={DASH} />
+        <text x="140" y="409" className={faint} fontSize="10.5">measured input</text>
+        <rect x="252" y="400" width="16" height="11" rx="3" className={declaredInput} strokeWidth="1.5" strokeDasharray={DASH} />
+        <text x="274" y="409" className={faint} fontSize="10.5">your input</text>
+        <rect x="360" y="400" width="16" height="11" rx="3" className={computed} strokeWidth="1.5" />
+        <text x="382" y="409" className={faint} fontSize="10.5">calculated</text>
+        <rect x="470" y="400" width="16" height="11" rx="3" className={computedFinal} strokeWidth="2.5" />
+        <text x="492" y="409" className={faint} fontSize="10.5">final result</text>
+      </svg>
+    </div>
+  );
+}

--- a/leakpro/webapp/frontend/src/components/results/RiskDiagram.tsx
+++ b/leakpro/webapp/frontend/src/components/results/RiskDiagram.tsx
@@ -1,56 +1,38 @@
 import React from "react";
 
 /**
- * Schematic of the risk assessment model.
+ * Schematic of the risk assessment model, in three boxes.
  *
- * The one thing the picture has to convey is the split: the left column is measured by this audit and
- * reproducible, the right column is declared by you and is a value judgement. Everything below is a
- * product of the two, which is why no single number can stand on its own.
+ * The point the picture has to make is the split: the left branch is measured by this audit and
+ * reproducible, the right branch is declared by the user and is a value judgement, and Risk is their
+ * product.
+ *
+ * Factor names are spelled out in full. The abbreviations (LEF, LM, V, DTS, NR, DST, NDS) that the JSON
+ * output, the summary table and the papers use are defined in the info modals instead, to keep the
+ * picture to one line of text per idea.
  *
  * Structure follows Sion et al., "Privacy Risk Assessment for Data Subject-aware Threat Modeling"
- * (IWPE 2019). Precision follows Jayaraman et al. (PoPETs 2021), Theorem 4.2.
+ * (IWPE 2019).
  *
- * Two visual encodings, spelled out in the legend at the foot of the diagram:
- *   role       dashed border = given value, solid border = computed value
- *   provenance amber = measured by the audit, grey = declared by the user
- *
- * Layout rows (viewBox 720x400), kept disjoint so nothing overlaps at any width:
- *   52..158  inputs   196..264  intermediate products   318..380  risk   400..411  legend
- *
- * Expected exposed subjects and attacker precision are deliberately NOT drawn here: neither is
- * derived from Risk. Both come off the measured vulnerability directly (with NDS, or with alpha and
- * pi), so putting them under Risk would assert a dependency the code does not have.
+ * Layout rows (viewBox 720x260), kept disjoint so nothing overlaps at any width:
+ *   52..114  the two products    170..228  risk
  */
 export default function RiskDiagram({ className = "" }: { className?: string }) {
-  // Two independent visual encodings, explained by the legend at the foot of the diagram:
-  //   role       dashed border = a value that is given, solid border = a value that is computed
-  //   provenance amber = measured by the audit, grey = declared by the user
-  // Risk is the terminal calculation, so it is solid with a heavier accent stroke.
-  const measuredInput = "fill-amber-50 dark:fill-[#2d5867] stroke-primary";
-  const declaredInput = "fill-slate-50 dark:fill-[#1d3e4a] stroke-slate-400 dark:stroke-[#365d6c]";
-  const computed = "fill-white dark:fill-[#254c5b] stroke-slate-400 dark:stroke-[#365d6c]";
-  const computedFinal = "fill-white dark:fill-[#254c5b] stroke-primary";
-  const DASH = "5 4";
+  const measured = "fill-amber-50 dark:fill-[#2d5867] stroke-primary";
+  const declared = "fill-slate-50 dark:fill-[#1d3e4a] stroke-slate-400 dark:stroke-[#365d6c]";
+  const result = "fill-white dark:fill-[#254c5b] stroke-primary";
 
-  const heading = "fill-slate-500 dark:fill-slate-300";
+  const headingCls = "fill-slate-500 dark:fill-slate-300";
   const body = "fill-slate-700 dark:fill-slate-100";
   const faint = "fill-slate-400 dark:fill-slate-400";
   const line = "stroke-slate-400 dark:stroke-slate-500";
-  const tag = "fill-slate-400 dark:fill-slate-400";
-
-  const factors: Array<[string, string, number]> = [
-    ["DTS", "data type sensitivity", 88],
-    ["NR", "records per subject", 106],
-    ["DST", "subject type weight", 124],
-    ["NDS", "number of data subjects", 142],
-  ];
 
   return (
     <div className={`w-full overflow-x-auto ${className}`}>
       <svg
-        viewBox="0 0 720 430"
+        viewBox="0 0 720 246"
         role="img"
-        aria-label="Risk equals loss magnitude times loss event frequency. Loss event frequency comes from the attack success rate measured by this audit; loss magnitude comes from four factors you declare."
+        aria-label="Risk is loss event frequency times loss magnitude. Loss event frequency is vulnerability times retention period times threat event frequency, measured by this audit. Loss magnitude is data type sensitivity times records per subject times data subject type times number of data subjects, declared by you."
         className="w-full min-w-[560px] h-auto font-display"
       >
         <defs>
@@ -59,76 +41,40 @@ export default function RiskDiagram({ className = "" }: { className?: string }) 
           </marker>
         </defs>
 
-        {/* Column headings */}
-        <text x="170" y="20" textAnchor="middle" className={heading} fontSize="12" fontWeight="700" letterSpacing="1.2">
+        {/* Column headings carry the measured / declared distinction */}
+        <text x="180" y="20" textAnchor="middle" className={headingCls} fontSize="12" fontWeight="700" letterSpacing="1.2">
           MEASURED BY THIS AUDIT
         </text>
-        <text x="170" y="36" textAnchor="middle" className={faint} fontSize="10.5">
+        <text x="180" y="36" textAnchor="middle" className={faint} fontSize="10.5">
           re-run it and get the same number
         </text>
-        <text x="550" y="20" textAnchor="middle" className={heading} fontSize="12" fontWeight="700" letterSpacing="1.2">
+        <text x="540" y="20" textAnchor="middle" className={headingCls} fontSize="12" fontWeight="700" letterSpacing="1.2">
           DECLARED BY YOU
         </text>
-        <text x="550" y="36" textAnchor="middle" className={faint} fontSize="10.5">
+        <text x="540" y="36" textAnchor="middle" className={faint} fontSize="10.5">
           your use case, which LeakPro cannot observe
         </text>
 
-        <line x1="360" y1="46" x2="360" y2="300" className={line} strokeDasharray="4 5" strokeWidth="1" />
+        {/* Loss Event Frequency */}
+        <rect x="30" y="52" width="300" height="62" rx="10" className={measured} strokeWidth="1.5" />
+        <text x="180" y="74" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Event Frequency</text>
+        <text x="180" y="93" textAnchor="middle" className={body} fontSize="10.5">Vulnerability × Retention Period</text>
+        <text x="180" y="107" textAnchor="middle" className={body} fontSize="10.5">× Threat Event Frequency</text>
 
-        {/* INPUT, measured: vulnerability */}
-        <rect x="55" y="52" width="230" height="106" rx="10" className={measuredInput} strokeWidth="1.5" strokeDasharray={DASH} />
-        <text x="170" y="70" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">INPUT</text>
-        <text x="170" y="99" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Vulnerability (V)</text>
-        <text x="170" y="119" textAnchor="middle" className={body} fontSize="12" fontFamily="monospace">TPR at your chosen α</text>
-        <text x="170" y="137" textAnchor="middle" className={faint} fontSize="10">how often the best attack is right</text>
-
-        {/* INPUTS, declared: the four harm factors */}
-        <rect x="435" y="52" width="230" height="106" rx="10" className={declaredInput} strokeWidth="1.5" strokeDasharray={DASH} />
-        <text x="550" y="68" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">INPUTS</text>
-        {factors.map(([abbr, desc, y]) => (
-          <g key={abbr}>
-            <text x="455" y={y} className={body} fontSize="11.5" fontWeight="700" fontFamily="monospace">{abbr}</text>
-            <text x="497" y={y} className={faint} fontSize="10.5">{desc}</text>
-          </g>
-        ))}
-
-        {/* Down into the two products */}
-        <line x1="170" y1="158" x2="170" y2="194" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
-        <line x1="550" y1="158" x2="550" y2="194" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
-
-        {/* CALCULATED: Loss Event Frequency */}
-        <rect x="55" y="196" width="230" height="68" rx="10" className={computed} strokeWidth="1.5" />
-        <text x="170" y="212" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
-        <text x="170" y="230" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Event Frequency</text>
-        <text x="170" y="247" textAnchor="middle" className={body} fontSize="11.5" fontFamily="monospace">LEF = V × (RP × TEF)</text>
-        <text x="170" y="259" textAnchor="middle" className={faint} fontSize="9.5">RP × TEF assumed 1: a single attempt</text>
-
-        {/* CALCULATED: Loss Magnitude */}
-        <rect x="435" y="196" width="230" height="68" rx="10" className={computed} strokeWidth="1.5" />
-        <text x="550" y="212" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
-        <text x="550" y="230" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Magnitude</text>
-        <text x="550" y="247" textAnchor="middle" className={body} fontSize="11.5" fontFamily="monospace">LM = DTS × NR × DST × NDS</text>
-        <text x="550" y="259" textAnchor="middle" className={faint} fontSize="9.5">factors assumed independent</text>
+        {/* Loss Magnitude */}
+        <rect x="390" y="52" width="300" height="62" rx="10" className={declared} strokeWidth="1.5" />
+        <text x="540" y="74" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Magnitude</text>
+        <text x="540" y="93" textAnchor="middle" className={body} fontSize="10.5">Data Type Sensitivity × Records per Subject</text>
+        <text x="540" y="107" textAnchor="middle" className={body} fontSize="10.5">× Data Subject Type × Number of Data Subjects</text>
 
         {/* Join into risk */}
-        <path d="M 170 264 L 170 292 L 360 292" fill="none" className={line} strokeWidth="1.5" />
-        <path d="M 550 264 L 550 292 L 360 292" fill="none" className={line} strokeWidth="1.5" />
-        <line x1="360" y1="292" x2="360" y2="316" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
+        <path d="M 180 114 L 180 142 L 360 142" fill="none" className={line} strokeWidth="1.5" />
+        <path d="M 540 114 L 540 142 L 360 142" fill="none" className={line} strokeWidth="1.5" />
+        <line x1="360" y1="142" x2="360" y2="168" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
 
-        <rect x="245" y="318" width="230" height="62" rx="10" className={computedFinal} strokeWidth="2.5" />
-        <text x="360" y="334" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
-        <text x="360" y="353" textAnchor="middle" className={body} fontSize="14" fontWeight="700">Risk</text>
-        <text x="360" y="371" textAnchor="middle" className={body} fontSize="12" fontFamily="monospace">Risk = LEF × LM</text>
-
-        {/* Legend: the two encodings, role by border and provenance by colour */}
-        <rect x="118" y="400" width="16" height="11" rx="3" className={measuredInput} strokeWidth="1.5" strokeDasharray={DASH} />
-        <text x="140" y="409" className={faint} fontSize="10.5">measured input</text>
-        <rect x="252" y="400" width="16" height="11" rx="3" className={declaredInput} strokeWidth="1.5" strokeDasharray={DASH} />
-        <text x="274" y="409" className={faint} fontSize="10.5">your input</text>
-        <rect x="360" y="400" width="16" height="11" rx="3" className={computed} strokeWidth="1.5" />
-        <text x="382" y="409" className={faint} fontSize="10.5">calculated</text>
-        <rect x="470" y="400" width="16" height="11" rx="3" className={computedFinal} strokeWidth="2.5" />
-        <text x="492" y="409" className={faint} fontSize="10.5">final result</text>
+        <rect x="200" y="170" width="320" height="58" rx="10" className={result} strokeWidth="2.5" />
+        <text x="360" y="192" textAnchor="middle" className={body} fontSize="14" fontWeight="700">Risk</text>
+        <text x="360" y="212" textAnchor="middle" className={body} fontSize="11.5">Loss Event Frequency × Loss Magnitude</text>
       </svg>
     </div>
   );

--- a/leakpro/webapp/frontend/src/components/results/Summary.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Summary.tsx
@@ -1,77 +1,378 @@
 import React, { useState } from "react";
-import { ModelResult } from "../../api";
+import { api, ModelResult, RiskAssessment, RiskRequest } from "../../api";
+import InfoButton from "../InfoButton";
 import MetaPanel from "./MetaPanel";
+import RiskDiagram from "./RiskDiagram";
 
-interface Props { results: ModelResult[] }
+/**
+ * Risk is never scored here. The measured half (TPR at the chosen operating point) comes straight from
+ * the audit, and the harm half is declared by the user and combined by leakpro/risk on the backend.
+ * This file only displays what it is given, which is why there is no threshold table in it.
+ *
+ * Presentation rule: the first view shows numbers, not prose. Every explanation lives behind an
+ * InfoButton. The one exception is warnings — those stay visible as a chip, because a caveat like
+ * "this operating point was not measurable" must not be something the reader has to go looking for.
+ *
+ * Risk state lives in the parent (Step7Results), not here. The tab bar unmounts this component when
+ * the user switches tabs, so local state would silently discard a completed assessment.
+ */
 
-function riskLevel(auc: number | undefined): { label: string; color: string; bg: string } {
-  if (auc === undefined) return { label: "N/A", color: "text-slate-400", bg: "bg-slate-100 dark:bg-surface-2" };
-  if (auc >= 0.75)        return { label: "HIGH",   color: "text-red-500",    bg: "bg-red-500/10 border border-red-500/30" };
-  if (auc >= 0.60)        return { label: "MEDIUM", color: "text-orange-500", bg: "bg-orange-500/10 border border-orange-500/30" };
-  return                         { label: "LOW",    color: "text-green-500",  bg: "bg-green-500/10 border border-green-500/30" };
+export interface RiskState {
+  draft: RiskRequest;
+  applied: RiskRequest | null;
+  /** Keyed by `${job_id}/${model_name}` — model names are not unique across jobs in compare mode. */
+  assessments: Record<string, RiskAssessment>;
+  unassessable: Record<string, string>;
+  error: string | null;
 }
 
-function bestAuc(model: ModelResult): number | undefined {
-  const vals = model.attacks.map((a) => a.roc_auc).filter((v): v is number => v !== null && v !== undefined);
-  return vals.length ? Math.max(...vals) : undefined;
+export const initialRiskState: RiskState = {
+  draft: {
+    tolerated_fpr: 0.01,
+    attacker_prior: 0.5,
+    records_per_subject: 1,
+    data_type_sensitivity: 1,
+    subject_type_weight: 1,
+    extrapolate_to_population: false,
+    notes: "",
+  },
+  applied: null,
+  assessments: {},
+  unassessable: {},
+  error: null,
+};
+
+interface Props {
+  results: ModelResult[];
+  risk: RiskState;
+  onRiskChange: (next: RiskState) => void;
 }
 
-function bestTpr(model: ModelResult): { value: number; attack: string } | undefined {
+function modelKey(m: ModelResult) {
+  return `${m.job_id ?? ""}/${m.model_name}`;
+}
+
+const ALPHAS = [
+  { value: 0.01, label: "1%" },
+  { value: 0.001, label: "0.1%" },
+  { value: 0.0001, label: "0.01%" },
+];
+
+const PRIORS = [
+  { value: 0.5, label: "0.5 — balanced" },
+  { value: 0.1, label: "0.1" },
+  { value: 0.01, label: "0.01" },
+  { value: 0.001, label: "0.001" },
+];
+
+// CNIL PIA-3 severity levels, offered as a starting scale. See leakpro/risk/policy.py.
+const SENSITIVITY = [
+  { value: 1, label: "1 — Negligible" },
+  { value: 2, label: "2 — Limited" },
+  { value: 3, label: "3 — Significant" },
+  { value: 4, label: "4 — Maximum" },
+];
+
+const BAND_STYLE: Record<string, { color: string; bg: string }> = {
+  SEVERE: { color: "text-red-500", bg: "bg-red-500/10 border border-red-500/30" },
+  HIGH: { color: "text-orange-500", bg: "bg-orange-500/10 border border-orange-500/30" },
+  MODERATE: { color: "text-amber-500", bg: "bg-amber-500/10 border border-amber-500/30" },
+  LOW: { color: "text-green-500", bg: "bg-green-500/10 border border-green-500/30" },
+  NONE: { color: "text-slate-400", bg: "bg-slate-100 dark:bg-surface-2" },
+};
+
+function bandStyle(band?: string) {
+  return (band && BAND_STYLE[band]) || BAND_STYLE.NONE;
+}
+
+function pct(v: number | undefined | null) {
+  return v != null ? (v * 100).toFixed(1) + "%" : "—";
+}
+
+function num(v: number | undefined | null, digits = 0) {
+  return v != null ? v.toLocaleString(undefined, { maximumFractionDigits: digits }) : "—";
+}
+
+/** Best TPR at a given operating point across a model's attacks, for the pre-assessment view. */
+function bestTpr(model: ModelResult, alpha: number): { value: number; attack: string } | undefined {
+  const key = alpha === 0.01 ? "TPR@1%FPR" : alpha === 0.001 ? "TPR@0.1%FPR" : "TPR@0.01%FPR";
   let best: { value: number; attack: string } | undefined;
   model.attacks.forEach((a) => {
-    const v = a.tpr_at_fpr?.["TPR@0.1%FPR"];
-    if (v != null && (best === undefined || v > best.value))
-      best = { value: v, attack: a.attack_name };
+    // Attacks with an inverted ROC are excluded, matching the backend's guard: an AUC below 0.5 means
+    // a real leak would read as no leak.
+    if (a.roc_auc != null && a.roc_auc < 0.5) return;
+    const v = a.tpr_at_fpr?.[key];
+    if (v != null && (best === undefined || v > best.value)) best = { value: v, attack: a.attack_name };
   });
   return best;
 }
 
-function pct(v: number | undefined) {
-  return v !== undefined ? (v * 100).toFixed(1) + "%" : "—";
-}
+// ---------------------------------------------------------------------------
+// Explanation content. Kept here, out of the layout, so the panels stay readable.
+// ---------------------------------------------------------------------------
 
-export default function Summary({ results }: Props) {
+const HOW_IT_WORKS = (
+  <>
+    <p>
+      The audit measures how often an attack correctly identifies a training member. Whether that
+      matters depends on your deployment, which LeakPro cannot observe. So the assessment keeps the two
+      halves apart and combines them without inventing any weights.
+    </p>
+    <RiskDiagram className="my-1" />
+    <p>
+      <b>Nothing is hidden in a coefficient.</b> Every number is either measured by this audit or
+      declared by you, and the result lists the assumption behind each derived figure.
+    </p>
+    <p>
+      <b>Why Loss Event Frequency is just the measured success rate.</b> In the published model,
+      <code> LEF = V × (RP × TEF)</code>, where <b>RP</b> is the <i>retention period</i> — how long the
+      data stays available to be attacked — and <b>TEF</b> is the <i>threat event frequency</i>, how
+      often an adversary tries. LeakPro can observe neither, so both are set to 1: a single attack
+      attempt against a model that is retained. If repeated attempts are plausible in your setting,
+      the real frequency is higher than this assessment assumes, and you should scale it up yourself.
+    </p>
+    <p className="text-xs text-slate-400">
+      Structure: Sion, Van Landuyt, Wuyts &amp; Joosen, “Privacy Risk Assessment for Data
+      Subject-aware Threat Modeling”, IWPE 2019. Precision: Jayaraman, Wang, Knipmeyer, Gu &amp; Evans,
+      “Revisiting Membership Inference Under Realistic Assumptions”, PoPETs 2021, Theorem 4.2.
+      Sensitivity scale: CNIL PIA-3 knowledge bases, 2018.
+    </p>
+  </>
+);
+
+const ABOUT_ALPHA = (
+  <>
+    <p>
+      α is the false-positive rate the attacker is assumed to tolerate. It sets the operating point the
+      whole assessment is read at, so there is no default: the choice is yours.
+    </p>
+    <ul className="list-disc ml-5 flex flex-col gap-1">
+      <li><b>1%</b> — resolvable on the audit set sizes most targets have. Start here.</li>
+      <li><b>0.1%</b> — stricter. Needs at least 1000 non-members to be measurable at all.</li>
+      <li><b>0.01%</b> — very strict. Needs at least 10000 non-members.</li>
+    </ul>
+    <p>
+      Below the resolution of your audit set, a true positive rate of zero means “not measurable”, not
+      “no leakage”. The backend refuses to report derived figures there rather than let you read a zero
+      as safety.
+    </p>
+  </>
+);
+
+const ABOUT_PRIOR = (
+  <>
+    <p>
+      π is the share of the attacker’s candidate pool that really are members. It does not change the
+      measurement; it changes what the measurement means.
+    </p>
+    <p>
+      The audit runs on a balanced split, so every TPR and AUC it reports implicitly assumes π = 0.5.
+      Real pools are usually far more skewed, and precision falls steeply as they are. At a 1%
+      false-positive rate and a measured TPR of 10%, an attacker is right 91% of the time at π = 0.5 —
+      and about 1% of the time at π = 0.001.
+    </p>
+    <p>Both values are always reported, so a balanced-prior figure can never be quoted by accident.</p>
+  </>
+);
+
+const ABOUT_FACTORS = (
+  <>
+    <p>
+      These four are the Loss Magnitude factors from Sion et al.: <code>LM = DTS × NR × DST × NDS</code>.
+      The paper deliberately supplies no numeric values for them, so they are yours to set. All default
+      to a neutral 1.0, which reduces the loss magnitude to a plain count of subjects.
+    </p>
+    <ul className="list-disc ml-5 flex flex-col gap-1">
+      <li><b>DTS</b> — sensitivity of the leaked data type. The CNIL PIA severity levels are a defensible starting scale.</li>
+      <li><b>NR</b> — records of this data type per subject. Fractions are fine when only some subjects contribute it.</li>
+      <li><b>DST</b> — weight for the subject type. Raise it for vulnerable subjects such as minors or patients.</li>
+      <li><b>NDS</b> — number of data subjects. Left blank, the target’s training-set size is used.</li>
+    </ul>
+    <p className="text-xs text-slate-400">
+      Sion et al. note the model assumes these factors are independent, which they flag as a
+      simplification of reality. That assumption is recorded in every assessment.
+    </p>
+  </>
+);
+
+const ABOUT_TPR = (
+  <p>
+    Of all the training members in the audit set, the share the strongest attack correctly identifies
+    while keeping its false-positive rate at or below α. Attacks whose ROC is inverted (AUC below 0.5)
+    are excluded rather than counted as weak evidence.
+  </p>
+);
+
+const ABOUT_LIFT = (
+  <p>
+    How many times better than random guessing the attack is at this operating point: TPR divided by α.
+    A lift of 1× is no better than chance. The band label is derived from this figure alone, and it is
+    an unsourced convenience — no published thresholds exist for it.
+  </p>
+);
+
+const ABOUT_PPV = (
+  <>
+    <p>
+      If the attacker claims a record was in the training set, how often are they right? This is the
+      number that decides whether a leak is actionable, and it depends on your declared prior π as much
+      as on the attack.
+    </p>
+    <p className="font-mono text-xs">PPV = TPR / (TPR + γ·α), γ = (1 − π) / π</p>
+    <p>
+      <b>γ is how outnumbered the members are:</b> for every genuine member in the attacker’s candidate
+      pool there are γ non-members. It is derived from your π, not a separate input — π = 0.5 gives
+      γ = 1, π = 0.01 gives γ = 99, π = 0.001 gives γ = 999.
+    </p>
+    <p>
+      That is why it multiplies the false-positive rate. At π = 0.001 with a measured TPR of 10% and
+      α = 1%, each member yields 0.10 expected true positives while the 999 non-members yield
+      999 × 0.01 = 9.99 false ones — about ten false alarms per correct hit, so precision is roughly
+      1%. The identical measurement reads 91% at π = 0.5.
+    </p>
+    <p className="text-xs text-slate-400">
+      A tenfold more skewed pool costs as much precision as a tenfold looser threshold, which is the
+      same reason strict operating points matter.
+    </p>
+  </>
+);
+
+const ABOUT_EXPOSED = (
+  <>
+    <p>
+      The measured success rate applied to your declared population: how many subjects an attacker would
+      be expected to identify. Sensitivity weights are deliberately left out of this figure so it stays
+      a plain count you can reason about.
+    </p>
+    <p>
+      <b>This count does not depend on π, and should not.</b> The true positive rate is conditional on a
+      record actually being a member, so it is unaffected by how the attacker’s pool is composed —
+      which means this figure already counts true positives only. Multiplying it by precision would be
+      circular, since precision times the flagged set <i>is</i> the true-positive count.
+    </p>
+    <p>
+      A skewed prior does not reduce how many members are genuinely identified; it increases the false
+      accusations sitting alongside them. So read the two columns as different questions: this one is
+      how many people the attack really exposes, precision is how far an attacker can trust any single
+      claim. “1000 exposed at 1% precision” and “40 exposed at 99% precision” are both real findings,
+      and they call for different responses.
+    </p>
+  </>
+);
+
+const ABOUT_BAND = (
+  <p>
+    An advisory label over the measured lift only, never over the combination of measurement and
+    judgement. The thresholds are round numbers chosen so that NONE means no better than chance and
+    SEVERE means two orders of magnitude better than chance. They are not calibrated against anything
+    published, which is why the policy version travels with every assessment.
+  </p>
+);
+
+export default function Summary({ results, risk, onRiskChange }: Props) {
+  // Ephemeral view state only. Anything the user would be annoyed to lose lives in `risk`.
   const [openKey, setOpenKey] = useState<string | null>(null);
+  const [wizard, setWizard] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [details, setDetails] = useState<string | null>(null);
 
+  const { draft, applied, assessments, unassessable, error } = risk;
+  const setDraft = (next: RiskRequest) => onRiskChange({ ...risk, draft: next });
+
+  const alpha = applied?.tolerated_fpr ?? draft.tolerated_fpr;
   const toggleInfo = (key: string) => setOpenKey((prev) => (prev === key ? null : key));
 
+  const submit = async () => {
+    // Compare mode can show models from several jobs, and the endpoint is per job, so assess each job
+    // the visible models come from and merge under composite keys.
+    const jobIds = Array.from(new Set(results.map((m) => m.job_id).filter((v): v is string => !!v)));
+    if (!jobIds.length) {
+      onRiskChange({ ...risk, error: "No job id on these results." });
+      return;
+    }
+    setBusy(true);
+    onRiskChange({ ...risk, error: null });
+    try {
+      const responses = await Promise.all(jobIds.map((id) => api.assessRisk(id, draft)));
+      const assessed: Record<string, RiskAssessment> = {};
+      const failed: Record<string, string> = {};
+      responses.forEach((res, i) => {
+        Object.entries(res.assessments).forEach(([name, a]) => { assessed[`${jobIds[i]}/${name}`] = a; });
+        Object.entries(res.unassessable).forEach(([name, why]) => { failed[`${jobIds[i]}/${name}`] = why; });
+      });
+      onRiskChange({ ...risk, assessments: assessed, unassessable: failed, applied: draft, error: null });
+      setWizard(false);
+    } catch (e) {
+      onRiskChange({ ...risk, error: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const downloadCSV = () => {
-    const rows = ["model,model_class,tpr_at_0.1pct_fpr,train_accuracy,test_accuracy,dpsgd,risk"];
+    const header = [
+      "model", "model_class", "alpha", "tpr_at_alpha", "advantage", "lift", "roc_auc",
+      "train_accuracy", "test_accuracy", "dpsgd", "attacker_prior", "ppv", "ppv_at_balanced_prior",
+      "n_subjects", "loss_magnitude", "risk_lm_x_lef", "expected_exposed_subjects", "expected_cost",
+      "vulnerability_band", "policy_version",
+    ];
+    const rows = [header.join(",")];
     results.forEach((m) => {
-      const auc = bestAuc(m);
-      const tpr = bestTpr(m);
-      const { label } = riskLevel(auc);
+      const a = assessments[modelKey(m)];
+      const tpr = bestTpr(m, alpha);
       rows.push([
         m.model_name,
         m.model_class ?? "",
-        tpr?.value.toFixed(6) ?? "",
+        alpha,
+        a?.measured.success_rate?.toFixed(6) ?? tpr?.value.toFixed(6) ?? "",
+        a?.measured.advantage?.toFixed(6) ?? "",
+        a?.measured.lift?.toFixed(3) ?? "",
+        a?.measured.roc_auc?.toFixed(6) ?? "",
         m.train_accuracy?.toFixed(6) ?? "",
         m.test_accuracy?.toFixed(6) ?? "",
         m.dpsgd ? `eps=${m.target_epsilon}` : "No",
-        label,
+        a?.declared.attacker_prior ?? "",
+        a?.combined.ppv?.toFixed(6) ?? "",
+        a?.combined.ppv_balanced?.toFixed(6) ?? "",
+        a?.declared.n_subjects ?? "",
+        a?.combined.loss_magnitude?.toFixed(2) ?? "",
+        a?.combined.risk?.toFixed(2) ?? "",
+        a?.combined.expected_exposed_subjects?.toFixed(2) ?? "",
+        a?.combined.expected_cost?.toFixed(2) ?? "",
+        a?.combined.vulnerability_band ?? "",
+        a?.policy_version ?? "",
       ].join(","));
     });
     const blob = new Blob([rows.join("\n")], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement("a"); a.href = url;
-    a.download = "leakpro_summary.csv"; a.click();
+    const el = document.createElement("a"); el.href = url;
+    el.download = "leakpro_summary.csv"; el.click();
     URL.revokeObjectURL(url);
   };
 
+  const alphaLabel = ALPHAS.find((a) => a.value === alpha)?.label ?? `${alpha * 100}%`;
+  const shown = details ? assessments[details] : undefined;
+
   return (
     <div className="flex flex-col gap-8">
-      {/* Risk cards */}
+      {/* Cards: measured lift until a use case is declared, band afterwards */}
       {results.length > 1 && (
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           {results.map((m) => {
-            const auc = bestAuc(m);
-            const { label, color, bg } = riskLevel(auc);
+            const a = assessments[modelKey(m)];
+            const tpr = bestTpr(m, alpha);
+            const style = bandStyle(a?.combined.vulnerability_band);
             return (
-              <div key={`${m.job_id}/${m.model_name}`} className={`rounded-xl p-4 ${bg}`}>
-                <p className={`text-2xl font-black ${color}`}>{label}</p>
-                <p className="font-bold text-sm mt-1">{m.model_name}</p>
+              <div key={modelKey(m)}
+                   className={a ? `rounded-xl p-4 ${style.bg}` : "rounded-xl p-4 bg-slate-50 dark:bg-surface border border-slate-200 dark:border-surface-border"}>
+                <p className={`text-2xl font-black ${a ? style.color : "text-primary"}`}>
+                  {a ? a.combined.vulnerability_band : `${num(tpr ? tpr.value / alpha : undefined, 1)}×`}
+                </p>
+                <p className="text-[11px] uppercase tracking-wider text-slate-400 -mt-0.5">
+                  {a ? "vulnerability" : "vs random"}
+                </p>
+                <p className="font-bold text-sm mt-2">{m.model_name}</p>
                 {m.model_class && <p className="text-xs font-mono text-slate-400 mt-0.5">{m.model_class}</p>}
-                <p className="text-xs text-slate-500 mt-1">AUC {auc?.toFixed(3) ?? "—"}</p>
                 {m.dpsgd && <p className="text-xs text-blue-500 mt-1">DP-SGD{m.target_epsilon != null ? ` ε=${m.target_epsilon}` : ""}</p>}
               </div>
             );
@@ -79,8 +380,44 @@ export default function Summary({ results }: Props) {
         </div>
       )}
 
+      {/* Risk bar. One line of text, everything else behind the info button. */}
+      <div className="flex items-center justify-between gap-3 flex-wrap rounded-xl border border-slate-200 dark:border-surface-border bg-slate-50 dark:bg-surface px-4 py-3">
+        <div>
+          <p className="font-bold text-sm flex items-center gap-1">
+            Risk assessment
+            <InfoButton label="How risk is computed" title="How risk is computed">{HOW_IT_WORKS}</InfoButton>
+          </p>
+          <p className="text-xs text-slate-400">
+            {applied
+              ? `α = ${alphaLabel} FPR · π = ${applied.attacker_prior} · policy ${Object.values(assessments)[0]?.policy_version ?? "—"}`
+              : "Measured leakage is above. Add your use case to turn it into risk."}
+          </p>
+        </div>
+        <button
+          onClick={() => setWizard(true)}
+          className="px-3 py-1.5 rounded-lg bg-primary text-white text-xs font-bold hover:opacity-90 transition-opacity"
+        >
+          {applied ? "Change inputs" : "Declare your use case"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-500">{error}</div>
+      )}
+
+      {Object.entries(unassessable).length > 0 && (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm">
+          <p className="font-bold text-amber-500 mb-1">Not assessable</p>
+          <ul className="list-disc ml-5 text-slate-600 dark:text-slate-300">
+            {Object.entries(unassessable).map(([key, reason]) => (
+              <li key={key}><b>{key.slice(key.indexOf("/") + 1)}</b>: {reason}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {/* Comparison table */}
-      <div className="rounded-xl border border-slate-200 dark:border-surface-border overflow-hidden">
+      <div className="rounded-xl border border-slate-200 dark:border-surface-border overflow-hidden overflow-x-auto">
         <div className="flex items-center justify-between px-3 py-2 bg-slate-50 dark:bg-surface border-b border-slate-200 dark:border-surface-border">
           <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Summary</span>
           <button
@@ -95,19 +432,30 @@ export default function Summary({ results }: Props) {
           <thead className="bg-slate-50 dark:bg-surface border-b border-slate-200 dark:border-surface-border">
             <tr>
               <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Model</th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">TPR@0.1%FPR</th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Train Acc</th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Test Acc</th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                TPR@{alphaLabel} <InfoButton label={`TPR at ${alphaLabel} FPR`}>{ABOUT_TPR}</InfoButton>
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                Lift <InfoButton label="Lift over random guessing">{ABOUT_LIFT}</InfoButton>
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                Precision <InfoButton label="Attacker precision (PPV)">{ABOUT_PPV}</InfoButton>
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                Exposed <InfoButton label="Expected exposed subjects">{ABOUT_EXPOSED}</InfoButton>
+              </th>
               <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">DP-SGD</th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Risk</th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                Band <InfoButton label="Vulnerability band">{ABOUT_BAND}</InfoButton>
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200 dark:divide-surface-border">
             {results.map((m) => {
-              const key = `${m.job_id}/${m.model_name}`;
-              const auc = bestAuc(m);
-              const tpr = bestTpr(m);
-              const { label, color } = riskLevel(auc);
+              const key = modelKey(m);
+              const a = assessments[key];
+              const tpr = bestTpr(m, alpha);
+              const style = bandStyle(a?.combined.vulnerability_band);
               const isOpen = openKey === key;
               return (
                 <React.Fragment key={key}>
@@ -127,23 +475,54 @@ export default function Summary({ results }: Props) {
                         >
                           info
                         </button>
+                        {a && (
+                          <button
+                            onClick={() => setDetails(key)}
+                            title="How this was computed"
+                            className="material-symbols-outlined text-base text-slate-400 hover:text-primary transition-colors"
+                          >
+                            calculate
+                          </button>
+                        )}
+                        {a && a.warnings.length > 0 && (
+                          <button
+                            onClick={() => setDetails(key)}
+                            title="Show caveats"
+                            className="px-1.5 py-0.5 rounded text-[11px] font-bold bg-amber-500/15 text-amber-600 dark:text-amber-400 border border-amber-500/30 hover:bg-amber-500/25 transition-colors"
+                          >
+                            {a.warnings.length} caveat{a.warnings.length > 1 ? "s" : ""}
+                          </button>
+                        )}
                       </div>
                     </td>
                     <td className="px-4 py-3 font-mono">
                       {tpr !== undefined
-                        ? <>{(tpr.value * 100).toFixed(2)}% <span className="text-slate-400 font-sans text-xs">({tpr.attack})</span></>
+                        ? <>{pct(tpr.value)} <span className="text-slate-400 font-sans text-xs">({tpr.attack})</span></>
                         : "—"}
                     </td>
-                    <td className="px-4 py-3 font-mono">{pct(m.train_accuracy)}</td>
-                    <td className="px-4 py-3 font-mono">{pct(m.test_accuracy)}</td>
-                    <td className="px-4 py-3">{m.dpsgd ? <span className="text-blue-500 font-semibold">{m.target_epsilon != null ? `ε=${m.target_epsilon}` : "Yes"}</span> : <span className="text-slate-400">No</span>}</td>
-                    <td className="px-4 py-3"><span className={`font-bold ${color}`}>{label}</span></td>
+                    <td className="px-4 py-3 font-mono">{tpr ? `${num(tpr.value / alpha, 1)}×` : "—"}</td>
+                    <td className="px-4 py-3 font-mono">
+                      {a?.combined.ppv != null
+                        ? <>{pct(a.combined.ppv)} <span className="text-slate-400 font-sans text-xs">(π={a.declared.attacker_prior})</span></>
+                        : <span className="text-slate-400 font-sans text-xs">—</span>}
+                    </td>
+                    <td className="px-4 py-3 font-mono">
+                      {a?.combined.expected_exposed_subjects != null ? num(a.combined.expected_exposed_subjects, 1) : "—"}
+                    </td>
+                    <td className="px-4 py-3">
+                      {m.dpsgd
+                        ? <span className="text-blue-500 font-semibold">{m.target_epsilon != null ? `ε=${m.target_epsilon}` : "Yes"}</span>
+                        : <span className="text-slate-400">No</span>}
+                    </td>
+                    <td className="px-4 py-3">
+                      {a?.combined.vulnerability_band
+                        ? <span className={`font-bold ${style.color}`}>{a.combined.vulnerability_band}</span>
+                        : <span className="text-slate-400">—</span>}
+                    </td>
                   </tr>
                   {isOpen && (
                     <tr className="bg-slate-50 dark:bg-surface/60">
-                      <td colSpan={6} className="px-6 py-4">
-                        <MetaPanel r={m} />
-                      </td>
+                      <td colSpan={7} className="px-6 py-4"><MetaPanel r={m} /></td>
                     </tr>
                   )}
                 </React.Fragment>
@@ -153,33 +532,229 @@ export default function Summary({ results }: Props) {
         </table>
       </div>
 
-      {/* Plain-English verdicts */}
+      {/* One sentence per model. Detail is a click away, not on the page. */}
       <div className="flex flex-col gap-3">
         {results.map((m) => {
-          const auc = bestAuc(m);
-          const { label, color, bg } = riskLevel(auc);
+          const key = modelKey(m);
+          const a = assessments[key];
+          const tpr = bestTpr(m, alpha);
+          const style = bandStyle(a?.combined.vulnerability_band);
           return (
-            <div key={`${m.job_id}/${m.model_name}`} className={`rounded-xl p-5 ${bg}`}>
-              <p className={`font-bold mb-1 ${color}`}>
+            <div key={key}
+                 className={a ? `rounded-xl p-5 ${style.bg}` : "rounded-xl p-5 bg-slate-50 dark:bg-surface border border-slate-200 dark:border-surface-border"}>
+              <p className={`font-bold mb-1 ${a ? style.color : ""}`}>
                 {m.model_name}
                 {m.model_class && <span className="ml-2 text-xs font-mono text-slate-400">{m.model_class}</span>}
-                {" "}— {label} risk
+                {a?.combined.vulnerability_band ? ` — ${a.combined.vulnerability_band} vulnerability` : ""}
               </p>
               <p className="text-sm text-slate-600 dark:text-slate-300">
-                {auc !== undefined
-                  ? label === "HIGH"
-                    ? `AUC = ${auc.toFixed(3)}. An attacker can reliably distinguish training members from non-members.`
-                    : label === "MEDIUM"
-                      ? `AUC = ${auc.toFixed(3)}. Moderate privacy leakage — some membership signal is detectable.`
-                      : `AUC = ${auc.toFixed(3)}. Low privacy leakage — model is reasonably well protected.`
-                  : "No attack results available for this model."
-                }
-                {m.dpsgd && ` Trained with DP-SGD${m.target_epsilon != null ? ` (ε=${m.target_epsilon})` : ""}.`}
+                {tpr
+                  ? `At a ${alphaLabel} false-positive rate, ${tpr.attack} identifies ${pct(tpr.value)} of training members, ${num(tpr.value / alpha, 1)}× better than chance.`
+                  : "No usable attack results at this operating point."}
+                {a?.combined.ppv != null && ` An attacker claiming membership would be right ${pct(a.combined.ppv)} of the time.`}
               </p>
+              {a && (
+                <button
+                  onClick={() => setDetails(key)}
+                  className="mt-2 text-xs font-bold text-primary hover:underline"
+                >
+                  Show the numbers behind this
+                </button>
+              )}
             </div>
           );
         })}
       </div>
+
+      {/* Wizard: labels and inputs only, explanations behind info buttons */}
+      {wizard && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4" onClick={() => setWizard(false)}>
+          <div className="max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-2xl bg-white dark:bg-surface-deep p-6 shadow-2xl"
+               onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-black mb-1 flex items-center gap-1">
+              Your use case
+              <InfoButton label="How risk is computed" title="How risk is computed">{HOW_IT_WORKS}</InfoButton>
+            </h3>
+            <p className="text-xs text-slate-500 mb-5">Only you can supply these. Defaults are neutral.</p>
+
+            <div className="flex flex-col gap-4 text-sm">
+              <label className="flex flex-col gap-1">
+                <span className="font-bold flex items-center gap-1">
+                  Tolerated false-positive rate (α)
+                  <InfoButton label="Operating point (α)">{ABOUT_ALPHA}</InfoButton>
+                </span>
+                <select
+                  className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                  value={draft.tolerated_fpr}
+                  onChange={(e) => setDraft({ ...draft, tolerated_fpr: Number(e.target.value) })}
+                >
+                  {ALPHAS.map((a) => <option key={a.value} value={a.value}>{a.label}</option>)}
+                </select>
+              </label>
+
+              <label className="flex flex-col gap-1">
+                <span className="font-bold flex items-center gap-1">
+                  Attacker prior (π)
+                  <InfoButton label="Attacker prior (π)">{ABOUT_PRIOR}</InfoButton>
+                </span>
+                <select
+                  className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                  value={draft.attacker_prior}
+                  onChange={(e) => setDraft({ ...draft, attacker_prior: Number(e.target.value) })}
+                >
+                  {PRIORS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+                </select>
+              </label>
+
+              <div className="flex items-center gap-1">
+                <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Harm factors</span>
+                <InfoButton label="Harm factors" title="Harm factors (Loss Magnitude)">{ABOUT_FACTORS}</InfoButton>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <label className="flex flex-col gap-1">
+                  <span className="font-bold">Data subjects (NDS)</span>
+                  <input
+                    type="number" min={1} placeholder="training-set size"
+                    className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                    value={draft.n_subjects ?? ""}
+                    onChange={(e) => setDraft({ ...draft, n_subjects: e.target.value ? Number(e.target.value) : undefined })}
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="font-bold">Records per subject (NR)</span>
+                  <input
+                    type="number" min={0.01} step={0.01}
+                    className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                    value={draft.records_per_subject}
+                    onChange={(e) => setDraft({ ...draft, records_per_subject: Number(e.target.value) })}
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="font-bold">Sensitivity (DTS)</span>
+                  <select
+                    className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                    value={draft.data_type_sensitivity}
+                    onChange={(e) => setDraft({ ...draft, data_type_sensitivity: Number(e.target.value) })}
+                  >
+                    {SENSITIVITY.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="font-bold">Subject weight (DST)</span>
+                  <input
+                    type="number" min={0.01} step={0.5}
+                    className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                    value={draft.subject_type_weight}
+                    onChange={(e) => setDraft({ ...draft, subject_type_weight: Number(e.target.value) })}
+                  />
+                </label>
+              </div>
+
+              <label className="flex flex-col gap-1">
+                <span className="font-bold flex items-center gap-1">
+                  Cost per exposed subject
+                  <InfoButton label="Cost per exposed subject">
+                    <p>
+                      Optional, in any unit you choose. Left blank, no monetary figure is reported at
+                      all — a default cost would be fabricated, and a fabricated cost is worse than
+                      none.
+                    </p>
+                  </InfoButton>
+                </span>
+                <input
+                  type="number" min={0} step={1} placeholder="optional"
+                  className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                  value={draft.cost_per_exposed_subject ?? ""}
+                  onChange={(e) => setDraft({ ...draft, cost_per_exposed_subject: e.target.value ? Number(e.target.value) : undefined })}
+                />
+              </label>
+
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={draft.extrapolate_to_population ?? false}
+                  onChange={(e) => setDraft({ ...draft, extrapolate_to_population: e.target.checked })}
+                />
+                <span className="flex items-center gap-1">
+                  Extrapolate exposed records to the full training set
+                  <InfoButton label="Extrapolation">
+                    <p>
+                      Scales the exposed-record count from the audit set up to the training population.
+                      Off by default: per-record vulnerability is strongly non-uniform, so this is an
+                      estimate under an assumption, not a measurement.
+                    </p>
+                  </InfoButton>
+                </span>
+              </label>
+
+              <label className="flex flex-col gap-1">
+                <span className="font-bold">Notes</span>
+                <textarea
+                  rows={2} placeholder="kept in the audit trail"
+                  className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                  value={draft.notes ?? ""}
+                  onChange={(e) => setDraft({ ...draft, notes: e.target.value })}
+                />
+              </label>
+            </div>
+
+            <div className="mt-6 flex justify-end gap-2">
+              <button onClick={() => setWizard(false)}
+                      className="px-4 py-2 rounded-lg border border-slate-300 dark:border-surface-border text-sm font-bold">
+                Cancel
+              </button>
+              <button onClick={submit} disabled={busy}
+                      className="px-4 py-2 rounded-lg bg-primary text-white text-sm font-bold disabled:opacity-50">
+                {busy ? "Assessing…" : "Assess risk"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Details: formula, assumptions, caveats */}
+      {details && shown && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4" onClick={() => setDetails(null)}>
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-white dark:bg-surface-deep p-6 shadow-2xl"
+               onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-black mb-1">
+              {details.slice(details.indexOf("/") + 1)}
+            </h3>
+            <p className="text-xs text-slate-500 mb-4">
+              Policy {shown.policy_version} · LeakPro {shown.leakpro_version}
+            </p>
+
+            <RiskDiagram className="mb-4" />
+
+            <pre className="text-xs bg-slate-100 dark:bg-surface-2 rounded-lg p-3 overflow-x-auto mb-4">
+{`LEF  = measured TPR at α    = ${shown.combined.loss_event_frequency}
+LM   = DTS × NR × DST × NDS = ${shown.combined.loss_magnitude ?? "—"}
+Risk = LEF × LM             = ${shown.combined.risk ?? "—"}
+PPV  = TPR / (TPR + γ·α)    = ${shown.combined.ppv ?? "—"}   γ = ${shown.combined.gamma}`}
+            </pre>
+
+            {shown.warnings.length > 0 && (
+              <>
+                <p className="font-bold text-sm mb-1 text-amber-500">Caveats</p>
+                <ul className="list-disc ml-5 text-xs text-amber-600 dark:text-amber-400 flex flex-col gap-1 mb-4">
+                  {shown.warnings.map((w, i) => <li key={i}>{w}</li>)}
+                </ul>
+              </>
+            )}
+
+            <p className="font-bold text-sm mb-1">Assumptions</p>
+            <ol className="list-decimal ml-5 text-xs text-slate-600 dark:text-slate-300 flex flex-col gap-1">
+              {shown.assumptions.map((a, i) => <li key={i}>{a}</li>)}
+            </ol>
+
+            <div className="mt-6 flex justify-end">
+              <button onClick={() => setDetails(null)}
+                      className="px-4 py-2 rounded-lg bg-primary text-white text-sm font-bold">Close</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/leakpro/webapp/frontend/src/components/results/Summary.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Summary.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { api, ModelResult, RiskAssessment, RiskRequest } from "../../api";
-import InfoButton from "../InfoButton";
+import InfoButton, { Detail } from "../InfoButton";
 import MetaPanel from "./MetaPanel";
 import RiskDiagram from "./RiskDiagram";
 
@@ -108,165 +108,166 @@ function bestTpr(model: ModelResult, alpha: number): { value: number; attack: st
 }
 
 // ---------------------------------------------------------------------------
-// Explanation content. Kept here, out of the layout, so the panels stay readable.
+// Explanation content. Each one opens with a plain-language lead; the depth sits behind a nested
+// Detail disclosure so the first thing a reader sees is never a wall of text.
 // ---------------------------------------------------------------------------
 
 const HOW_IT_WORKS = (
   <>
     <p>
-      The audit measures how often an attack correctly identifies a training member. Whether that
-      matters depends on your deployment, which LeakPro cannot observe. So the assessment keeps the two
-      halves apart and combines them without inventing any weights.
+      The audit measures how often an attack succeeds. You say how much a success would cost. Risk is
+      those two multiplied.
     </p>
     <RiskDiagram className="my-1" />
-    <p>
-      <b>Nothing is hidden in a coefficient.</b> Every number is either measured by this audit or
-      declared by you, and the result lists the assumption behind each derived figure.
-    </p>
-    <p>
-      <b>Why Loss Event Frequency is just the measured success rate.</b> In the published model,
-      <code> LEF = V × (RP × TEF)</code>, where <b>RP</b> is the <i>retention period</i> — how long the
-      data stays available to be attacked — and <b>TEF</b> is the <i>threat event frequency</i>, how
-      often an adversary tries. LeakPro can observe neither, so both are set to 1: a single attack
-      attempt against a model that is retained. If repeated attempts are plausible in your setting,
-      the real frequency is higher than this assessment assumes, and you should scale it up yourself.
-    </p>
-    <p className="text-xs text-slate-400">
-      Structure: Sion, Van Landuyt, Wuyts &amp; Joosen, “Privacy Risk Assessment for Data
-      Subject-aware Threat Modeling”, IWPE 2019. Precision: Jayaraman, Wang, Knipmeyer, Gu &amp; Evans,
-      “Revisiting Membership Inference Under Realistic Assumptions”, PoPETs 2021, Theorem 4.2.
-      Sensitivity scale: CNIL PIA-3 knowledge bases, 2018.
-    </p>
+    <Detail>
+      <p>
+        Nothing is hidden in a coefficient: every number is either measured here or declared by you, and
+        the result lists the assumption behind each derived figure.
+      </p>
+      <p>
+        Loss Event Frequency is the measured success rate on its own because the published model puts two
+        more factors in it — retention period (how long the data stays attackable) and threat event
+        frequency (how often an adversary tries). LeakPro can observe neither, so both are set to 1: one
+        attempt on a model that is kept. If repeated attempts are plausible for you, real frequency is
+        higher than this assumes.
+      </p>
+      <p className="text-xs text-slate-400">
+        Structure: Sion, Van Landuyt, Wuyts &amp; Joosen, IWPE 2019. Precision: Jayaraman, Wang,
+        Knipmeyer, Gu &amp; Evans, PoPETs 2021, Theorem 4.2. Sensitivity scale: CNIL PIA-3, 2018.
+      </p>
+    </Detail>
   </>
 );
 
 const ABOUT_ALPHA = (
   <>
-    <p>
-      α is the false-positive rate the attacker is assumed to tolerate. It sets the operating point the
-      whole assessment is read at, so there is no default: the choice is yours.
-    </p>
-    <ul className="list-disc ml-5 flex flex-col gap-1">
-      <li><b>1%</b> — resolvable on the audit set sizes most targets have. Start here.</li>
-      <li><b>0.1%</b> — stricter. Needs at least 1000 non-members to be measurable at all.</li>
-      <li><b>0.01%</b> — very strict. Needs at least 10000 non-members.</li>
-    </ul>
-    <p>
-      Below the resolution of your audit set, a true positive rate of zero means “not measurable”, not
-      “no leakage”. The backend refuses to report derived figures there rather than let you read a zero
-      as safety.
-    </p>
+    <p>How many false alarms the attacker puts up with. Lower is stricter. Use 1% unless you have a reason not to.</p>
+    <Detail>
+      <p>
+        A stricter rate needs a bigger audit set to be measurable at all: you need at least 1/α
+        non-members, so 1000 for 0.1% and 10000 for 0.01%.
+      </p>
+      <p>
+        Below that, a true positive rate of zero means “not measurable”, not “no leakage”, so the
+        derived figures are withheld rather than letting a zero read as safety.
+      </p>
+    </Detail>
   </>
 );
 
 const ABOUT_PRIOR = (
   <>
     <p>
-      π is the share of the attacker’s candidate pool that really are members. It does not change the
-      measurement; it changes what the measurement means.
+      How common members are in the pool the attacker is guessing from. The audit assumes half of them
+      are, which makes any attack look better than it would in practice.
     </p>
-    <p>
-      The audit runs on a balanced split, so every TPR and AUC it reports implicitly assumes π = 0.5.
-      Real pools are usually far more skewed, and precision falls steeply as they are. At a 1%
-      false-positive rate and a measured TPR of 10%, an attacker is right 91% of the time at π = 0.5 —
-      and about 1% of the time at π = 0.001.
-    </p>
-    <p>Both values are always reported, so a balanced-prior figure can never be quoted by accident.</p>
+    <Detail>
+      <p>
+        It changes what the measurement means, not the measurement. With a 10% true positive rate at a 1%
+        false-alarm rate, an attacker is right 91% of the time if half the pool are members, and about 1%
+        of the time if one in a thousand are.
+      </p>
+      <p>Both values are always reported, so the flattering one can never be quoted by accident.</p>
+    </Detail>
   </>
 );
 
 const ABOUT_FACTORS = (
   <>
     <p>
-      These four are the Loss Magnitude factors from Sion et al.: <code>LM = DTS × NR × DST × NDS</code>.
-      The paper deliberately supplies no numeric values for them, so they are yours to set. All default
-      to a neutral 1.0, which reduces the loss magnitude to a plain count of subjects.
+      Four numbers describing how bad a leak would be for the people in your data. All default to 1,
+      meaning no weighting.
     </p>
-    <ul className="list-disc ml-5 flex flex-col gap-1">
-      <li><b>DTS</b> — sensitivity of the leaked data type. The CNIL PIA severity levels are a defensible starting scale.</li>
-      <li><b>NR</b> — records of this data type per subject. Fractions are fine when only some subjects contribute it.</li>
-      <li><b>DST</b> — weight for the subject type. Raise it for vulnerable subjects such as minors or patients.</li>
-      <li><b>NDS</b> — number of data subjects. Left blank, the target’s training-set size is used.</li>
-    </ul>
-    <p className="text-xs text-slate-400">
-      Sion et al. note the model assumes these factors are independent, which they flag as a
-      simplification of reality. That assumption is recorded in every assessment.
-    </p>
+    <Detail>
+      <ul className="list-disc ml-5 flex flex-col gap-1">
+        <li><b>Sensitivity</b> — how revealing the leaked data type is. The CNIL PIA severity levels are a defensible scale.</li>
+        <li><b>Records per subject</b> — fractions are fine when only some subjects contribute the data.</li>
+        <li><b>Subject weight</b> — raise it for vulnerable subjects such as minors or patients.</li>
+        <li><b>Data subjects</b> — left blank, the target’s training-set size is used.</li>
+      </ul>
+      <p>
+        These are the Loss Magnitude factors of Sion et al., who supply the structure but deliberately no
+        values, and who note the model treats the factors as independent — a simplification recorded in
+        every assessment.
+      </p>
+    </Detail>
   </>
 );
 
 const ABOUT_TPR = (
-  <p>
-    Of all the training members in the audit set, the share the strongest attack correctly identifies
-    while keeping its false-positive rate at or below α. Attacks whose ROC is inverted (AUC below 0.5)
-    are excluded rather than counted as weak evidence.
-  </p>
+  <>
+    <p>Share of training members the best attack finds, at your false-alarm rate.</p>
+    <Detail>
+      <p>
+        Attacks whose ROC is inverted (AUC below 0.5) are excluded rather than counted as weak evidence,
+        because an inverted result makes a real leak read as no leak.
+      </p>
+    </Detail>
+  </>
 );
 
 const ABOUT_LIFT = (
-  <p>
-    How many times better than random guessing the attack is at this operating point: TPR divided by α.
-    A lift of 1× is no better than chance. The band label is derived from this figure alone, and it is
-    an unsourced convenience — no published thresholds exist for it.
-  </p>
+  <>
+    <p>How many times better than guessing the attack is. 1× is chance.</p>
+    <Detail>
+      <p>
+        True positive rate divided by the false-alarm rate. The band label comes from this figure alone,
+        and its thresholds are round numbers rather than anything published.
+      </p>
+    </Detail>
+  </>
 );
 
 const ABOUT_PPV = (
   <>
-    <p>
-      If the attacker claims a record was in the training set, how often are they right? This is the
-      number that decides whether a leak is actionable, and it depends on your declared prior π as much
-      as on the attack.
-    </p>
-    <p className="font-mono text-xs">PPV = TPR / (TPR + γ·α), γ = (1 − π) / π</p>
-    <p>
-      <b>γ is how outnumbered the members are:</b> for every genuine member in the attacker’s candidate
-      pool there are γ non-members. It is derived from your π, not a separate input — π = 0.5 gives
-      γ = 1, π = 0.01 gives γ = 99, π = 0.001 gives γ = 999.
-    </p>
-    <p>
-      That is why it multiplies the false-positive rate. At π = 0.001 with a measured TPR of 10% and
-      α = 1%, each member yields 0.10 expected true positives while the 999 non-members yield
-      999 × 0.01 = 9.99 false ones — about ten false alarms per correct hit, so precision is roughly
-      1%. The identical measurement reads 91% at π = 0.5.
-    </p>
-    <p className="text-xs text-slate-400">
-      A tenfold more skewed pool costs as much precision as a tenfold looser threshold, which is the
-      same reason strict operating points matter.
-    </p>
+    <p>When the attacker says “this record was used in training”, how often they are right.</p>
+    <Detail>
+      <p className="font-mono text-xs">PPV = TPR / (TPR + γ·α), γ = (1 − π) / π</p>
+      <p>
+        γ is how outnumbered the members are: for every real member in the pool there are γ others. It
+        comes from your prior, so π = 0.5 gives γ = 1 and π = 0.001 gives γ = 999.
+      </p>
+      <p>
+        That is why it multiplies the false-alarm rate. At π = 0.001 with a 10% true positive rate and a
+        1% false-alarm rate, one member yields 0.10 correct flags while the other 999 yield about 10
+        wrong ones — so roughly ten false alarms per hit.
+      </p>
+    </Detail>
   </>
 );
 
 const ABOUT_EXPOSED = (
   <>
-    <p>
-      The measured success rate applied to your declared population: how many subjects an attacker would
-      be expected to identify. Sensitivity weights are deliberately left out of this figure so it stays
-      a plain count you can reason about.
-    </p>
-    <p>
-      <b>This count does not depend on π, and should not.</b> The true positive rate is conditional on a
-      record actually being a member, so it is unaffected by how the attacker’s pool is composed —
-      which means this figure already counts true positives only. Multiplying it by precision would be
-      circular, since precision times the flagged set <i>is</i> the true-positive count.
-    </p>
-    <p>
-      A skewed prior does not reduce how many members are genuinely identified; it increases the false
-      accusations sitting alongside them. So read the two columns as different questions: this one is
-      how many people the attack really exposes, precision is how far an attacker can trust any single
-      claim. “1000 exposed at 1% precision” and “40 exposed at 99% precision” are both real findings,
-      and they call for different responses.
-    </p>
+    <p>Roughly how many of your subjects an attacker would actually identify.</p>
+    <Detail>
+      <p>
+        This count does not depend on the prior, and should not. The true positive rate is conditional on
+        a record really being a member, so the figure already counts correct identifications only.
+        Multiplying it by precision would be circular, since precision times the flagged set is that same
+        count.
+      </p>
+      <p>
+        A skewed prior does not reduce how many members are identified; it adds false accusations beside
+        them. So read the two columns as different questions: this one is how many people are exposed,
+        precision is how far a single claim can be trusted.
+      </p>
+      <p>Sensitivity weights are left out on purpose, so this stays a plain count.</p>
+    </Detail>
   </>
 );
 
 const ABOUT_BAND = (
-  <p>
-    An advisory label over the measured lift only, never over the combination of measurement and
-    judgement. The thresholds are round numbers chosen so that NONE means no better than chance and
-    SEVERE means two orders of magnitude better than chance. They are not calibrated against anything
-    published, which is why the policy version travels with every assessment.
-  </p>
+  <>
+    <p>A rough label for the measured lift. Advisory only.</p>
+    <Detail>
+      <p>
+        It labels the measurement, never the combination of measurement and judgement. NONE means no
+        better than chance and SEVERE means two orders of magnitude better, but the thresholds are not
+        calibrated against anything published — which is why the policy version travels with every
+        assessment.
+      </p>
+    </Detail>
+  </>
 );
 
 export default function Summary({ results, risk, onRiskChange }: Props) {
@@ -655,11 +656,13 @@ export default function Summary({ results, risk, onRiskChange }: Props) {
                 <span className="font-bold flex items-center gap-1">
                   Cost per exposed subject
                   <InfoButton label="Cost per exposed subject">
-                    <p>
-                      Optional, in any unit you choose. Left blank, no monetary figure is reported at
-                      all — a default cost would be fabricated, and a fabricated cost is worse than
-                      none.
-                    </p>
+                    <p>Optional, in any unit you like.</p>
+                    <Detail>
+                      <p>
+                        Left blank, no monetary figure is reported at all. A default cost would be made
+                        up, and a made-up cost is worse than none.
+                      </p>
+                    </Detail>
                   </InfoButton>
                 </span>
                 <input
@@ -679,11 +682,13 @@ export default function Summary({ results, risk, onRiskChange }: Props) {
                 <span className="flex items-center gap-1">
                   Extrapolate exposed records to the full training set
                   <InfoButton label="Extrapolation">
-                    <p>
-                      Scales the exposed-record count from the audit set up to the training population.
-                      Off by default: per-record vulnerability is strongly non-uniform, so this is an
-                      estimate under an assumption, not a measurement.
-                    </p>
+                    <p>Scales the exposed count from the audit set up to the whole training set.</p>
+                    <Detail>
+                      <p>
+                        Off by default, because some records are far more exposed than others. The
+                        scaled number is an estimate under that assumption, not a measurement.
+                      </p>
+                    </Detail>
                   </InfoButton>
                 </span>
               </label>

--- a/leakpro/webapp/frontend/src/components/steps/Step7Results.tsx
+++ b/leakpro/webapp/frontend/src/components/steps/Step7Results.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { api, ModelResult, JobListItem } from "../../api";
-import Summary from "../results/Summary";
+import Summary, { RiskState, initialRiskState } from "../results/Summary";
 import RocChart from "../results/RocChart";
 import Histograms from "../results/Histograms";
 import Records from "../results/Records";
@@ -39,6 +39,10 @@ export default function Step7Results({ jobId, onRestart, autoOpenCompare }: Prop
 
   // Rename dialog state
   const [pendingRename, setPendingRename] = useState<PendingRename | null>(null);
+
+  // Risk assessment state. Held here rather than in Summary because the tab bar unmounts the tab
+  // components, which would throw away a completed assessment when the user looks at the ROC curves.
+  const [risk, setRisk] = useState<RiskState>(initialRiskState);
 
   useEffect(() => {
     api.getResults(jobId)
@@ -303,7 +307,7 @@ export default function Step7Results({ jobId, onRestart, autoOpenCompare }: Prop
           </div>
 
           <div>
-            {tab === "summary"    && <Summary    results={allResults} />}
+            {tab === "summary"    && <Summary    results={allResults} risk={risk} onRiskChange={setRisk} />}
             {tab === "roc"        && <RocChart   results={allResults} />}
             {tab === "histograms" && <Histograms results={allResults} />}
             {tab === "records"    && <Records    results={allResults} jobId={jobId} />}


### PR DESCRIPTION
Closes #443. Jira: [LDG-30](https://aisweden.atlassian.net/browse/LDG-30).

## What this adds

`leakpro/risk/`, which turns MIA audit results plus a declared use-case profile into a risk assessment, and replaces the webapp's AUC-threshold risk bands with it.

The problem it solves: LeakPro measured attack success but had no defensible way to state risk. `Summary.tsx` scored it from hardcoded AUC bands (`>= 0.75` HIGH, `>= 0.60` MEDIUM) with no provenance, and AUC is an average-case measure that hides the worst-case per-record leakage that actually determines exposure — a model can sit at AUC 0.58 and still have training records that are perfectly identifiable. The core library had no risk concept at all, so CLI and notebook users got nothing.

## Design: a decomposition, not a score

Risk is reported in three blocks that are never collapsed:

- **Measured** (reproducible from the audit): TPR at a chosen operating point α, advantage, lift, and the count of members flagged at that point.
- **Declared** (by the data controller, echoed verbatim): attacker prior π and the four harm factors.
- **Combined** (every factor traceable to one of the above): precision, expected exposed subjects, `Risk = LEF × LM`, and an advisory band.

Structure follows Sion et al. (IWPE 2019): `LM = DTS × NR × DST × NDS`. That paper supplies the factor *structure* but deliberately no numeric values — §III-G states every input is an analyst estimate. So the four factors are user-supplied numbers defaulting to a neutral 1.0, and **there is no combined risk band at all**, only an advisory `vulnerability_band` over the measured lift, explicitly marked heuristic. The suggested sensitivity scale is cited to CNIL PIA-3, which §VI-A points at.

Precision follows Jayaraman et al. (PoPETs 2021, Thm 4.2): `PPV = TPR / (TPR + γ·α)`, `γ = (1−π)/π`. This is not decoration. Our audits run on a balanced split, so every TPR and AUC LeakPro reports implicitly assumes π = 0.5. At TPR(1% FPR) = 0.10 that is 91% precision, but about 1% at π = 0.001. Both are always reported so the flattering figure cannot be quoted by accident.

Two assumptions the published model forces into the open, emitted in `assumptions` on every assessment: `LEF = V` only because retention period × threat event frequency is assumed to be 1 (a single attempt on a retained model), and the LM product treats its factors as independent, which Sion §VI-B itself flags as a simplification.

## API

`assess_risk` is a **separate call**, not part of `run_audit`, so one expensive audit can be re-assessed cheaply under different α and π — exactly the parameters users vary. `run_audit` keeps its signature and return type.

```python
results = leakpro.run_audit()
assessment = assess_risk(results, profile, num_train=leakpro.handler.target_model_metadata.num_train)
assessment.save(f"{leakpro.report_dir}/risk_assessment.json")
```

A profile can be declared in `audit.yaml` under an optional top-level `use_case:` block. Declaring it triggers nothing; absent it, behaviour is unchanged.

## Four guards, each a way a naive version reports a confidently wrong number

1. **Unresolvable operating point.** `MIAResult._get_result_fixed_fpr` uses `max(..., default=0.0)`, so TPR at an FPR the audit set cannot express comes back as `0.0`. A 200-non-member audit asked for α = 0.001 would read as zero risk. The layer refuses below `1 / n_non_members`, or (non-strict, used by the webapp) withholds derived figures with a warning.
2. **Inverted ROC.** `attack_p` currently reports an inverted ROC for every target (measured AUC 0.214 where correctly oriented is 0.786). Results with AUC < 0.5 are rejected by name rather than averaged in. The underlying bug is out of scope here.
3. **Attack selection.** `MIAResult.get_strongest` maximises ROC AUC; risk needs the attack that wins at the user's operating point. These disagree routinely.
4. **Units.** Two TPR conventions coexist: the live `MIAResult` tabulates fractions (`TPR@1%FPR`), the legacy `metrics/attack_result.py` helper returns percentages (`TPR@1.0%FPR`). The layer accepts fractions and rejects a percentage-valued table rather than letting a 100× error reach a risk figure.

## Webapp

All scoring moved to Python behind `POST /jobs/{job_id}/risk`; the frontend posts a profile and renders the response, so no thresholds live in TypeScript. The results view leads with numbers and puts explanations behind info buttons, with a three-box schematic of the model. Warnings deliberately stay visible as a caveat chip — a caveat like "this operating point was not measurable" must not require a click to discover.

Two bugs found and fixed while building it: risk state was lost when switching result tabs (the tab bar unmounts the tab components), and in cross-job compare mode only the first job's models were ever assessed, with model-name keys that collide across jobs.

## Scope

MIA only, behind a family-agnostic `VulnerabilityMeasurement` schema so MINV, GIA and synthetic data can implement it later without reworking the risk layer. `assessment.py` imports nothing from `leakpro.attacks`.

Not doing the FAIR Bayesian network: it needs published priors we do not have, and it buys a defensible *combine* for inputs that are the controller's own judgement either way. Sion's PERT + Monte Carlo treatment of uncertainty is the natural v2 and would let us report a distribution rather than a point.

## Testing

85 tests in `leakpro/tests/risk/`, all passing, and the full suite is **362 passed / 0 failed**.

- 79 unit tests: PPV against hand-computed values at three priors, the unresolvable-α guard, inverted-result rejection, TPR-over-AUC selection, percent-vs-fraction rejection, no monetary figure without a declared cost, byte-identical output for identical input.
- 6 end-to-end tests that run a real LiRA audit through `run_audit` and then assess it, asserting the JSON is self-contained and the PDF gains a Risk section.
- `ruff` clean over `leakpro/`; frontend `tsc` and `vite build` pass.

## License compliance

- No new dependencies, Python or npm (`pyproject.toml` and `package.json` unchanged).
- Apache 2.0 boilerplate header on all six new source files.
- No third-party code copied, so no `NOTICE` update needed.

## Review notes

- **The UI has not been reviewed visually.** Geometry of the SVG schematic is verified by a coordinate check (no overlaps, nothing clipped or out of frame), but whether it reads well on screen needs a human look.
- `examples/mia/cifar/` gains a commented `use_case:` block and two notebook cells as documentation; no example behaviour changes.
- The advisory band thresholds are the one unsourced judgement left in the layer. They are versioned, overridable, and printed alongside any band they produce, but if you would rather the UI showed no band at all, that is a one-line change.


[LDG-30]: https://aisweden.atlassian.net/browse/LDG-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ