### PR TITLE
PETRecipe: one shared DP-SGD training path

### DIFF
--- a/examples/mia/LOS/pet_optimization/run_campaign.py
+++ b/examples/mia/LOS/pet_optimization/run_campaign.py
@@ -72,22 +72,18 @@ def load_splits(seed: int = 0) -> dict:
     }
 
 
-class LRSigmoid(nn.Module):
-    """Logistic regression emitting probabilities (matches the LOS example's LR + BCELoss)."""
-
-    def __init__(self, input_dim: int) -> None:
-        super().__init__()
-        self.linear = nn.Linear(input_dim, 1)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return torch.sigmoid(self.linear(x))
-
-
 def make_recipe(splits: dict, epochs: int) -> PETRecipe:
-    """The LOS training recipe: logistic regression + Adam + BCE."""
+    """The LOS training recipe: logistic regression + Adam + BCE.
+
+    The model is the example's own ``target_models.LR`` — the same class the
+    audited target was trained with, so the campaign measures that model rather
+    than a look-alike.
+    """
+    from target_models import LR  # noqa: PLC0415 — EXAMPLE_DIR is on sys.path above
+
     input_dim = splits["x"].shape[1]
     return PETRecipe(
-        make_model=lambda config: LRSigmoid(input_dim),
+        make_model=lambda config: LR(input_dim),
         make_optimizer=lambda params, config: optim.Adam(params, lr=config["learning_rate"]),
         make_loader=lambda indices, config: DataLoader(
             TensorDataset(splits["x"][indices], splits["y"][indices]),

--- a/examples/mia/LOS/pet_optimization/run_campaign.py
+++ b/examples/mia/LOS/pet_optimization/run_campaign.py
@@ -5,15 +5,9 @@
 """PET optimization campaign on the MIMIC LOS logistic-regression target.
 
 Traces the utility-vs-attack-success frontier for DP-SGD on the LOS binary
-classification task, using the leakpro.optimization core module.
-
-- Knobs (joint search, per the frontier plan): noise multiplier, clipping
-  norm, learning rate, batch size. Epochs are fixed.
-- Utility: AUC on a held-out test split.
-- Attack: matched-reference MIA (RMIA-style calibration with 1-2 reference
-  models trained with the SAME configuration as the candidate — full mimicry).
-  Signal: logit-scaled confidence of the target minus the reference mean.
-- Loop metric: TPR @ FPR = 1% (powered proxy; tail FPRs are validation-only).
+classification task. The training loop, attack and utility evaluation all come
+from the shared ``PETRecipe`` path in ``leakpro.optimization`` — this file only
+declares the recipe (LR model, Adam, BCE loss) and the data splits.
 
 Usage:
     python run_campaign.py --smoke          # 2 configs, quick pipeline check
@@ -21,41 +15,31 @@ Usage:
 """
 
 import argparse
+import pickle
 import sys
 import time
 from pathlib import Path
 
 import numpy as np
 import torch
-from opacus import PrivacyEngine
-from sklearn.metrics import roc_auc_score
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
 
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(EXAMPLE_DIR))  # mimic_data_handler must be importable for unpickling
 
-from leakpro.optimization import (
-    AttackScores,
-    Campaign,
-    confidence_signal,
-    default_dpsgd_space,
-    pareto_front,
-    plot_frontier,
-)
+from leakpro.optimization import Campaign, PETRecipe, build_campaign_fns, default_dpsgd_space, pareto_front, plot_frontier
 from leakpro.utils.logger import logger
 
-DELTA = 1e-5
+N_AUDIT = 2000
 
 
 def load_splits(seed: int = 0) -> dict:
-    """Load the LOS LR dataset and carve person-disjoint roles from the stored splits.
+    """Load the LOS LR dataset and carve disjoint roles from the stored splits.
 
     train_indices -> target-train + reference pool (disjoint);
     test_indices  -> audit nonmembers + utility eval (disjoint).
     """
-    import pickle
-
     data_dir = EXAMPLE_DIR / "data" / "LR_data"
     with (data_dir / "dataset.pkl").open("rb") as f:
         dataset = pickle.load(f)
@@ -73,7 +57,7 @@ def load_splits(seed: int = 0) -> dict:
     # Audit members must be a subset of target_train (the first n_target train
     # indices), and nonmembers plus a non-empty utility split must both fit in
     # the test indices — cap instead of assuming the dataset is large enough.
-    n_audit = min(2000, n_target, len(test_idx) - 1)
+    n_audit = min(N_AUDIT, n_target, len(test_idx) - 1)
     if n_audit <= 0 or len(test_idx) - n_audit <= 0:
         raise ValueError(f"Dataset too small for the campaign splits: {len(train_idx)} train / "
                          f"{len(test_idx)} test indices.")
@@ -88,75 +72,31 @@ def load_splits(seed: int = 0) -> dict:
     }
 
 
-def train_dpsgd_lr(config: dict, splits: dict, train_indices: np.ndarray,
-                   epochs: int, device: str) -> nn.Module:
-    """Train one logistic-regression model with DP-SGD under the sampled config."""
-    from target_models import LR
+class LRSigmoid(nn.Module):
+    """Logistic regression emitting probabilities (matches the LOS example's LR + BCELoss)."""
 
-    x, y = splits["x"], splits["y"]
-    loader = DataLoader(
-        TensorDataset(x[train_indices], y[train_indices]),
-        batch_size=int(config["batch_size"]), shuffle=True,
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(input_dim, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.sigmoid(self.linear(x))
+
+
+def make_recipe(splits: dict, epochs: int) -> PETRecipe:
+    """The LOS training recipe: logistic regression + Adam + BCE."""
+    input_dim = splits["x"].shape[1]
+    return PETRecipe(
+        make_model=lambda config: LRSigmoid(input_dim),
+        make_optimizer=lambda params, config: optim.Adam(params, lr=config["learning_rate"]),
+        make_loader=lambda indices, config: DataLoader(
+            TensorDataset(splits["x"][indices], splits["y"][indices]),
+            batch_size=int(config["batch_size"]), shuffle=True,
+        ),
+        criterion=nn.BCELoss(),
+        epochs=epochs,
+        output_kind="binary_probs",
     )
-    model = LR(input_dim=x.shape[1]).to(device)
-    optimizer = optim.Adam(model.parameters(), lr=config["learning_rate"])
-    criterion = nn.BCELoss()
-
-    engine = PrivacyEngine(accountant="rdp")
-    model, optimizer, loader = engine.make_private(
-        module=model,
-        optimizer=optimizer,
-        data_loader=loader,
-        noise_multiplier=config["noise_multiplier"],
-        max_grad_norm=config["max_grad_norm"],
-    )
-
-    model.train()
-    for _ in range(epochs):
-        for xb, yb in loader:
-            optimizer.zero_grad()
-            loss = criterion(model(xb.to(device)), yb.to(device))
-            loss.backward()
-            optimizer.step()
-
-    epsilon = engine.get_epsilon(delta=DELTA)
-    logger.info(f"Trained DP-SGD LR: formal epsilon = {epsilon:.2f} (delta = {DELTA}).")
-    model.campaign_extras = {"epsilon": epsilon, "delta": DELTA}  # recorded next to the attack result
-    return model.eval()
-
-
-def make_fns(splits: dict, epochs: int, n_refs: int, device: str, ref_seed: int = 1) -> tuple:
-    """Build the campaign's (train, utility, attack) callables."""
-
-    def train_fn(config: dict) -> nn.Module:
-        return train_dpsgd_lr(config, splits, splits["target_train"], epochs, device)
-
-    def utility_fn(model: nn.Module) -> float:
-        idx = splits["utility_eval"]
-        phi = model(splits["x"][idx].to(device)).detach().cpu().numpy().ravel()
-        return float(roc_auc_score(splits["y"][idx].numpy().ravel(), phi))
-
-    def attack_fn(model: nn.Module, config: dict) -> AttackScores:
-        # Full mimicry: references use the SAME config (and epochs) as the candidate,
-        # trained on data disjoint from the target's training set.
-        rng = np.random.default_rng(ref_seed)
-        x, y = splits["x"], splits["y"]
-        members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
-
-        ref_models = []
-        pool = splits["ref_pool"]
-        for _ in range(n_refs):
-            sub = rng.choice(pool, size=min(len(splits["target_train"]), len(pool)), replace=False)
-            ref_models.append(train_dpsgd_lr(config, splits, sub, epochs, device))
-
-        def calibrated(idx: np.ndarray) -> np.ndarray:
-            target_phi = confidence_signal(model, x[idx], y[idx], device, "binary_probs")
-            ref_phi = np.mean([confidence_signal(r, x[idx], y[idx], device, "binary_probs") for r in ref_models], axis=0)
-            return target_phi - ref_phi
-
-        return AttackScores(member_scores=calibrated(members), nonmember_scores=calibrated(nonmembers))
-
-    return train_fn, utility_fn, attack_fn
 
 
 
@@ -194,11 +134,14 @@ def main() -> None:
         args.n_configs, args.epochs, args.n_refs = 2, 2, 1
         args.out = args.out + "_smoke"
 
-    # Campaign re-seeds torch per configuration from (seed, index); this covers
-    # only what happens before the loop starts.
+    # Seed torch too: numpy covers the Sobol draw and the split permutation,
+    # but model init, shuffling, Poisson sampling and the DP noise run off
+    # torch's global RNG.
     torch.manual_seed(args.seed)
     splits = load_splits(seed=args.seed)
-    train_fn, utility_fn, attack_fn = make_fns(splits, args.epochs, args.n_refs, args.device)
+    recipe = make_recipe(splits, args.epochs)
+    train_fn, utility_fn, attack_fn = build_campaign_fns(
+        recipe, splits, n_refs=args.n_refs, device=args.device, utility_metric="auc")
 
     campaign = Campaign(
         train_fn, utility_fn, attack_fn,

--- a/examples/mia/LOS/pet_optimization/run_campaign_grud.py
+++ b/examples/mia/LOS/pet_optimization/run_campaign_grud.py
@@ -53,6 +53,7 @@ from leakpro.optimization import (  # noqa: E402
 from leakpro.utils.logger import logger  # noqa: E402
 
 N_AUDIT = 2000
+MAX_PHYSICAL_BATCH = 128
 
 
 def load_splits(seed: int = 0) -> dict:
@@ -75,14 +76,21 @@ def load_splits(seed: int = 0) -> dict:
     test_idx = rng.permutation(np.asarray(indices["test_indices"]))
 
     n_target = len(train_idx) // 2
+    # Members must stay inside target_train (the first n_target indices) and the
+    # nonmembers must leave a non-empty utility split behind — cap rather than
+    # assume the dataset is big enough, as the LR campaign does.
+    n_audit = min(N_AUDIT, n_target, len(test_idx) - 1)
+    if n_audit <= 0 or len(test_idx) - n_audit <= 0:
+        raise ValueError(f"Dataset too small for the campaign splits: {len(train_idx)} train / "
+                         f"{len(test_idx)} test indices.")
     return {
         "x": x,
         "y": y,
         "target_train": train_idx[:n_target],
         "ref_pool": train_idx[n_target:],
-        "audit_members": train_idx[:N_AUDIT],  # subset of target_train
-        "audit_nonmembers": test_idx[:N_AUDIT],
-        "utility_eval": test_idx[N_AUDIT:],
+        "audit_members": train_idx[:n_audit],  # subset of target_train
+        "audit_nonmembers": test_idx[:n_audit],
+        "utility_eval": test_idx[n_audit:],
     }
 
 
@@ -173,14 +181,13 @@ def main() -> None:
     # torch's global RNG.
     torch.manual_seed(args.seed)
     splits = load_splits(seed=args.seed)
-    # Auto-detected on purpose: GRUD pins X_mean, the identity matrix and
-    # FilterLinear's filter to this device at construction, and .to(device)
-    # does not move those unregistered attributes — a flag would accept a
-    # value it cannot honor.
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = "cuda" if torch.cuda.is_available() else "cpu"  # see the parser note above
     recipe = make_recipe(splits, args.epochs)
     train_fn, utility_fn, attack_fn = build_campaign_fns(
-        recipe, splits, n_refs=args.n_refs, device=device, utility_metric="auc")
+        recipe, splits, n_refs=args.n_refs, device=device, utility_metric="auc",
+        # GRU-D is the memory-heaviest target in the repo: per-sample gradients
+        # over the unrolled sequence OOM at the shared 256 default.
+        max_physical_batch=MAX_PHYSICAL_BATCH)
 
     campaign = Campaign(
         train_fn, utility_fn, attack_fn,

--- a/examples/mia/LOS/pet_optimization/run_campaign_grud.py
+++ b/examples/mia/LOS/pet_optimization/run_campaign_grud.py
@@ -4,18 +4,21 @@
 #
 """PET optimization campaign on the MIMIC LOS GRU-D target.
 
-The leakier LOS counterpart to run_campaign.py (logistic regression): GRU-D is
-a recurrent net over the raw multivariate time series, so its
-utility-vs-attack-success frontier has a real privacy axis to trace.
+GRU-D is the leakier LOS target (a recurrent net over the raw multivariate time
+series, versus the flat logistic-regression target in ``run_campaign.py``), so
+its utility-vs-attack frontier has a real privacy axis to trace.
 
-Same design as the LR campaign — joint DP-SGD knob search, matched-reference
-MIA (full mimicry), AUC utility, TPR@1% loop metric — with two GRU-D specifics:
+Like the LR and CIFAR campaigns, this file only declares a ``PETRecipe`` (the
+GRU-D model, optimizer, loader, loss) and the data splits; the DP-SGD loop,
+matched-reference attack and utility evaluation come from the shared core path.
 
-- GRU-D outputs a raw logit (BCEWithLogitsLoss); the membership signal is the
-  signed logit (phi = logit for members of the true class, negated otherwise).
-- GRU-D contains a custom FilterLinear and a manual 104-step recurrence, so
-  Opacus is put on its functorch per-sample-gradient path (force_functorch).
-  Correct but slower than LR/CNN targets: keep --n-configs and epochs modest.
+Two GRU-D specifics worth knowing:
+- The model outputs a raw logit (BCEWithLogitsLoss), so ``output_kind`` is
+  "binary_logits".
+- GRU-D contains a custom ``FilterLinear`` and a manual 104-step recurrence.
+  Opacus is put on its functorch per-sample-gradient path (``force_functorch``)
+  to differentiate it; this is correct but far slower than the LR/CNN targets,
+  so keep --n-configs and epochs modest.
 
 Usage:
     python run_campaign_grud.py --smoke          # 2 configs, pipeline check
@@ -30,9 +33,6 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from opacus import PrivacyEngine
-from opacus.utils.batch_memory_manager import BatchMemoryManager
-from sklearn.metrics import roc_auc_score
 from torch import nn, optim, zeros
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -42,23 +42,25 @@ sys.path.insert(0, str(EXAMPLE_DIR))  # mimic_data_handler (unpickling) + target
 from target_models import GRUD  # noqa: E402
 
 from leakpro.optimization import (  # noqa: E402
-    AttackScores,
     Campaign,
     Knob,
     KnobSpace,
-    confidence_signal,
+    PETRecipe,
+    build_campaign_fns,
     pareto_front,
     plot_frontier,
 )
 from leakpro.utils.logger import logger  # noqa: E402
 
-DELTA = 1e-5
 N_AUDIT = 2000
-HIDDEN_SIZE = 78
 
 
 def load_splits(seed: int = 0) -> dict:
-    """Load the LOS GRU-D time-series dataset and carve person-disjoint roles."""
+    """Load the LOS GRU-D time-series dataset and carve disjoint roles.
+
+    train_indices -> target-train + reference pool (disjoint);
+    test_indices  -> audit nonmembers + utility eval (disjoint).
+    """
     data_dir = EXAMPLE_DIR / "data" / "GRUD_data"
     with (data_dir / "dataset.pkl").open("rb") as f:
         dataset = pickle.load(f)
@@ -84,96 +86,38 @@ def load_splits(seed: int = 0) -> dict:
     }
 
 
-def _build_grud(x: torch.Tensor, batch_size: int) -> nn.Module:
-    """Instantiate GRU-D; init params mirror the LOS example notebooks."""
+def make_recipe(splits: dict, epochs: int, hidden_size: int = 78) -> PETRecipe:
+    """The GRU-D training recipe. Init params mirror the LOS example's notebooks.
+
+    ``input_size`` and ``X_mean`` follow the packed [N, time*3, features] layout:
+    input_size = time_steps = data.shape[1] // 3, X_mean = zeros(1, features, time_steps).
+    """
+    x = splits["x"]
     time_steps = x.shape[1] // 3
     features = x.shape[2]
-    return GRUD(
-        input_size=time_steps,
-        hidden_size=HIDDEN_SIZE,
-        X_mean=zeros(1, features, time_steps),
-        batch_size=batch_size,
-        bn_flag=False,          # BatchNorm is incompatible with Opacus
-        force_functorch=True,   # custom FilterLinear needs the functorch grad sampler
-    )
+    x_mean = zeros(1, features, time_steps)
 
-
-def train_dpsgd_grud(config: dict, splits: dict, train_indices: np.ndarray,
-                     epochs: int, device: str) -> nn.Module:
-    """Train one GRU-D model with DP-SGD under the sampled config."""
-    x, y = splits["x"], splits["y"]
-    loader = DataLoader(
-        TensorDataset(x[train_indices], y[train_indices]),
-        batch_size=int(config["batch_size"]), shuffle=True,
-    )
-    model = _build_grud(x, int(config["batch_size"])).to(device)
-    optimizer = optim.Adam(model.parameters(), lr=config["learning_rate"])
-    criterion = nn.BCEWithLogitsLoss()
-
-    engine = PrivacyEngine(accountant="rdp")
-    model, optimizer, loader = engine.make_private(
-        module=model,
-        optimizer=optimizer,
-        data_loader=loader,
-        noise_multiplier=config["noise_multiplier"],
-        max_grad_norm=config["max_grad_norm"],
-    )
-
-    model.train()
-    with BatchMemoryManager(data_loader=loader, max_physical_batch_size=128,
-                            optimizer=optimizer) as mem_loader:
-        for _ in range(epochs):
-            for xb, yb in mem_loader:
-                optimizer.zero_grad()
-                loss = criterion(model(xb.to(device)), yb.to(device))
-                loss.backward()
-                optimizer.step()
-
-    epsilon = engine.get_epsilon(delta=DELTA)
-    logger.info(f"Trained DP-SGD GRU-D: formal epsilon = {epsilon:.2f} (delta = {DELTA}).")
-    model.campaign_extras = {"epsilon": epsilon, "delta": DELTA}
-    return model.eval()
-
-
-def make_fns(splits: dict, epochs: int, n_refs: int, device: str, ref_seed: int = 1) -> tuple:
-    """Build the campaign's (train, utility, attack) callables."""
-
-    def train_fn(config: dict) -> nn.Module:
-        if device.startswith("cuda"):
-            torch.cuda.empty_cache()
-        return train_dpsgd_grud(config, splits, splits["target_train"], epochs, device)
-
-    @torch.no_grad()
-    def utility_fn(model: nn.Module) -> float:
-        idx = splits["utility_eval"]
-        scores = []
-        for i in range(0, len(idx), 1024):
-            scores.append(model(splits["x"][idx[i:i + 1024]].to(device)).cpu().reshape(-1))
-        return float(roc_auc_score(splits["y"][idx].numpy().ravel(), torch.cat(scores).numpy()))
-
-    def attack_fn(model: nn.Module, config: dict) -> AttackScores:
-        # Full mimicry: references share the candidate's config, on disjoint data.
-        rng = np.random.default_rng(ref_seed)
-        x, y = splits["x"], splits["y"]
-        members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
-
-        ref_phi_m = np.zeros(len(members))
-        ref_phi_n = np.zeros(len(nonmembers))
-        for _ in range(n_refs):
-            sub = rng.choice(splits["ref_pool"], size=len(splits["target_train"]), replace=False)
-            ref = train_dpsgd_grud(config, splits, sub, epochs, device)
-            ref_phi_m += confidence_signal(ref, x[members], y[members], device, "binary_logits") / n_refs
-            ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, "binary_logits") / n_refs
-            del ref
-            if device.startswith("cuda"):
-                torch.cuda.empty_cache()
-
-        return AttackScores(
-            member_scores=confidence_signal(model, x[members], y[members], device, "binary_logits") - ref_phi_m,
-            nonmember_scores=confidence_signal(model, x[nonmembers], y[nonmembers], device, "binary_logits") - ref_phi_n,
+    def make_model(config: dict) -> nn.Module:
+        return GRUD(
+            input_size=time_steps,
+            hidden_size=hidden_size,
+            X_mean=x_mean,
+            batch_size=int(config["batch_size"]),
+            bn_flag=False,          # BatchNorm is incompatible with Opacus
+            force_functorch=True,   # custom FilterLinear needs the functorch grad sampler
         )
 
-    return train_fn, utility_fn, attack_fn
+    return PETRecipe(
+        make_model=make_model,
+        make_optimizer=lambda params, config: optim.Adam(params, lr=config["learning_rate"]),
+        make_loader=lambda indices, config: DataLoader(
+            TensorDataset(x[indices], splits["y"][indices]),
+            batch_size=int(config["batch_size"]), shuffle=True,
+        ),
+        criterion=nn.BCEWithLogitsLoss(),
+        epochs=epochs,
+        output_kind="binary_logits",
+    )
 
 
 
@@ -224,12 +168,19 @@ def main() -> None:
         args.n_configs, args.epochs, args.n_refs = 2, 1, 1
         args.out = args.out + "_smoke"
 
-    # Campaign re-seeds torch per configuration from (seed, index); this covers
-    # only what happens before the loop starts.
+    # Seed torch too: numpy covers the Sobol draw and the split permutation,
+    # but model init, shuffling, Poisson sampling and the DP noise run off
+    # torch's global RNG.
     torch.manual_seed(args.seed)
     splits = load_splits(seed=args.seed)
+    # Auto-detected on purpose: GRUD pins X_mean, the identity matrix and
+    # FilterLinear's filter to this device at construction, and .to(device)
+    # does not move those unregistered attributes — a flag would accept a
+    # value it cannot honor.
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    train_fn, utility_fn, attack_fn = make_fns(splits, args.epochs, args.n_refs, device)
+    recipe = make_recipe(splits, args.epochs)
+    train_fn, utility_fn, attack_fn = build_campaign_fns(
+        recipe, splits, n_refs=args.n_refs, device=device, utility_metric="auc")
 
     campaign = Campaign(
         train_fn, utility_fn, attack_fn,

--- a/examples/mia/cifar/pet_optimization/run_campaign.py
+++ b/examples/mia/cifar/pet_optimization/run_campaign.py
@@ -6,15 +6,11 @@
 
 The leaky-by-design counterpart of the LOS campaign: a small convolutional
 network trained on a 15k subset of CIFAR-10 memorizes visibly, so the
-utility-vs-attack frontier has a real privacy axis to trace. Same design as
-the LOS example:
+utility-vs-attack frontier has a real privacy axis to trace.
 
-- Joint DP-SGD knobs {noise multiplier, clip norm, lr, batch size}; noise may
-  be swept down to (near) zero via --include-nonprivate to anchor the leaky end.
-- Utility: test accuracy.
-- Attack: matched-reference MIA, references trained with the candidate's
-  config on disjoint data (full mimicry).
-- Loop metric: TPR @ FPR = 1%.
+The training loop, attack and utility evaluation all come from the shared
+``PETRecipe`` path in ``leakpro.optimization`` — this file only declares the
+recipe (model, optimizer, loader, loss) and the data splits.
 
 Usage:
     python run_campaign.py --smoke          # 2 configs, pipeline check
@@ -30,8 +26,6 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from opacus import PrivacyEngine
-from opacus.utils.batch_memory_manager import BatchMemoryManager
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -39,17 +33,16 @@ EXAMPLE_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(EXAMPLE_DIR))  # cifar_data_handler must be importable for unpickling
 
 from leakpro.optimization import (
-    AttackScores,
     Campaign,
     Knob,
     KnobSpace,
-    confidence_signal,
+    PETRecipe,
+    build_campaign_fns,
     pareto_front,
     plot_frontier,
 )
 from leakpro.utils.logger import logger
 
-DELTA = 1e-5
 N_TARGET_TRAIN = 15000
 N_AUDIT = 2000
 NUM_CLASSES = 10
@@ -112,95 +105,19 @@ def load_splits(seed: int = 0, audit_size: int = N_AUDIT) -> dict:
     }
 
 
-def train_dpsgd_cnn(config: dict, splits: dict, train_indices: np.ndarray,
-                    epochs: int, device: str) -> nn.Module:
-    """Train one SmallCNN with DP-SGD under the sampled config (noise 0 = non-private SGD baseline)."""
-    x, y = splits["x"], splits["y"]
-    loader = DataLoader(
-        TensorDataset(x[train_indices], y[train_indices]),
-        batch_size=int(config["batch_size"]), shuffle=True,
+def make_recipe(splits: dict, epochs: int) -> PETRecipe:
+    """The CIFAR training recipe: SmallCNN + SGD(momentum) + CrossEntropy."""
+    return PETRecipe(
+        make_model=lambda config: SmallCNN(),
+        make_optimizer=lambda params, config: optim.SGD(params, lr=config["learning_rate"], momentum=0.9),
+        make_loader=lambda indices, config: DataLoader(
+            TensorDataset(splits["x"][indices], splits["y"][indices]),
+            batch_size=int(config["batch_size"]), shuffle=True,
+        ),
+        criterion=nn.CrossEntropyLoss(),
+        epochs=epochs,
+        output_kind="logits",
     )
-    model = SmallCNN().to(device)
-    optimizer = optim.SGD(model.parameters(), lr=config["learning_rate"], momentum=0.9)
-    criterion = nn.CrossEntropyLoss()
-
-    epsilon = float("inf")
-    if config["noise_multiplier"] > 0:
-        engine = PrivacyEngine(accountant="rdp")
-        model, optimizer, loader = engine.make_private(
-            module=model,
-            optimizer=optimizer,
-            data_loader=loader,
-            noise_multiplier=config["noise_multiplier"],
-            max_grad_norm=config["max_grad_norm"],
-        )
-
-    def run_epochs(epoch_loader) -> None:
-        for _ in range(epochs):
-            for xb, yb in epoch_loader:
-                optimizer.zero_grad()
-                loss = criterion(model(xb.to(device)), yb.to(device))
-                loss.backward()
-                optimizer.step()
-
-    model.train()
-    if config["noise_multiplier"] > 0:
-        # Cap the physical batch: per-example gradients cost batch x params memory.
-        # The sampled (logical) batch size, and hence the accounting, is unchanged.
-        with BatchMemoryManager(data_loader=loader, max_physical_batch_size=256,
-                                optimizer=optimizer) as mem_loader:
-            run_epochs(mem_loader)
-        epsilon = engine.get_epsilon(delta=DELTA)
-    else:
-        run_epochs(loader)
-    logger.info(f"Trained CNN: formal epsilon = {epsilon:.2f} (delta = {DELTA}).")
-    model.campaign_extras = {"epsilon": epsilon, "delta": DELTA}
-    return model.eval()
-
-
-def make_fns(splits: dict, epochs: int, n_refs: int, device: str, ref_seed: int = 1) -> tuple:
-    """Build the campaign's (train, utility, attack) callables."""
-
-    def train_fn(config: dict) -> nn.Module:
-        if device.startswith("cuda"):
-            torch.cuda.empty_cache()  # models from the previous config are gone; release their cache
-        return train_dpsgd_cnn(config, splits, splits["target_train"], epochs, device)
-
-    @torch.no_grad()
-    def utility_fn(model: nn.Module) -> float:
-        idx = splits["utility_eval"]
-        correct, total = 0, 0
-        for i in range(0, len(idx), 1024):
-            batch = idx[i:i + 1024]
-            pred = model(splits["x"][batch].to(device)).argmax(dim=1).cpu()
-            correct += int((pred == splits["y"][batch]).sum())
-            total += len(batch)
-        return correct / total
-
-    def attack_fn(model: nn.Module, config: dict) -> AttackScores:
-        # Full mimicry: references share the candidate's config, on disjoint data.
-        rng = np.random.default_rng(ref_seed)
-        x, y = splits["x"], splits["y"]
-        members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
-
-        # Train references one at a time and free each after scoring (GPU memory).
-        ref_phi_members = np.zeros(len(members))
-        ref_phi_nonmembers = np.zeros(len(nonmembers))
-        for _ in range(n_refs):
-            sub = rng.choice(splits["ref_pool"], size=N_TARGET_TRAIN, replace=False)
-            ref = train_dpsgd_cnn(config, splits, sub, epochs, device)
-            ref_phi_members += confidence_signal(ref, x[members], y[members], device, "logits") / n_refs
-            ref_phi_nonmembers += confidence_signal(ref, x[nonmembers], y[nonmembers], device, "logits") / n_refs
-            del ref
-            if device.startswith("cuda"):
-                torch.cuda.empty_cache()
-
-        return AttackScores(
-            member_scores=confidence_signal(model, x[members], y[members], device, "logits") - ref_phi_members,
-            nonmember_scores=confidence_signal(model, x[nonmembers], y[nonmembers], device, "logits") - ref_phi_nonmembers,
-        )
-
-    return train_fn, utility_fn, attack_fn
 
 
 
@@ -261,12 +178,16 @@ def main() -> None:
         args.n_configs, args.epochs, args.n_refs = 2, 2, 1
         args.out = args.out + "_smoke"
 
-    # Campaign re-seeds torch per configuration from (seed, index), so training
-    # is reproducible regardless of how many configs ran before it in this
-    # process. This seeds only what happens before the loop.
+    # Seed torch too: the Sobol draw and the split permutation are numpy, but
+    # model init, DataLoader shuffling, Opacus Poisson sampling and the DP noise
+    # itself all run off torch's global RNG. Without this, --seed does not make
+    # a run reproducible and the resume/validation seed guards promise more than
+    # they deliver.
     torch.manual_seed(args.seed)
     splits = load_splits(seed=args.seed)
-    train_fn, utility_fn, attack_fn = make_fns(splits, args.epochs, args.n_refs, args.device)
+    recipe = make_recipe(splits, args.epochs)
+    train_fn, utility_fn, attack_fn = build_campaign_fns(
+        recipe, splits, n_refs=args.n_refs, device=args.device, utility_metric="accuracy")
 
     campaign = Campaign(
         train_fn, utility_fn, attack_fn,

--- a/examples/mia/cifar/pet_optimization/validate_frontier.py
+++ b/examples/mia/cifar/pet_optimization/validate_frontier.py
@@ -27,20 +27,22 @@ import numpy as np
 import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from run_campaign import N_TARGET_TRAIN, load_splits, train_dpsgd_cnn  # noqa: E402
+from run_campaign import N_TARGET_TRAIN, load_splits, make_recipe  # noqa: E402
 
 from leakpro.optimization import (  # noqa: E402
     AttackScores,
     EvaluationRecord,
+    PETRecipe,
     confidence_signal,
     proxy_agreement,
+    train_with_dpsgd,
     validate_frontier,
 )
 from leakpro.optimization.validation import resolution_warning  # noqa: E402
 from leakpro.utils.logger import logger  # noqa: E402
 
 
-def make_revalidate_fn(splits: dict, epochs: int, n_refs: int, device: str,
+def make_revalidate_fn(splits: dict, recipe: PETRecipe, n_refs: int, device: str,
                        audit_size: int, seed: int = 99) -> callable:
     """Stronger attack: more matched references, larger audit set, fresh reference seed.
 
@@ -54,23 +56,24 @@ def make_revalidate_fn(splits: dict, epochs: int, n_refs: int, device: str,
 
     def revalidate_fn(config: dict) -> AttackScores:
         x, y = splits["x"], splits["y"]
-        target = train_dpsgd_cnn(config, splits, splits["target_train"], epochs, device)
+        kind = recipe.output_kind
+        target = train_with_dpsgd(recipe, config, splits["target_train"], device)
 
         ref_phi_m = np.zeros(len(members))
         ref_phi_n = np.zeros(len(nonmembers))
         rng = np.random.default_rng(rng_master.integers(1 << 30))
         for _ in range(n_refs):
             sub = rng.choice(splits["ref_pool"], size=N_TARGET_TRAIN, replace=False)
-            ref = train_dpsgd_cnn(config, splits, sub, epochs, device)
-            ref_phi_m += confidence_signal(ref, x[members], y[members], device, "logits") / n_refs
-            ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, "logits") / n_refs
+            ref = train_with_dpsgd(recipe, config, sub, device)
+            ref_phi_m += confidence_signal(ref, x[members], y[members], device, kind) / n_refs
+            ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, kind) / n_refs
             del ref
             if device.startswith("cuda"):
                 torch.cuda.empty_cache()
 
         scores = AttackScores(
-            member_scores=confidence_signal(target, x[members], y[members], device, "logits") - ref_phi_m,
-            nonmember_scores=confidence_signal(target, x[nonmembers], y[nonmembers], device, "logits") - ref_phi_n,
+            member_scores=confidence_signal(target, x[members], y[members], device, kind) - ref_phi_m,
+            nonmember_scores=confidence_signal(target, x[nonmembers], y[nonmembers], device, kind) - ref_phi_n,
         )
         del target
         if device.startswith("cuda"):
@@ -125,7 +128,8 @@ def main() -> None:
     if warning:
         logger.warning(warning)
 
-    revalidate_fn = make_revalidate_fn(splits, args.epochs, args.n_refs, args.device, args.audit_size)
+    recipe = make_recipe(splits, args.epochs)
+    revalidate_fn = make_revalidate_fn(splits, recipe, args.n_refs, args.device, args.audit_size)
 
     start = time.time()
     validated = validate_frontier(records, revalidate_fn, report_fprs=tuple(args.report_fprs))

--- a/leakpro/optimization/__init__.py
+++ b/leakpro/optimization/__init__.py
@@ -13,7 +13,12 @@ from leakpro.optimization.objectives import (
     confidence_signal,
     tpr_at_fpr,
 )
-from leakpro.optimization.training import PETRecipe, build_campaign_fns, train_with_dpsgd
+from leakpro.optimization.training import (
+    PETRecipe,
+    build_campaign_fns,
+    make_opacus_compatible,
+    train_with_dpsgd,
+)
 from leakpro.optimization.validation import proxy_agreement, resolution_warning, validate_frontier
 
 __all__ = [
@@ -27,6 +32,7 @@ __all__ = [
     "clopper_pearson_ci",
     "confidence_signal",
     "default_dpsgd_space",
+    "make_opacus_compatible",
     "pareto_front",
     "plot_frontier",
     "proxy_agreement",

--- a/leakpro/optimization/__init__.py
+++ b/leakpro/optimization/__init__.py
@@ -13,6 +13,7 @@ from leakpro.optimization.objectives import (
     confidence_signal,
     tpr_at_fpr,
 )
+from leakpro.optimization.training import PETRecipe, build_campaign_fns, train_with_dpsgd
 from leakpro.optimization.validation import proxy_agreement, resolution_warning, validate_frontier
 
 __all__ = [
@@ -21,6 +22,8 @@ __all__ = [
     "EvaluationRecord",
     "Knob",
     "KnobSpace",
+    "PETRecipe",
+    "build_campaign_fns",
     "clopper_pearson_ci",
     "confidence_signal",
     "default_dpsgd_space",
@@ -29,5 +32,6 @@ __all__ = [
     "proxy_agreement",
     "resolution_warning",
     "tpr_at_fpr",
+    "train_with_dpsgd",
     "validate_frontier",
 ]

--- a/leakpro/optimization/training.py
+++ b/leakpro/optimization/training.py
@@ -1,0 +1,207 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Structured PET recipe and the shared DP-SGD training path.
+
+A ``PETRecipe`` is the plan's structured training contract: instead of a
+monolithic ``train(data) -> model``, the user provides factories the optimizer
+can intervene in. Every factory receives the sampled knob configuration and
+picks out what it needs — ``make_loader`` reads ``batch_size``,
+``make_optimizer`` reads ``learning_rate``. Unused knobs are ignored, which is
+what makes further PETs cheap: a regularization bundle is just ``make_model``
+reading ``dropout`` and ``make_optimizer`` reading ``weight_decay``.
+
+``train_with_dpsgd`` is the single Opacus path (privacy engine, physical-batch
+cap, ε accounting) previously duplicated per example. ``build_campaign_fns``
+turns a recipe plus data splits into the three callables a ``Campaign`` needs;
+exotic training loops that do not fit the recipe keep the escape hatch of
+writing those callables directly.
+"""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+
+import numpy as np
+import torch
+from opacus import PrivacyEngine
+from opacus.utils.batch_memory_manager import BatchMemoryManager
+from torch.nn import Module, Parameter
+from torch.nn.modules.loss import _Loss
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader
+
+from leakpro.optimization.objectives import AttackScores, confidence_signal
+from leakpro.utils.logger import logger
+
+REQUIRED_SPLIT_KEYS = ("x", "y", "target_train", "ref_pool", "audit_members", "audit_nonmembers", "utility_eval")
+
+
+@dataclass(frozen=True)
+class PETRecipe:
+    """Structured training recipe: the factories a PET optimizer may intervene in.
+
+    Args:
+        make_model: config -> a fresh, untrained model.
+        make_optimizer: (parameters, config) -> optimizer (reads e.g. ``learning_rate``).
+        make_loader: (indices, config) -> training DataLoader (reads e.g. ``batch_size``).
+        criterion: loss module shared by target and reference models.
+        epochs: fixed number of training epochs.
+        output_kind: "logits" for raw multiclass logits (CrossEntropyLoss models),
+            "binary_probs" for a single sigmoid output column (BCELoss models).
+            Decides how membership confidence is extracted.
+
+    """
+
+    make_model: Callable[[dict], Module]
+    make_optimizer: Callable[[Iterable[Parameter], dict], Optimizer]
+    make_loader: Callable[[np.ndarray, dict], DataLoader]
+    criterion: _Loss
+    epochs: int
+    output_kind: str = field(default="logits")
+
+    def __post_init__(self) -> None:
+        """Validate the output kind."""
+        if self.output_kind not in ("logits", "binary_probs"):
+            raise ValueError(f"output_kind must be 'logits' or 'binary_probs', got '{self.output_kind}'.")
+
+
+def train_with_dpsgd(  # noqa: PLR0913
+    recipe: PETRecipe,
+    config: dict,
+    train_indices: np.ndarray,
+    device: str,
+    delta: float = 1e-5,
+    max_physical_batch: int = 256,
+) -> Module:
+    """Train one model under the sampled config; the single shared Opacus path.
+
+    ``noise_multiplier > 0`` wraps the loop in a PrivacyEngine with the physical
+    batch capped at ``max_physical_batch`` (per-example gradients cost
+    batch x params memory; the sampled batch size and the accounting are
+    unchanged). ``noise_multiplier == 0`` runs the plain loop — the non-private
+    anchor, ε = ∞.
+
+    The formal (ε, δ) is stored on the returned model as ``campaign_extras``,
+    which ``Campaign`` records next to the empirical attack result.
+    """
+    loader = recipe.make_loader(train_indices, config)
+    model = recipe.make_model(config).to(device)
+    optimizer = recipe.make_optimizer(model.parameters(), config)
+    private = config.get("noise_multiplier", 0) > 0
+
+    def run_epochs(epoch_loader) -> None:  # noqa: ANN001
+        for _ in range(recipe.epochs):
+            for xb, yb in epoch_loader:
+                optimizer.zero_grad()
+                loss = recipe.criterion(model(xb.to(device)), yb.to(device))
+                loss.backward()
+                optimizer.step()
+
+    model.train()
+    if private:
+        engine = PrivacyEngine(accountant="rdp")
+        model, optimizer, loader = engine.make_private(
+            module=model,
+            optimizer=optimizer,
+            data_loader=loader,
+            noise_multiplier=config["noise_multiplier"],
+            max_grad_norm=config["max_grad_norm"],
+        )
+        with BatchMemoryManager(data_loader=loader, max_physical_batch_size=max_physical_batch,
+                                optimizer=optimizer) as mem_loader:
+            run_epochs(mem_loader)
+        epsilon = engine.get_epsilon(delta=delta)
+    else:
+        run_epochs(loader)
+        epsilon = float("inf")
+
+    logger.info(f"Trained model: formal epsilon = {epsilon:.2f} (delta = {delta}).")
+    model.campaign_extras = {"epsilon": epsilon, "delta": delta}
+    return model.eval()
+
+
+def _free_cuda(device: str) -> None:
+    if device.startswith("cuda"):
+        torch.cuda.empty_cache()
+
+
+@torch.no_grad()
+def _evaluate_utility(model: Module, metric: str | Callable, x: torch.Tensor,
+                      y: torch.Tensor, device: str) -> float:
+    if callable(metric):
+        return float(metric(model, x, y, device))
+    if metric == "accuracy":
+        correct = 0
+        for i in range(0, len(x), 1024):
+            pred = model(x[i:i + 1024].to(device)).argmax(dim=1).cpu()
+            correct += int((pred == y[i:i + 1024]).sum())
+        return correct / len(x)
+    if metric == "auc":
+        from sklearn.metrics import roc_auc_score
+        scores = [model(x[i:i + 4096].to(device)).cpu().reshape(-1) for i in range(0, len(x), 4096)]
+        return float(roc_auc_score(y.numpy().ravel(), torch.cat(scores).numpy()))
+    raise ValueError(f"Unknown utility_metric '{metric}'; use 'accuracy', 'auc' or a callable.")
+
+
+def build_campaign_fns(  # noqa: PLR0913
+    recipe: PETRecipe,
+    splits: dict,
+    n_refs: int,
+    device: str,
+    utility_metric: str | Callable = "accuracy",
+    ref_seed: int = 1,
+) -> tuple[Callable, Callable, Callable]:
+    """Turn a recipe + data splits into a Campaign's (train_fn, utility_fn, attack_fn).
+
+    Args:
+        recipe: the structured training recipe.
+        splits: dict with keys ``x, y, target_train, ref_pool, audit_members,
+            audit_nonmembers, utility_eval`` (audit members must be a subset of
+            ``target_train``; the reference pool must be disjoint from it).
+        n_refs: matched reference models per attack — full mimicry: references
+            are trained with the candidate's config via the same recipe.
+        device: torch device string.
+        utility_metric: "accuracy", "auc", or a callable (model, x, y, device) -> float.
+        ref_seed: seed for reference-pool subsampling.
+
+    """
+    missing = [k for k in REQUIRED_SPLIT_KEYS if k not in splits]
+    if missing:
+        raise KeyError(f"splits is missing {missing}; required keys are {REQUIRED_SPLIT_KEYS}.")
+    if len(splits["ref_pool"]) == 0:
+        raise ValueError("Reference pool is empty; the matched attack needs disjoint training data.")
+
+    def train_fn(config: dict) -> Module:
+        _free_cuda(device)
+        return train_with_dpsgd(recipe, config, splits["target_train"], device)
+
+    def utility_fn(model: Module) -> float:
+        idx = splits["utility_eval"]
+        return _evaluate_utility(model, utility_metric, splits["x"][idx], splits["y"][idx], device)
+
+    def attack_fn(model: Module, config: dict) -> AttackScores:
+        rng = np.random.default_rng(ref_seed)
+        x, y = splits["x"], splits["y"]
+        members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
+        n_ref_train = min(len(splits["target_train"]), len(splits["ref_pool"]))
+
+        # References are trained one at a time and freed after scoring (GPU memory).
+        ref_phi_m = np.zeros(len(members))
+        ref_phi_n = np.zeros(len(nonmembers))
+        for _ in range(n_refs):
+            sub = rng.choice(splits["ref_pool"], size=n_ref_train, replace=False)
+            ref = train_with_dpsgd(recipe, config, sub, device)
+            ref_phi_m += confidence_signal(ref, x[members], y[members], device, recipe.output_kind) / n_refs
+            ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, recipe.output_kind) / n_refs
+            del ref
+            _free_cuda(device)
+
+        return AttackScores(
+            member_scores=confidence_signal(model, x[members], y[members], device, recipe.output_kind) - ref_phi_m,
+            nonmember_scores=(
+                confidence_signal(model, x[nonmembers], y[nonmembers], device, recipe.output_kind) - ref_phi_n
+            ),
+        )
+
+    return train_fn, utility_fn, attack_fn

--- a/leakpro/optimization/training.py
+++ b/leakpro/optimization/training.py
@@ -93,11 +93,20 @@ def _patch_residual_blocks(model: Module) -> None:
         out = self.bn3(self.conv3(out))
         return self.relu(out + identity)
 
+    # Only patch blocks that still use the stock forward. A subclass overriding
+    # forward (SE, attention, anything custom) would be silently replaced by the
+    # vanilla residual path, changing the model instead of just making it
+    # Opacus-safe.
     for module in model.modules():
-        if isinstance(module, BasicBlock):
+        if isinstance(module, BasicBlock) and type(module).forward is BasicBlock.forward:
             module.forward = MethodType(basic_forward, module)
-        elif isinstance(module, Bottleneck):
+        elif isinstance(module, Bottleneck) and type(module).forward is Bottleneck.forward:
             module.forward = MethodType(bottleneck_forward, module)
+        elif isinstance(module, (BasicBlock, Bottleneck)):
+            logger.warning(
+                f"{type(module).__name__} overrides forward; leaving it untouched. If it adds the "
+                "residual in place, Opacus will reject it — rewrite that forward out of place."
+            )
 
 
 def make_opacus_compatible(model: Module) -> Module:
@@ -135,12 +144,19 @@ def train_with_dpsgd(  # noqa: PLR0913
 ) -> Module:
     """Train one model under the sampled config; the single shared Opacus path.
 
-    ``noise_multiplier > 0`` runs the model through ``make_opacus_compatible``
-    and wraps the loop in a PrivacyEngine with the physical batch capped at
-    ``max_physical_batch`` (per-example gradients cost batch x params memory;
-    the sampled batch size and the accounting are unchanged).
-    ``noise_multiplier == 0`` runs the plain loop, untouched — the non-private
-    anchor, ε = ∞.
+    Every model goes through ``make_opacus_compatible`` regardless of noise, so
+    all points on one frontier share an architecture: applying the BatchNorm to
+    GroupNorm rewrite only to private configs would leave the non-private anchor
+    a structurally different model, and its utility gap would then mix the cost
+    of DP noise with the cost of an architecture change. The submitted
+    architecture is therefore not necessarily what gets trained — check the log
+    for the ModuleValidator notice.
+
+    ``noise_multiplier > 0`` wraps the loop in a PrivacyEngine with the physical
+    batch capped at ``max_physical_batch`` (per-example gradients cost
+    batch x params memory; the sampled batch size and the accounting are
+    unchanged). ``noise_multiplier == 0`` runs the plain loop — the non-private
+    anchor, ε = ∞. The key is required either way: see below.
 
     ``accountant`` must match whatever else in the pipeline reports ε, or the
     numbers are not comparable: PRV is tighter than RDP, so the same noise reads
@@ -150,12 +166,22 @@ def train_with_dpsgd(  # noqa: PLR0913
     The formal (ε, δ) is stored on the returned model as ``campaign_extras``,
     which ``Campaign`` records next to the empirical attack result.
     """
+    # Never default this: a missing or misspelled key would silently train a
+    # fully non-private model from a function whose whole purpose is DP-SGD.
+    # Non-private runs must say so by passing an explicit 0.
+    if "noise_multiplier" not in config:
+        raise KeyError(
+            "config has no 'noise_multiplier'. Pass an explicit 0.0 for the non-private anchor; "
+            "defaulting it would silently disable DP-SGD."
+        )
+    private = config["noise_multiplier"] > 0
+
     loader = recipe.make_loader(train_indices, config)
-    model = recipe.make_model(config).to(device)
-    private = config.get("noise_multiplier", 0) > 0
-    if private:
-        # Before the optimizer: fixing the model can replace parameter objects.
-        model = make_opacus_compatible(model).to(device)
+    # Applied on both branches so every point on a frontier shares one
+    # architecture: rewriting BatchNorm only for private configs would make the
+    # non-private anchor a different model, and its utility gap would then mix
+    # the cost of DP noise with the cost of an architecture change.
+    model = make_opacus_compatible(recipe.make_model(config)).to(device)
     optimizer = recipe.make_optimizer(model.parameters(), config)
 
     def run_epochs(epoch_loader) -> None:  # noqa: ANN001
@@ -185,7 +211,11 @@ def train_with_dpsgd(  # noqa: PLR0913
         epsilon = float("inf")
 
     logger.info(f"Trained model: formal epsilon = {epsilon:.2f} (delta = {delta}).")
-    model.campaign_extras = {"epsilon": epsilon, "delta": delta}
+    # The accountant travels with the number: PRV and RDP epsilons are not
+    # comparable, so a record that does not name its accountant cannot be
+    # safely compared with one from another run.
+    model.campaign_extras = {"epsilon": epsilon, "delta": delta,
+                             "accountant": accountant if private else None}
     return model.eval()
 
 
@@ -207,8 +237,16 @@ def _evaluate_utility(model: Module, metric: str | Callable, x: torch.Tensor,
         return correct / len(x)
     if metric == "auc":
         from sklearn.metrics import roc_auc_score
-        scores = [model(x[i:i + 4096].to(device)).cpu().reshape(-1) for i in range(0, len(x), 4096)]
-        return float(roc_auc_score(y.numpy().ravel(), torch.cat(scores).numpy()))
+        outs = [model(x[i:i + 4096].to(device)).cpu() for i in range(0, len(x), 4096)]
+        scores = torch.cat(outs)
+        # Flattening a multiclass output would interleave class scores with
+        # sample labels and produce a meaningless number, so refuse instead.
+        if scores.ndim > 1 and scores.shape[-1] != 1:
+            raise ValueError(
+                f"utility_metric='auc' needs a single-column model output, got shape {tuple(scores.shape)}. "
+                "Use 'accuracy' for multiclass models, or pass a callable."
+            )
+        return float(roc_auc_score(y.numpy().ravel(), scores.reshape(-1).numpy()))
     raise ValueError(f"Unknown utility_metric '{metric}'; use 'accuracy', 'auc' or a callable.")
 
 
@@ -247,6 +285,15 @@ def build_campaign_fns(  # noqa: PLR0913
         raise KeyError(f"splits is missing {missing}; required keys are {REQUIRED_SPLIT_KEYS}.")
     if len(splits["ref_pool"]) == 0:
         raise ValueError("Reference pool is empty; the matched attack needs disjoint training data.")
+    # Full mimicry means references train on as much data as the target. Quietly
+    # shrinking them would weaken the attack and make the audit read safer than
+    # it is, so a short reference pool is an error, not a silent downgrade.
+    if len(splits["ref_pool"]) < len(splits["target_train"]):
+        raise ValueError(
+            f"Reference pool ({len(splits['ref_pool'])}) is smaller than the target's training set "
+            f"({len(splits['target_train'])}). Full mimicry needs at least as many reference samples; "
+            "shrinking them silently would bias the audit optimistic."
+        )
 
     train_kwargs = {"delta": delta, "max_physical_batch": max_physical_batch, "accountant": accountant}
 
@@ -262,7 +309,7 @@ def build_campaign_fns(  # noqa: PLR0913
         rng = np.random.default_rng(ref_seed)
         x, y = splits["x"], splits["y"]
         members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
-        n_ref_train = min(len(splits["target_train"]), len(splits["ref_pool"]))
+        n_ref_train = len(splits["target_train"])  # guaranteed <= ref_pool by the check above
 
         # References are trained one at a time and freed after scoring (GPU memory).
         ref_phi_m = np.zeros(len(members))

--- a/leakpro/optimization/training.py
+++ b/leakpro/optimization/training.py
@@ -21,11 +21,13 @@ writing those callables directly.
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from types import MethodType
 
 import numpy as np
 import torch
 from opacus import PrivacyEngine
 from opacus.utils.batch_memory_manager import BatchMemoryManager
+from opacus.validators import ModuleValidator
 from torch.nn import Module, Parameter
 from torch.nn.modules.loss import _Loss
 from torch.optim import Optimizer
@@ -66,6 +68,62 @@ class PETRecipe:
             raise ValueError(f"output_kind must be 'logits' or 'binary_probs', got '{self.output_kind}'.")
 
 
+def _patch_residual_blocks(model: Module) -> None:
+    """Rewrite torchvision residual blocks to add the skip connection out of place.
+
+    ``ModuleValidator`` cannot fix this: ``out += identity`` lives in the block's
+    ``forward``, not in a submodule, and the in-place add overwrites the tensor
+    Opacus's backward hooks need. Silently does nothing if torchvision is absent.
+    """
+    try:
+        from torchvision.models.resnet import BasicBlock, Bottleneck
+    except ImportError:
+        return
+
+    def basic_forward(self: Module, x: torch.Tensor) -> torch.Tensor:
+        identity = x if self.downsample is None else self.downsample(x)
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        return self.relu(out + identity)
+
+    def bottleneck_forward(self: Module, x: torch.Tensor) -> torch.Tensor:
+        identity = x if self.downsample is None else self.downsample(x)
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.relu(self.bn2(self.conv2(out)))
+        out = self.bn3(self.conv3(out))
+        return self.relu(out + identity)
+
+    for module in model.modules():
+        if isinstance(module, BasicBlock):
+            module.forward = MethodType(basic_forward, module)
+        elif isinstance(module, Bottleneck):
+            module.forward = MethodType(bottleneck_forward, module)
+
+
+def make_opacus_compatible(model: Module) -> Module:
+    """Rewrite a module until Opacus can attach per-sample gradient hooks to it.
+
+    Three incompatibilities, in the order they bite: BatchNorm mixes samples
+    within a batch, so ``ModuleValidator`` swaps it for GroupNorm; in-place
+    activations overwrite tensors the hooks still need; and torchvision's
+    residual blocks add their skip connection in place (see
+    ``_patch_residual_blocks``).
+
+    Returns the fixed module, which may be a different object than the input —
+    build the optimizer from *this* model's parameters, not the original's.
+    """
+    if ModuleValidator.validate(model, strict=False):
+        model = ModuleValidator.fix(model)
+        logger.info("Model was not Opacus-compatible; ModuleValidator.fix() applied (BatchNorm -> GroupNorm).")
+
+    for module in model.modules():
+        if isinstance(getattr(module, "inplace", None), bool):
+            module.inplace = False
+
+    _patch_residual_blocks(model)
+    return model
+
+
 def train_with_dpsgd(  # noqa: PLR0913
     recipe: PETRecipe,
     config: dict,
@@ -73,22 +131,32 @@ def train_with_dpsgd(  # noqa: PLR0913
     device: str,
     delta: float = 1e-5,
     max_physical_batch: int = 256,
+    accountant: str = "prv",
 ) -> Module:
     """Train one model under the sampled config; the single shared Opacus path.
 
-    ``noise_multiplier > 0`` wraps the loop in a PrivacyEngine with the physical
-    batch capped at ``max_physical_batch`` (per-example gradients cost
-    batch x params memory; the sampled batch size and the accounting are
-    unchanged). ``noise_multiplier == 0`` runs the plain loop — the non-private
+    ``noise_multiplier > 0`` runs the model through ``make_opacus_compatible``
+    and wraps the loop in a PrivacyEngine with the physical batch capped at
+    ``max_physical_batch`` (per-example gradients cost batch x params memory;
+    the sampled batch size and the accounting are unchanged).
+    ``noise_multiplier == 0`` runs the plain loop, untouched — the non-private
     anchor, ε = ∞.
+
+    ``accountant`` must match whatever else in the pipeline reports ε, or the
+    numbers are not comparable: PRV is tighter than RDP, so the same noise reads
+    as a smaller ε under "prv". It defaults to "prv" for agreement with the
+    webapp's DP-SGD path.
 
     The formal (ε, δ) is stored on the returned model as ``campaign_extras``,
     which ``Campaign`` records next to the empirical attack result.
     """
     loader = recipe.make_loader(train_indices, config)
     model = recipe.make_model(config).to(device)
-    optimizer = recipe.make_optimizer(model.parameters(), config)
     private = config.get("noise_multiplier", 0) > 0
+    if private:
+        # Before the optimizer: fixing the model can replace parameter objects.
+        model = make_opacus_compatible(model).to(device)
+    optimizer = recipe.make_optimizer(model.parameters(), config)
 
     def run_epochs(epoch_loader) -> None:  # noqa: ANN001
         for _ in range(recipe.epochs):
@@ -100,7 +168,7 @@ def train_with_dpsgd(  # noqa: PLR0913
 
     model.train()
     if private:
-        engine = PrivacyEngine(accountant="rdp")
+        engine = PrivacyEngine(accountant=accountant)
         model, optimizer, loader = engine.make_private(
             module=model,
             optimizer=optimizer,
@@ -151,6 +219,9 @@ def build_campaign_fns(  # noqa: PLR0913
     device: str,
     utility_metric: str | Callable = "accuracy",
     ref_seed: int = 1,
+    delta: float = 1e-5,
+    max_physical_batch: int = 256,
+    accountant: str = "prv",
 ) -> tuple[Callable, Callable, Callable]:
     """Turn a recipe + data splits into a Campaign's (train_fn, utility_fn, attack_fn).
 
@@ -164,6 +235,11 @@ def build_campaign_fns(  # noqa: PLR0913
         device: torch device string.
         utility_metric: "accuracy", "auc", or a callable (model, x, y, device) -> float.
         ref_seed: seed for reference-pool subsampling.
+        delta: privacy-accounting δ, passed to every training run.
+        max_physical_batch: per-example-gradient memory cap; does not change the
+            sampled batch size or the accounting.
+        accountant: Opacus accountant ("prv", "rdp", "gdp"). Reference models use
+            the same one as the target, so mimicry stays exact.
 
     """
     missing = [k for k in REQUIRED_SPLIT_KEYS if k not in splits]
@@ -172,9 +248,11 @@ def build_campaign_fns(  # noqa: PLR0913
     if len(splits["ref_pool"]) == 0:
         raise ValueError("Reference pool is empty; the matched attack needs disjoint training data.")
 
+    train_kwargs = {"delta": delta, "max_physical_batch": max_physical_batch, "accountant": accountant}
+
     def train_fn(config: dict) -> Module:
         _free_cuda(device)
-        return train_with_dpsgd(recipe, config, splits["target_train"], device)
+        return train_with_dpsgd(recipe, config, splits["target_train"], device, **train_kwargs)
 
     def utility_fn(model: Module) -> float:
         idx = splits["utility_eval"]
@@ -194,6 +272,7 @@ def build_campaign_fns(  # noqa: PLR0913
             ref = train_with_dpsgd(recipe, config, sub, device)
             ref_phi_m += confidence_signal(ref, x[members], y[members], device, recipe.output_kind) / n_refs
             ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, recipe.output_kind) / n_refs
+            ref = train_with_dpsgd(recipe, config, sub, device, **train_kwargs)
             del ref
             _free_cuda(device)
 

--- a/leakpro/tests/test_optimization/test_training.py
+++ b/leakpro/tests/test_optimization/test_training.py
@@ -15,6 +15,7 @@ from leakpro.optimization import (
     PETRecipe,
     build_campaign_fns,
     confidence_signal,
+    make_opacus_compatible,
     train_with_dpsgd,
 )
 
@@ -144,3 +145,91 @@ class TestBuildCampaignFns:
             utility_metric=lambda model, x, y, device: 0.42)
         model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
         assert utility_fn(model) == 0.42
+
+
+def _batchnorm_recipe(splits, dim=8, classes=3, epochs=1):
+    """A model Opacus rejects as submitted: BatchNorm mixes samples within a batch."""
+    def make_loader(idx, cfg):
+        return DataLoader(TensorDataset(splits["x"][idx], splits["y"][idx]),
+                          batch_size=int(cfg["batch_size"]), shuffle=True)
+
+    return PETRecipe(
+        make_model=lambda cfg: nn.Sequential(
+            nn.Linear(dim, 16), nn.BatchNorm1d(16), nn.ReLU(inplace=True), nn.Linear(16, classes)),
+        make_optimizer=lambda params, cfg: optim.SGD(params, lr=cfg["learning_rate"]),
+        make_loader=make_loader,
+        criterion=nn.CrossEntropyLoss(),
+        epochs=epochs,
+    )
+
+
+class TestOpacusCompatibility:
+    def test_batchnorm_model_trains_under_dpsgd(self):
+        # Before the ModuleValidator pass this raised straight out of make_private.
+        splits = _toy_splits()
+        model = train_with_dpsgd(_batchnorm_recipe(splits), PRIVATE, splits["target_train"], "cpu")
+        assert np.isfinite(model.campaign_extras["epsilon"])
+
+    def test_batchnorm_is_replaced_and_inplace_disabled(self):
+        fixed = make_opacus_compatible(
+            nn.Sequential(nn.Linear(8, 16), nn.BatchNorm1d(16), nn.ReLU(inplace=True)))
+        assert not any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in fixed.modules())
+        assert not any(getattr(m, "inplace", False) for m in fixed.modules())
+
+    def test_nonprivate_path_leaves_batchnorm_alone(self):
+        # eps = inf means no Opacus, so there is no reason to rewrite the user's model.
+        splits = _toy_splits()
+        model = train_with_dpsgd(_batchnorm_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        assert any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in model.modules())
+
+    def test_compatible_model_is_returned_unchanged(self):
+        model = nn.Sequential(nn.Linear(8, 16), nn.GroupNorm(4, 16))
+        assert make_opacus_compatible(model) is model
+
+    def test_resnet_residual_block_trains_under_dpsgd(self):
+        # torchvision's `out += identity` is in-place and lives in forward, so
+        # ModuleValidator cannot see it; without the patch Opacus's hooks fail here.
+        torchvision = pytest.importorskip("torchvision")
+        rng = np.random.default_rng(0)
+        x = torch.tensor(rng.normal(size=(64, 4, 8, 8)), dtype=torch.float32)
+        y = torch.tensor(rng.integers(0, 3, size=64))
+        splits = {"x": x, "y": y, "target_train": np.arange(64), "ref_pool": np.arange(64),
+                  "audit_members": np.arange(8), "audit_nonmembers": np.arange(8), "utility_eval": np.arange(8)}
+
+        recipe = PETRecipe(
+            make_model=lambda cfg: nn.Sequential(
+                torchvision.models.resnet.BasicBlock(4, 4),
+                nn.AdaptiveAvgPool2d(1), nn.Flatten(), nn.Linear(4, 3)),
+            make_optimizer=lambda params, cfg: optim.SGD(params, lr=cfg["learning_rate"]),
+            make_loader=lambda idx, cfg: DataLoader(
+                TensorDataset(splits["x"][idx], splits["y"][idx]), batch_size=int(cfg["batch_size"]), shuffle=True),
+            criterion=nn.CrossEntropyLoss(),
+            epochs=1,
+        )
+        model = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu")
+        assert np.isfinite(model.campaign_extras["epsilon"])
+
+
+class TestAccountant:
+    def test_accountant_is_configurable_and_changes_epsilon(self):
+        splits = _toy_splits()
+        recipe = _toy_recipe(splits)
+        prv = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", accountant="prv")
+        rdp = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", accountant="rdp")
+        # PRV is the tighter bound, so it must not report a larger epsilon than RDP.
+        assert prv.campaign_extras["epsilon"] < rdp.campaign_extras["epsilon"]
+
+    def test_default_accountant_is_prv(self):
+        splits = _toy_splits()
+        recipe = _toy_recipe(splits)
+        default = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu")
+        prv = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", accountant="prv")
+        assert default.campaign_extras["epsilon"] == pytest.approx(prv.campaign_extras["epsilon"], rel=1e-9)
+
+    def test_build_campaign_fns_threads_accountant_through(self):
+        splits = _toy_splits()
+        train_fn, _, _ = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu", accountant="rdp")
+        direct = train_with_dpsgd(_toy_recipe(splits), PRIVATE, splits["target_train"], "cpu", accountant="rdp")
+        assert train_fn(PRIVATE).campaign_extras["epsilon"] == pytest.approx(
+            direct.campaign_extras["epsilon"], rel=1e-9)

--- a/leakpro/tests/test_optimization/test_training.py
+++ b/leakpro/tests/test_optimization/test_training.py
@@ -18,6 +18,7 @@ from leakpro.optimization import (
     make_opacus_compatible,
     train_with_dpsgd,
 )
+from leakpro.optimization.training import _patch_residual_blocks
 
 
 def _toy_splits(n=600, dim=8, classes=3, seed=0):
@@ -163,6 +164,18 @@ def _batchnorm_recipe(splits, dim=8, classes=3, epochs=1):
     )
 
 
+try:  # torchvision is optional; the subclass test skips without it
+    from torchvision.models.resnet import BasicBlock as _BasicBlock
+
+    class _CustomResidualBlock(_BasicBlock):
+        """A residual block with its own forward — must survive the Opacus patcher untouched."""
+
+        def forward(self, x):  # noqa: ANN001, ANN201, D102
+            return self.conv1(x) * 1.0
+except ImportError:  # pragma: no cover
+    _CustomResidualBlock = None
+
+
 class TestOpacusCompatibility:
     def test_batchnorm_model_trains_under_dpsgd(self):
         # Before the ModuleValidator pass this raised straight out of make_private.
@@ -176,11 +189,58 @@ class TestOpacusCompatibility:
         assert not any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in fixed.modules())
         assert not any(getattr(m, "inplace", False) for m in fixed.modules())
 
-    def test_nonprivate_path_leaves_batchnorm_alone(self):
-        # eps = inf means no Opacus, so there is no reason to rewrite the user's model.
+    def test_nonprivate_anchor_shares_the_private_architecture(self):
+        # Every point on a frontier must be the same model. If only private
+        # configs got BatchNorm -> GroupNorm, the anchor's utility gap would
+        # mix the cost of DP noise with the cost of an architecture change.
         splits = _toy_splits()
-        model = train_with_dpsgd(_batchnorm_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
-        assert any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in model.modules())
+        anchor = train_with_dpsgd(_batchnorm_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        private = train_with_dpsgd(_batchnorm_recipe(splits), PRIVATE, splits["target_train"], "cpu")
+        def leaves(model):
+            return [type(m).__name__ for m in model.modules() if not list(m.children())]
+
+        assert not any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in anchor.modules())
+        # Leaves only: the private model is additionally wrapped in Opacus's
+        # GradSampleModule, which is not an architecture difference.
+        assert leaves(anchor) == leaves(private)
+
+    def test_missing_noise_multiplier_is_rejected(self):
+        # Fail closed: defaulting the key would silently train non-privately.
+        splits = _toy_splits()
+        bad = {k: v for k, v in PRIVATE.items() if k != "noise_multiplier"}
+        with pytest.raises(KeyError, match="noise_multiplier"):
+            train_with_dpsgd(_toy_recipe(splits), bad, splits["target_train"], "cpu")
+
+    def test_accountant_is_recorded_with_the_epsilon(self):
+        splits = _toy_splits()
+        model = train_with_dpsgd(_toy_recipe(splits), PRIVATE, splits["target_train"], "cpu", accountant="rdp")
+        assert model.campaign_extras["accountant"] == "rdp"
+
+    def test_short_reference_pool_is_rejected(self):
+        # Full mimicry is a promise: shrinking references silently would weaken
+        # the attack and bias the audit optimistic.
+        splits = _toy_splits()
+        splits["ref_pool"] = splits["ref_pool"][:10]
+        with pytest.raises(ValueError, match="Full mimicry"):
+            build_campaign_fns(_toy_recipe(splits), splits, n_refs=1, device="cpu")
+
+    def test_auc_metric_refuses_multiclass_output(self):
+        splits = _toy_splits()
+        _, utility_fn, _ = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu", utility_metric="auc")
+        model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        with pytest.raises(ValueError, match="single-column"):
+            utility_fn(model)
+
+    def test_overridden_residual_forward_is_left_alone(self):
+        # The patcher works by assigning a bound method into the instance
+        # __dict__, so that is what "was it patched?" actually means.
+        torchvision = pytest.importorskip("torchvision")
+        custom = _CustomResidualBlock(8, 8)
+        stock = torchvision.models.resnet.BasicBlock(8, 8)
+        _patch_residual_blocks(nn.Sequential(custom, stock))
+        assert "forward" not in custom.__dict__   # subclass left untouched
+        assert "forward" in stock.__dict__        # stock block still patched
 
     def test_compatible_model_is_returned_unchanged(self):
         model = nn.Sequential(nn.Linear(8, 16), nn.GroupNorm(4, 16))

--- a/leakpro/tests/test_optimization/test_training.py
+++ b/leakpro/tests/test_optimization/test_training.py
@@ -1,0 +1,138 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for PETRecipe and the shared DP-SGD training path (CPU, tiny models)."""
+
+import numpy as np
+import pytest
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader, TensorDataset
+
+from leakpro.optimization import (
+    AttackScores,
+    PETRecipe,
+    build_campaign_fns,
+    confidence_signal,
+    train_with_dpsgd,
+)
+
+
+def _toy_splits(n=600, dim=8, classes=3, seed=0):
+    rng = np.random.default_rng(seed)
+    x = torch.tensor(rng.normal(size=(n, dim)), dtype=torch.float32)
+    y = torch.tensor(rng.integers(0, classes, size=n))
+    order = rng.permutation(n)
+    return {
+        "x": x, "y": y,
+        "target_train": order[:200],
+        "ref_pool": order[200:400],
+        "audit_members": order[:100],
+        "audit_nonmembers": order[400:500],
+        "utility_eval": order[500:],
+    }
+
+
+def _toy_recipe(splits=None, dim=8, classes=3, epochs=1):
+    def make_loader(idx, cfg):
+        return DataLoader(TensorDataset(splits["x"][idx], splits["y"][idx]),
+                          batch_size=int(cfg["batch_size"]), shuffle=True)
+
+    return PETRecipe(
+        make_model=lambda cfg: nn.Linear(dim, classes),
+        make_optimizer=lambda params, cfg: optim.SGD(params, lr=cfg["learning_rate"]),
+        make_loader=make_loader,
+        criterion=nn.CrossEntropyLoss(),
+        epochs=epochs,
+    )
+
+
+PRIVATE = {"noise_multiplier": 1.0, "max_grad_norm": 1.0, "learning_rate": 0.1, "batch_size": 64}
+NONPRIVATE = {"noise_multiplier": 0.0, "max_grad_norm": 1.0, "learning_rate": 0.1, "batch_size": 64}
+
+
+class TestTrainWithDPSGD:
+    def test_private_path_records_finite_epsilon(self):
+        splits = _toy_splits()
+        model = train_with_dpsgd(_toy_recipe(splits), PRIVATE, splits["target_train"], "cpu")
+        assert np.isfinite(model.campaign_extras["epsilon"])
+        assert model.campaign_extras["epsilon"] > 0
+
+    def test_nonprivate_path_is_epsilon_inf(self):
+        splits = _toy_splits()
+        model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        assert model.campaign_extras["epsilon"] == float("inf")
+
+    def test_physical_batch_cap_matches_uncapped_accounting(self):
+        splits = _toy_splits()
+        recipe = _toy_recipe(splits)
+        m_small = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", max_physical_batch=16)
+        m_large = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", max_physical_batch=512)
+        # The cap is a memory measure only: the accounting must be identical.
+        assert m_small.campaign_extras["epsilon"] == pytest.approx(m_large.campaign_extras["epsilon"], rel=1e-6)
+
+    def test_invalid_output_kind_rejected(self):
+        with pytest.raises(ValueError):
+            PETRecipe(
+                make_model=lambda cfg: nn.Linear(2, 2),
+                make_optimizer=lambda p, cfg: optim.SGD(p, lr=0.1),
+                make_loader=lambda idx, cfg: None,
+                criterion=nn.CrossEntropyLoss(),
+                epochs=1,
+                output_kind="probabilities",
+            )
+
+
+class TestConfidenceSignal:
+    def test_multiclass_prefers_true_class(self):
+        model = nn.Identity()  # "logits" are the inputs themselves
+        x = torch.eye(3).repeat(4, 1) * 5  # strongly peaked one-hot logits
+        y = torch.arange(3).repeat(4)
+        phi = confidence_signal(model, x, y, "cpu", output_kind="logits")
+        y_wrong = (y + 1) % 3
+        phi_wrong = confidence_signal(model, x, y_wrong, "cpu", output_kind="logits")
+        assert phi.min() > phi_wrong.max()
+
+    def test_binary_probs_symmetry(self):
+        model = nn.Identity()
+        p = torch.tensor([[0.9], [0.9]])
+        y = torch.tensor([[1.0], [0.0]])
+        phi = confidence_signal(model, p, y, "cpu", output_kind="binary_probs")
+        assert phi[0] == pytest.approx(-phi[1])  # log(0.9/0.1) vs log(0.1/0.9)
+
+
+class TestBuildCampaignFns:
+    def test_end_to_end_on_toy_data(self):
+        splits = _toy_splits()
+        train_fn, utility_fn, attack_fn = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu")
+        model = train_fn(NONPRIVATE)
+        acc = utility_fn(model)
+        assert 0.0 <= acc <= 1.0
+        scores = attack_fn(model, NONPRIVATE)
+        assert isinstance(scores, AttackScores)
+        assert len(scores.member_scores) == 100
+        assert len(scores.nonmember_scores) == 100
+
+    def test_missing_split_keys_rejected(self):
+        splits = _toy_splits()
+        del splits["ref_pool"]
+        with pytest.raises(KeyError):
+            build_campaign_fns(_toy_recipe(splits), splits, n_refs=1, device="cpu")
+
+    def test_unknown_utility_metric_rejected(self):
+        splits = _toy_splits()
+        _, utility_fn, _ = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu", utility_metric="f1")
+        model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        with pytest.raises(ValueError):
+            utility_fn(model)
+
+    def test_callable_utility_metric(self):
+        splits = _toy_splits()
+        _, utility_fn, _ = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu",
+            utility_metric=lambda model, x, y, device: 0.42)
+        model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        assert utility_fn(model) == 0.42

--- a/leakpro/tests/test_optimization/test_training.py
+++ b/leakpro/tests/test_optimization/test_training.py
@@ -101,6 +101,14 @@ class TestConfidenceSignal:
         phi = confidence_signal(model, p, y, "cpu", output_kind="binary_probs")
         assert phi[0] == pytest.approx(-phi[1])  # log(0.9/0.1) vs log(0.1/0.9)
 
+    def test_binary_logits_signed_by_label(self):
+        model = nn.Identity()
+        logit = torch.tensor([[2.0], [2.0]])
+        y = torch.tensor([[1.0], [0.0]])
+        phi = confidence_signal(model, logit, y, "cpu", output_kind="binary_logits")
+        assert phi[0] == pytest.approx(2.0)   # confident and correct
+        assert phi[1] == pytest.approx(-2.0)  # confident and wrong
+
 
 class TestBuildCampaignFns:
     def test_end_to_end_on_toy_data(self):


### PR DESCRIPTION
Stacked on #438 (base is `feature/pet-optimization`; GitHub retargets this to main automatically once #438 merges).

## What

Adds `leakpro/optimization/training.py`: the structured training contract (`PETRecipe`) and the single shared Opacus path (`train_with_dpsgd`, `build_campaign_fns`) that replaces the DP-SGD loop previously duplicated in every campaign example. All three examples (LOS-LR, CIFAR, LOS GRU-D) are ported onto it and shrink to declaring a recipe; the standalone GRU-D script is superseded by the recipe-ported one.

A `PETRecipe` is the plan's structured contract: instead of a monolithic `train(data) -> model`, the user supplies factories the optimizer can intervene in (`make_model`, `make_optimizer`, `make_loader`, criterion, epochs). Each factory receives the sampled knob config and reads what it needs, which is what makes the next PET cheap — a regularization bundle is just `make_model` reading `dropout` and `make_optimizer` reading `weight_decay`, with no interface change. Exotic loops that do not fit keep the escape hatch of writing the three campaign callables directly.

## Hardening beyond the refactor

- **`make_opacus_compatible()`** — ModuleValidator pass (BatchNorm → GroupNorm), disables in-place activations, and rewrites torchvision residual blocks whose in-place `out += identity` ModuleValidator cannot see because it lives in `forward` rather than a submodule. Without this, any BatchNorm architecture — including both webapp image presets — fails at `make_private()`.
- **The privacy accountant is a parameter**, defaulting to `"prv"` (was hard-coded `"rdp"`). RDP is the looser bound, so identical noise reported a larger ε here than via the webapp's DP-SGD path. This changes reported ε for existing campaigns (downward, for identical noise); empirical attack numbers are unaffected.
- **The accuracy metric thresholds single-logit binary heads at 0** instead of `argmax` — `argmax` over one column is always 0, silently yielding 0% or 100%.

## Review fixes applied

An adversarial review of this PR produced 10 findings; all are addressed in `18db5a2a`. The theme was silent behaviour changes versus the per-example code this PR replaced.

- **`train_with_dpsgd` fails closed.** A missing or misspelled `noise_multiplier` silently trained a fully non-private model, from a function whose only purpose is DP-SGD. The key is now required; non-private runs pass an explicit `0.0`.
- **`make_opacus_compatible` runs on both branches.** Rewriting BatchNorm → GroupNorm only for private configs left the noise=0 anchor a structurally different model, so its utility gap mixed the cost of DP noise with the cost of an architecture change — the frontier's utility axis was not comparable end to end. Documented consequence: the submitted architecture is not necessarily what trains.
- **Full mimicry is enforced, not silently downgraded.** `n_ref_train` used `min(target, ref_pool)`, so a short reference pool quietly trained weaker references and biased the audit optimistic. A short pool is now an error — which is what the old per-example code did loudly.
- **`_patch_residual_blocks` only rewrites blocks still using the stock `forward`.** Subclasses with their own forward (SE, attention) were being silently replaced by the vanilla residual path, changing the model rather than making it Opacus-safe. Such blocks are now left alone with a warning.
- **The `auc` utility metric refuses multiclass output** instead of `reshape(-1)`-ing it into a meaningless number.
- **The accountant travels with the epsilon** in `campaign_extras`. The `prv` default is deliberate, but PRV and RDP epsilons are not comparable — measured 4.22 vs 4.87 for identical noise — so a record that does not name its accountant cannot safely be compared with another run's.

Examples: GRU-D regains the `max_physical_batch=128` cap the pre-PR code set deliberately (it is the memory-heaviest target in the repo; the shared 256 default would OOM mid-campaign) and gains the small-dataset split guard its LR sibling already had. The LOS campaign imports `target_models.LR` instead of redeclaring an identical `LRSigmoid`, so it trains the same class the audited target used.

One earlier test asserted the now-incorrect behaviour (BatchNorm surviving the non-private path) and has been inverted to assert architecture consistency instead.

## Verification

- `pytest leakpro/tests/test_optimization/` — 47 tests pass.
- `ruff check .` clean.
- The DP-SGD compatibility tests fail with the fix disabled (checked), so they are real regression tests rather than vacuous ones.

The webapp's near-verbatim copy of the Opacus-compat block is removed in #448, which now calls this shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBPG7MprEqhqG95fFURk8h
