### PR TITLE
Webapp: PET optimization view + per-model risk assessment

### DIFF
--- a/examples/mia/LOS/pet_optimization/run_campaign.py
+++ b/examples/mia/LOS/pet_optimization/run_campaign.py
@@ -72,22 +72,18 @@ def load_splits(seed: int = 0) -> dict:
     }
 
 
-class LRSigmoid(nn.Module):
-    """Logistic regression emitting probabilities (matches the LOS example's LR + BCELoss)."""
-
-    def __init__(self, input_dim: int) -> None:
-        super().__init__()
-        self.linear = nn.Linear(input_dim, 1)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return torch.sigmoid(self.linear(x))
-
-
 def make_recipe(splits: dict, epochs: int) -> PETRecipe:
-    """The LOS training recipe: logistic regression + Adam + BCE."""
+    """The LOS training recipe: logistic regression + Adam + BCE.
+
+    The model is the example's own ``target_models.LR`` — the same class the
+    audited target was trained with, so the campaign measures that model rather
+    than a look-alike.
+    """
+    from target_models import LR  # noqa: PLC0415 — EXAMPLE_DIR is on sys.path above
+
     input_dim = splits["x"].shape[1]
     return PETRecipe(
-        make_model=lambda config: LRSigmoid(input_dim),
+        make_model=lambda config: LR(input_dim),
         make_optimizer=lambda params, config: optim.Adam(params, lr=config["learning_rate"]),
         make_loader=lambda indices, config: DataLoader(
             TensorDataset(splits["x"][indices], splits["y"][indices]),

--- a/examples/mia/LOS/pet_optimization/run_campaign.py
+++ b/examples/mia/LOS/pet_optimization/run_campaign.py
@@ -5,15 +5,9 @@
 """PET optimization campaign on the MIMIC LOS logistic-regression target.
 
 Traces the utility-vs-attack-success frontier for DP-SGD on the LOS binary
-classification task, using the leakpro.optimization core module.
-
-- Knobs (joint search, per the frontier plan): noise multiplier, clipping
-  norm, learning rate, batch size. Epochs are fixed.
-- Utility: AUC on a held-out test split.
-- Attack: matched-reference MIA (RMIA-style calibration with 1-2 reference
-  models trained with the SAME configuration as the candidate — full mimicry).
-  Signal: logit-scaled confidence of the target minus the reference mean.
-- Loop metric: TPR @ FPR = 1% (powered proxy; tail FPRs are validation-only).
+classification task. The training loop, attack and utility evaluation all come
+from the shared ``PETRecipe`` path in ``leakpro.optimization`` — this file only
+declares the recipe (LR model, Adam, BCE loss) and the data splits.
 
 Usage:
     python run_campaign.py --smoke          # 2 configs, quick pipeline check
@@ -21,41 +15,31 @@ Usage:
 """
 
 import argparse
+import pickle
 import sys
 import time
 from pathlib import Path
 
 import numpy as np
 import torch
-from opacus import PrivacyEngine
-from sklearn.metrics import roc_auc_score
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
 
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(EXAMPLE_DIR))  # mimic_data_handler must be importable for unpickling
 
-from leakpro.optimization import (
-    AttackScores,
-    Campaign,
-    confidence_signal,
-    default_dpsgd_space,
-    pareto_front,
-    plot_frontier,
-)
+from leakpro.optimization import Campaign, PETRecipe, build_campaign_fns, default_dpsgd_space, pareto_front, plot_frontier
 from leakpro.utils.logger import logger
 
-DELTA = 1e-5
+N_AUDIT = 2000
 
 
 def load_splits(seed: int = 0) -> dict:
-    """Load the LOS LR dataset and carve person-disjoint roles from the stored splits.
+    """Load the LOS LR dataset and carve disjoint roles from the stored splits.
 
     train_indices -> target-train + reference pool (disjoint);
     test_indices  -> audit nonmembers + utility eval (disjoint).
     """
-    import pickle
-
     data_dir = EXAMPLE_DIR / "data" / "LR_data"
     with (data_dir / "dataset.pkl").open("rb") as f:
         dataset = pickle.load(f)
@@ -73,7 +57,7 @@ def load_splits(seed: int = 0) -> dict:
     # Audit members must be a subset of target_train (the first n_target train
     # indices), and nonmembers plus a non-empty utility split must both fit in
     # the test indices — cap instead of assuming the dataset is large enough.
-    n_audit = min(2000, n_target, len(test_idx) - 1)
+    n_audit = min(N_AUDIT, n_target, len(test_idx) - 1)
     if n_audit <= 0 or len(test_idx) - n_audit <= 0:
         raise ValueError(f"Dataset too small for the campaign splits: {len(train_idx)} train / "
                          f"{len(test_idx)} test indices.")
@@ -88,75 +72,31 @@ def load_splits(seed: int = 0) -> dict:
     }
 
 
-def train_dpsgd_lr(config: dict, splits: dict, train_indices: np.ndarray,
-                   epochs: int, device: str) -> nn.Module:
-    """Train one logistic-regression model with DP-SGD under the sampled config."""
-    from target_models import LR
+class LRSigmoid(nn.Module):
+    """Logistic regression emitting probabilities (matches the LOS example's LR + BCELoss)."""
 
-    x, y = splits["x"], splits["y"]
-    loader = DataLoader(
-        TensorDataset(x[train_indices], y[train_indices]),
-        batch_size=int(config["batch_size"]), shuffle=True,
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(input_dim, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.sigmoid(self.linear(x))
+
+
+def make_recipe(splits: dict, epochs: int) -> PETRecipe:
+    """The LOS training recipe: logistic regression + Adam + BCE."""
+    input_dim = splits["x"].shape[1]
+    return PETRecipe(
+        make_model=lambda config: LRSigmoid(input_dim),
+        make_optimizer=lambda params, config: optim.Adam(params, lr=config["learning_rate"]),
+        make_loader=lambda indices, config: DataLoader(
+            TensorDataset(splits["x"][indices], splits["y"][indices]),
+            batch_size=int(config["batch_size"]), shuffle=True,
+        ),
+        criterion=nn.BCELoss(),
+        epochs=epochs,
+        output_kind="binary_probs",
     )
-    model = LR(input_dim=x.shape[1]).to(device)
-    optimizer = optim.Adam(model.parameters(), lr=config["learning_rate"])
-    criterion = nn.BCELoss()
-
-    engine = PrivacyEngine(accountant="rdp")
-    model, optimizer, loader = engine.make_private(
-        module=model,
-        optimizer=optimizer,
-        data_loader=loader,
-        noise_multiplier=config["noise_multiplier"],
-        max_grad_norm=config["max_grad_norm"],
-    )
-
-    model.train()
-    for _ in range(epochs):
-        for xb, yb in loader:
-            optimizer.zero_grad()
-            loss = criterion(model(xb.to(device)), yb.to(device))
-            loss.backward()
-            optimizer.step()
-
-    epsilon = engine.get_epsilon(delta=DELTA)
-    logger.info(f"Trained DP-SGD LR: formal epsilon = {epsilon:.2f} (delta = {DELTA}).")
-    model.campaign_extras = {"epsilon": epsilon, "delta": DELTA}  # recorded next to the attack result
-    return model.eval()
-
-
-def make_fns(splits: dict, epochs: int, n_refs: int, device: str, ref_seed: int = 1) -> tuple:
-    """Build the campaign's (train, utility, attack) callables."""
-
-    def train_fn(config: dict) -> nn.Module:
-        return train_dpsgd_lr(config, splits, splits["target_train"], epochs, device)
-
-    def utility_fn(model: nn.Module) -> float:
-        idx = splits["utility_eval"]
-        phi = model(splits["x"][idx].to(device)).detach().cpu().numpy().ravel()
-        return float(roc_auc_score(splits["y"][idx].numpy().ravel(), phi))
-
-    def attack_fn(model: nn.Module, config: dict) -> AttackScores:
-        # Full mimicry: references use the SAME config (and epochs) as the candidate,
-        # trained on data disjoint from the target's training set.
-        rng = np.random.default_rng(ref_seed)
-        x, y = splits["x"], splits["y"]
-        members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
-
-        ref_models = []
-        pool = splits["ref_pool"]
-        for _ in range(n_refs):
-            sub = rng.choice(pool, size=min(len(splits["target_train"]), len(pool)), replace=False)
-            ref_models.append(train_dpsgd_lr(config, splits, sub, epochs, device))
-
-        def calibrated(idx: np.ndarray) -> np.ndarray:
-            target_phi = confidence_signal(model, x[idx], y[idx], device, "binary_probs")
-            ref_phi = np.mean([confidence_signal(r, x[idx], y[idx], device, "binary_probs") for r in ref_models], axis=0)
-            return target_phi - ref_phi
-
-        return AttackScores(member_scores=calibrated(members), nonmember_scores=calibrated(nonmembers))
-
-    return train_fn, utility_fn, attack_fn
 
 
 
@@ -194,11 +134,14 @@ def main() -> None:
         args.n_configs, args.epochs, args.n_refs = 2, 2, 1
         args.out = args.out + "_smoke"
 
-    # Campaign re-seeds torch per configuration from (seed, index); this covers
-    # only what happens before the loop starts.
+    # Seed torch too: numpy covers the Sobol draw and the split permutation,
+    # but model init, shuffling, Poisson sampling and the DP noise run off
+    # torch's global RNG.
     torch.manual_seed(args.seed)
     splits = load_splits(seed=args.seed)
-    train_fn, utility_fn, attack_fn = make_fns(splits, args.epochs, args.n_refs, args.device)
+    recipe = make_recipe(splits, args.epochs)
+    train_fn, utility_fn, attack_fn = build_campaign_fns(
+        recipe, splits, n_refs=args.n_refs, device=args.device, utility_metric="auc")
 
     campaign = Campaign(
         train_fn, utility_fn, attack_fn,

--- a/examples/mia/LOS/pet_optimization/run_campaign_grud.py
+++ b/examples/mia/LOS/pet_optimization/run_campaign_grud.py
@@ -53,6 +53,7 @@ from leakpro.optimization import (  # noqa: E402
 from leakpro.utils.logger import logger  # noqa: E402
 
 N_AUDIT = 2000
+MAX_PHYSICAL_BATCH = 128
 
 
 def load_splits(seed: int = 0) -> dict:
@@ -75,14 +76,21 @@ def load_splits(seed: int = 0) -> dict:
     test_idx = rng.permutation(np.asarray(indices["test_indices"]))
 
     n_target = len(train_idx) // 2
+    # Members must stay inside target_train (the first n_target indices) and the
+    # nonmembers must leave a non-empty utility split behind — cap rather than
+    # assume the dataset is big enough, as the LR campaign does.
+    n_audit = min(N_AUDIT, n_target, len(test_idx) - 1)
+    if n_audit <= 0 or len(test_idx) - n_audit <= 0:
+        raise ValueError(f"Dataset too small for the campaign splits: {len(train_idx)} train / "
+                         f"{len(test_idx)} test indices.")
     return {
         "x": x,
         "y": y,
         "target_train": train_idx[:n_target],
         "ref_pool": train_idx[n_target:],
-        "audit_members": train_idx[:N_AUDIT],  # subset of target_train
-        "audit_nonmembers": test_idx[:N_AUDIT],
-        "utility_eval": test_idx[N_AUDIT:],
+        "audit_members": train_idx[:n_audit],  # subset of target_train
+        "audit_nonmembers": test_idx[:n_audit],
+        "utility_eval": test_idx[n_audit:],
     }
 
 
@@ -173,14 +181,13 @@ def main() -> None:
     # torch's global RNG.
     torch.manual_seed(args.seed)
     splits = load_splits(seed=args.seed)
-    # Auto-detected on purpose: GRUD pins X_mean, the identity matrix and
-    # FilterLinear's filter to this device at construction, and .to(device)
-    # does not move those unregistered attributes — a flag would accept a
-    # value it cannot honor.
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = "cuda" if torch.cuda.is_available() else "cpu"  # see the parser note above
     recipe = make_recipe(splits, args.epochs)
     train_fn, utility_fn, attack_fn = build_campaign_fns(
-        recipe, splits, n_refs=args.n_refs, device=device, utility_metric="auc")
+        recipe, splits, n_refs=args.n_refs, device=device, utility_metric="auc",
+        # GRU-D is the memory-heaviest target in the repo: per-sample gradients
+        # over the unrolled sequence OOM at the shared 256 default.
+        max_physical_batch=MAX_PHYSICAL_BATCH)
 
     campaign = Campaign(
         train_fn, utility_fn, attack_fn,

--- a/examples/mia/LOS/pet_optimization/run_campaign_grud.py
+++ b/examples/mia/LOS/pet_optimization/run_campaign_grud.py
@@ -4,18 +4,21 @@
 #
 """PET optimization campaign on the MIMIC LOS GRU-D target.
 
-The leakier LOS counterpart to run_campaign.py (logistic regression): GRU-D is
-a recurrent net over the raw multivariate time series, so its
-utility-vs-attack-success frontier has a real privacy axis to trace.
+GRU-D is the leakier LOS target (a recurrent net over the raw multivariate time
+series, versus the flat logistic-regression target in ``run_campaign.py``), so
+its utility-vs-attack frontier has a real privacy axis to trace.
 
-Same design as the LR campaign — joint DP-SGD knob search, matched-reference
-MIA (full mimicry), AUC utility, TPR@1% loop metric — with two GRU-D specifics:
+Like the LR and CIFAR campaigns, this file only declares a ``PETRecipe`` (the
+GRU-D model, optimizer, loader, loss) and the data splits; the DP-SGD loop,
+matched-reference attack and utility evaluation come from the shared core path.
 
-- GRU-D outputs a raw logit (BCEWithLogitsLoss); the membership signal is the
-  signed logit (phi = logit for members of the true class, negated otherwise).
-- GRU-D contains a custom FilterLinear and a manual 104-step recurrence, so
-  Opacus is put on its functorch per-sample-gradient path (force_functorch).
-  Correct but slower than LR/CNN targets: keep --n-configs and epochs modest.
+Two GRU-D specifics worth knowing:
+- The model outputs a raw logit (BCEWithLogitsLoss), so ``output_kind`` is
+  "binary_logits".
+- GRU-D contains a custom ``FilterLinear`` and a manual 104-step recurrence.
+  Opacus is put on its functorch per-sample-gradient path (``force_functorch``)
+  to differentiate it; this is correct but far slower than the LR/CNN targets,
+  so keep --n-configs and epochs modest.
 
 Usage:
     python run_campaign_grud.py --smoke          # 2 configs, pipeline check
@@ -30,9 +33,6 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from opacus import PrivacyEngine
-from opacus.utils.batch_memory_manager import BatchMemoryManager
-from sklearn.metrics import roc_auc_score
 from torch import nn, optim, zeros
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -42,23 +42,25 @@ sys.path.insert(0, str(EXAMPLE_DIR))  # mimic_data_handler (unpickling) + target
 from target_models import GRUD  # noqa: E402
 
 from leakpro.optimization import (  # noqa: E402
-    AttackScores,
     Campaign,
     Knob,
     KnobSpace,
-    confidence_signal,
+    PETRecipe,
+    build_campaign_fns,
     pareto_front,
     plot_frontier,
 )
 from leakpro.utils.logger import logger  # noqa: E402
 
-DELTA = 1e-5
 N_AUDIT = 2000
-HIDDEN_SIZE = 78
 
 
 def load_splits(seed: int = 0) -> dict:
-    """Load the LOS GRU-D time-series dataset and carve person-disjoint roles."""
+    """Load the LOS GRU-D time-series dataset and carve disjoint roles.
+
+    train_indices -> target-train + reference pool (disjoint);
+    test_indices  -> audit nonmembers + utility eval (disjoint).
+    """
     data_dir = EXAMPLE_DIR / "data" / "GRUD_data"
     with (data_dir / "dataset.pkl").open("rb") as f:
         dataset = pickle.load(f)
@@ -84,96 +86,38 @@ def load_splits(seed: int = 0) -> dict:
     }
 
 
-def _build_grud(x: torch.Tensor, batch_size: int) -> nn.Module:
-    """Instantiate GRU-D; init params mirror the LOS example notebooks."""
+def make_recipe(splits: dict, epochs: int, hidden_size: int = 78) -> PETRecipe:
+    """The GRU-D training recipe. Init params mirror the LOS example's notebooks.
+
+    ``input_size`` and ``X_mean`` follow the packed [N, time*3, features] layout:
+    input_size = time_steps = data.shape[1] // 3, X_mean = zeros(1, features, time_steps).
+    """
+    x = splits["x"]
     time_steps = x.shape[1] // 3
     features = x.shape[2]
-    return GRUD(
-        input_size=time_steps,
-        hidden_size=HIDDEN_SIZE,
-        X_mean=zeros(1, features, time_steps),
-        batch_size=batch_size,
-        bn_flag=False,          # BatchNorm is incompatible with Opacus
-        force_functorch=True,   # custom FilterLinear needs the functorch grad sampler
-    )
+    x_mean = zeros(1, features, time_steps)
 
-
-def train_dpsgd_grud(config: dict, splits: dict, train_indices: np.ndarray,
-                     epochs: int, device: str) -> nn.Module:
-    """Train one GRU-D model with DP-SGD under the sampled config."""
-    x, y = splits["x"], splits["y"]
-    loader = DataLoader(
-        TensorDataset(x[train_indices], y[train_indices]),
-        batch_size=int(config["batch_size"]), shuffle=True,
-    )
-    model = _build_grud(x, int(config["batch_size"])).to(device)
-    optimizer = optim.Adam(model.parameters(), lr=config["learning_rate"])
-    criterion = nn.BCEWithLogitsLoss()
-
-    engine = PrivacyEngine(accountant="rdp")
-    model, optimizer, loader = engine.make_private(
-        module=model,
-        optimizer=optimizer,
-        data_loader=loader,
-        noise_multiplier=config["noise_multiplier"],
-        max_grad_norm=config["max_grad_norm"],
-    )
-
-    model.train()
-    with BatchMemoryManager(data_loader=loader, max_physical_batch_size=128,
-                            optimizer=optimizer) as mem_loader:
-        for _ in range(epochs):
-            for xb, yb in mem_loader:
-                optimizer.zero_grad()
-                loss = criterion(model(xb.to(device)), yb.to(device))
-                loss.backward()
-                optimizer.step()
-
-    epsilon = engine.get_epsilon(delta=DELTA)
-    logger.info(f"Trained DP-SGD GRU-D: formal epsilon = {epsilon:.2f} (delta = {DELTA}).")
-    model.campaign_extras = {"epsilon": epsilon, "delta": DELTA}
-    return model.eval()
-
-
-def make_fns(splits: dict, epochs: int, n_refs: int, device: str, ref_seed: int = 1) -> tuple:
-    """Build the campaign's (train, utility, attack) callables."""
-
-    def train_fn(config: dict) -> nn.Module:
-        if device.startswith("cuda"):
-            torch.cuda.empty_cache()
-        return train_dpsgd_grud(config, splits, splits["target_train"], epochs, device)
-
-    @torch.no_grad()
-    def utility_fn(model: nn.Module) -> float:
-        idx = splits["utility_eval"]
-        scores = []
-        for i in range(0, len(idx), 1024):
-            scores.append(model(splits["x"][idx[i:i + 1024]].to(device)).cpu().reshape(-1))
-        return float(roc_auc_score(splits["y"][idx].numpy().ravel(), torch.cat(scores).numpy()))
-
-    def attack_fn(model: nn.Module, config: dict) -> AttackScores:
-        # Full mimicry: references share the candidate's config, on disjoint data.
-        rng = np.random.default_rng(ref_seed)
-        x, y = splits["x"], splits["y"]
-        members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
-
-        ref_phi_m = np.zeros(len(members))
-        ref_phi_n = np.zeros(len(nonmembers))
-        for _ in range(n_refs):
-            sub = rng.choice(splits["ref_pool"], size=len(splits["target_train"]), replace=False)
-            ref = train_dpsgd_grud(config, splits, sub, epochs, device)
-            ref_phi_m += confidence_signal(ref, x[members], y[members], device, "binary_logits") / n_refs
-            ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, "binary_logits") / n_refs
-            del ref
-            if device.startswith("cuda"):
-                torch.cuda.empty_cache()
-
-        return AttackScores(
-            member_scores=confidence_signal(model, x[members], y[members], device, "binary_logits") - ref_phi_m,
-            nonmember_scores=confidence_signal(model, x[nonmembers], y[nonmembers], device, "binary_logits") - ref_phi_n,
+    def make_model(config: dict) -> nn.Module:
+        return GRUD(
+            input_size=time_steps,
+            hidden_size=hidden_size,
+            X_mean=x_mean,
+            batch_size=int(config["batch_size"]),
+            bn_flag=False,          # BatchNorm is incompatible with Opacus
+            force_functorch=True,   # custom FilterLinear needs the functorch grad sampler
         )
 
-    return train_fn, utility_fn, attack_fn
+    return PETRecipe(
+        make_model=make_model,
+        make_optimizer=lambda params, config: optim.Adam(params, lr=config["learning_rate"]),
+        make_loader=lambda indices, config: DataLoader(
+            TensorDataset(x[indices], splits["y"][indices]),
+            batch_size=int(config["batch_size"]), shuffle=True,
+        ),
+        criterion=nn.BCEWithLogitsLoss(),
+        epochs=epochs,
+        output_kind="binary_logits",
+    )
 
 
 
@@ -224,12 +168,19 @@ def main() -> None:
         args.n_configs, args.epochs, args.n_refs = 2, 1, 1
         args.out = args.out + "_smoke"
 
-    # Campaign re-seeds torch per configuration from (seed, index); this covers
-    # only what happens before the loop starts.
+    # Seed torch too: numpy covers the Sobol draw and the split permutation,
+    # but model init, shuffling, Poisson sampling and the DP noise run off
+    # torch's global RNG.
     torch.manual_seed(args.seed)
     splits = load_splits(seed=args.seed)
+    # Auto-detected on purpose: GRUD pins X_mean, the identity matrix and
+    # FilterLinear's filter to this device at construction, and .to(device)
+    # does not move those unregistered attributes — a flag would accept a
+    # value it cannot honor.
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    train_fn, utility_fn, attack_fn = make_fns(splits, args.epochs, args.n_refs, device)
+    recipe = make_recipe(splits, args.epochs)
+    train_fn, utility_fn, attack_fn = build_campaign_fns(
+        recipe, splits, n_refs=args.n_refs, device=device, utility_metric="auc")
 
     campaign = Campaign(
         train_fn, utility_fn, attack_fn,

--- a/examples/mia/cifar/audit.yaml
+++ b/examples/mia/cifar/audit.yaml
@@ -65,3 +65,45 @@ target:
 shadow_model:
 
 distillation_model:
+
+# Optional. Declares the deployment context so `leakpro.risk.assess_risk` can turn measured attack
+# success into a risk statement. Omitting the block changes nothing: the audit runs as before and
+# `leakpro.use_case_profile` is simply None. Declaring it does NOT run an assessment either — that is
+# an explicit call after run_audit, see the notebook.
+#
+# Factor names follow the Loss Magnitude decomposition of Sion et al. (IWPE 2019),
+# LM = DTS x NR x DST x NDS. LeakPro measures the Vulnerability term; you supply the rest.
+use_case:
+  # Operating point: the false-positive rate the attacker is assumed to tolerate. Required, no
+  # default. Keep 0.01 unless you have a reason to go lower — a stricter FPR needs a larger audit
+  # set to be measurable at all (you need at least 1/alpha non-members).
+  tolerated_fpr: 0.01
+
+  # pi: share of the attacker's candidate pool that really are members. 0.5 is the balanced-audit
+  # assumption behind every TPR and AUC LeakPro reports, and it overstates precision badly for
+  # realistic pools. Declare what your threat model actually implies.
+  attacker_prior: 0.01
+
+  # NDS: data subjects in the training population. Commented out here so the assessment falls back
+  # to the target's num_train. Set it when subjects and training records are not the same thing.
+  # n_subjects: 50000
+
+  # NR: records of this data type per subject. Fractions are allowed.
+  records_per_subject: 1.0
+
+  # DTS: sensitivity of the leaked data type, on a scale you choose. 1.0 is neutral. The CNIL PIA
+  # severity levels are a defensible starting point: 1 negligible, 2 limited, 3 significant,
+  # 4 maximum. CIFAR-10 is public benchmark data, so 1.0 is honest here.
+  data_type_sensitivity: 1.0
+
+  # DST: weight for the data subject type. Raise it for vulnerable subjects such as minors.
+  subject_type_weight: 1.0
+
+  # Optional. Left unset, no monetary figure is reported at all, rather than a fabricated one.
+  # cost_per_exposed_subject: 250.0
+
+  # Scale the exposed-record count from the audit set up to the training population. Off by default:
+  # per-record vulnerability is strongly non-uniform, so it is an estimate, not a measurement.
+  extrapolate_to_population: false
+
+  notes: "CIFAR-10 benchmark run. Public data, so sensitivity is neutral."

--- a/examples/mia/cifar/cifar_main.ipynb
+++ b/examples/mia/cifar/cifar_main.ipynb
@@ -246,6 +246,46 @@
     "\n",
     "mia_results = leakpro.run_audit(create_pdf=True)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Risk assessment\n",
+    "\n",
+    "The audit measures how often an attack succeeds. Turning that into a risk statement needs one\n",
+    "thing LeakPro cannot observe: how much a success would cost the people in the training data.\n",
+    "\n",
+    "`assess_risk` is a separate call on purpose. `run_audit` is expensive; re-assessing under a\n",
+    "different operating point or attacker prior is nearly free, and those are exactly the parameters\n",
+    "you want to vary. The profile below comes from the `use_case:` block in `audit.yaml`, but you can\n",
+    "build a `UseCaseProfile(...)` in Python instead.\n",
+    "\n",
+    "Every figure in the output is either measured (from this audit) or declared (by you). The\n",
+    "`assumptions` list names the assumption behind each derived number, including the two inherited\n",
+    "from the published model: a single attack attempt, and independence of the harm factors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from leakpro.risk import UseCaseProfile, assess_risk, to_markdown\n",
+    "\n",
+    "# Declared in audit.yaml under `use_case:`. Or build one here:\n",
+    "#   profile = UseCaseProfile(tolerated_fpr=0.01, attacker_prior=0.01, data_type_sensitivity=3.0)\n",
+    "profile = leakpro.use_case_profile\n",
+    "\n",
+    "assessment = assess_risk(\n",
+    "    mia_results,\n",
+    "    profile,\n",
+    "    num_train=leakpro.handler.target_model_metadata.num_train,\n",
+    ")\n",
+    "assessment.save(f\"{leakpro.report_dir}/risk_assessment.json\")\n",
+    "print(to_markdown(assessment))"
+   ]
   }
  ],
  "metadata": {

--- a/examples/mia/cifar/pet_optimization/run_campaign.py
+++ b/examples/mia/cifar/pet_optimization/run_campaign.py
@@ -6,15 +6,11 @@
 
 The leaky-by-design counterpart of the LOS campaign: a small convolutional
 network trained on a 15k subset of CIFAR-10 memorizes visibly, so the
-utility-vs-attack frontier has a real privacy axis to trace. Same design as
-the LOS example:
+utility-vs-attack frontier has a real privacy axis to trace.
 
-- Joint DP-SGD knobs {noise multiplier, clip norm, lr, batch size}; noise may
-  be swept down to (near) zero via --include-nonprivate to anchor the leaky end.
-- Utility: test accuracy.
-- Attack: matched-reference MIA, references trained with the candidate's
-  config on disjoint data (full mimicry).
-- Loop metric: TPR @ FPR = 1%.
+The training loop, attack and utility evaluation all come from the shared
+``PETRecipe`` path in ``leakpro.optimization`` — this file only declares the
+recipe (model, optimizer, loader, loss) and the data splits.
 
 Usage:
     python run_campaign.py --smoke          # 2 configs, pipeline check
@@ -30,8 +26,6 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from opacus import PrivacyEngine
-from opacus.utils.batch_memory_manager import BatchMemoryManager
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -39,17 +33,16 @@ EXAMPLE_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(EXAMPLE_DIR))  # cifar_data_handler must be importable for unpickling
 
 from leakpro.optimization import (
-    AttackScores,
     Campaign,
     Knob,
     KnobSpace,
-    confidence_signal,
+    PETRecipe,
+    build_campaign_fns,
     pareto_front,
     plot_frontier,
 )
 from leakpro.utils.logger import logger
 
-DELTA = 1e-5
 N_TARGET_TRAIN = 15000
 N_AUDIT = 2000
 NUM_CLASSES = 10
@@ -112,95 +105,19 @@ def load_splits(seed: int = 0, audit_size: int = N_AUDIT) -> dict:
     }
 
 
-def train_dpsgd_cnn(config: dict, splits: dict, train_indices: np.ndarray,
-                    epochs: int, device: str) -> nn.Module:
-    """Train one SmallCNN with DP-SGD under the sampled config (noise 0 = non-private SGD baseline)."""
-    x, y = splits["x"], splits["y"]
-    loader = DataLoader(
-        TensorDataset(x[train_indices], y[train_indices]),
-        batch_size=int(config["batch_size"]), shuffle=True,
+def make_recipe(splits: dict, epochs: int) -> PETRecipe:
+    """The CIFAR training recipe: SmallCNN + SGD(momentum) + CrossEntropy."""
+    return PETRecipe(
+        make_model=lambda config: SmallCNN(),
+        make_optimizer=lambda params, config: optim.SGD(params, lr=config["learning_rate"], momentum=0.9),
+        make_loader=lambda indices, config: DataLoader(
+            TensorDataset(splits["x"][indices], splits["y"][indices]),
+            batch_size=int(config["batch_size"]), shuffle=True,
+        ),
+        criterion=nn.CrossEntropyLoss(),
+        epochs=epochs,
+        output_kind="logits",
     )
-    model = SmallCNN().to(device)
-    optimizer = optim.SGD(model.parameters(), lr=config["learning_rate"], momentum=0.9)
-    criterion = nn.CrossEntropyLoss()
-
-    epsilon = float("inf")
-    if config["noise_multiplier"] > 0:
-        engine = PrivacyEngine(accountant="rdp")
-        model, optimizer, loader = engine.make_private(
-            module=model,
-            optimizer=optimizer,
-            data_loader=loader,
-            noise_multiplier=config["noise_multiplier"],
-            max_grad_norm=config["max_grad_norm"],
-        )
-
-    def run_epochs(epoch_loader) -> None:
-        for _ in range(epochs):
-            for xb, yb in epoch_loader:
-                optimizer.zero_grad()
-                loss = criterion(model(xb.to(device)), yb.to(device))
-                loss.backward()
-                optimizer.step()
-
-    model.train()
-    if config["noise_multiplier"] > 0:
-        # Cap the physical batch: per-example gradients cost batch x params memory.
-        # The sampled (logical) batch size, and hence the accounting, is unchanged.
-        with BatchMemoryManager(data_loader=loader, max_physical_batch_size=256,
-                                optimizer=optimizer) as mem_loader:
-            run_epochs(mem_loader)
-        epsilon = engine.get_epsilon(delta=DELTA)
-    else:
-        run_epochs(loader)
-    logger.info(f"Trained CNN: formal epsilon = {epsilon:.2f} (delta = {DELTA}).")
-    model.campaign_extras = {"epsilon": epsilon, "delta": DELTA}
-    return model.eval()
-
-
-def make_fns(splits: dict, epochs: int, n_refs: int, device: str, ref_seed: int = 1) -> tuple:
-    """Build the campaign's (train, utility, attack) callables."""
-
-    def train_fn(config: dict) -> nn.Module:
-        if device.startswith("cuda"):
-            torch.cuda.empty_cache()  # models from the previous config are gone; release their cache
-        return train_dpsgd_cnn(config, splits, splits["target_train"], epochs, device)
-
-    @torch.no_grad()
-    def utility_fn(model: nn.Module) -> float:
-        idx = splits["utility_eval"]
-        correct, total = 0, 0
-        for i in range(0, len(idx), 1024):
-            batch = idx[i:i + 1024]
-            pred = model(splits["x"][batch].to(device)).argmax(dim=1).cpu()
-            correct += int((pred == splits["y"][batch]).sum())
-            total += len(batch)
-        return correct / total
-
-    def attack_fn(model: nn.Module, config: dict) -> AttackScores:
-        # Full mimicry: references share the candidate's config, on disjoint data.
-        rng = np.random.default_rng(ref_seed)
-        x, y = splits["x"], splits["y"]
-        members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
-
-        # Train references one at a time and free each after scoring (GPU memory).
-        ref_phi_members = np.zeros(len(members))
-        ref_phi_nonmembers = np.zeros(len(nonmembers))
-        for _ in range(n_refs):
-            sub = rng.choice(splits["ref_pool"], size=N_TARGET_TRAIN, replace=False)
-            ref = train_dpsgd_cnn(config, splits, sub, epochs, device)
-            ref_phi_members += confidence_signal(ref, x[members], y[members], device, "logits") / n_refs
-            ref_phi_nonmembers += confidence_signal(ref, x[nonmembers], y[nonmembers], device, "logits") / n_refs
-            del ref
-            if device.startswith("cuda"):
-                torch.cuda.empty_cache()
-
-        return AttackScores(
-            member_scores=confidence_signal(model, x[members], y[members], device, "logits") - ref_phi_members,
-            nonmember_scores=confidence_signal(model, x[nonmembers], y[nonmembers], device, "logits") - ref_phi_nonmembers,
-        )
-
-    return train_fn, utility_fn, attack_fn
 
 
 
@@ -261,12 +178,16 @@ def main() -> None:
         args.n_configs, args.epochs, args.n_refs = 2, 2, 1
         args.out = args.out + "_smoke"
 
-    # Campaign re-seeds torch per configuration from (seed, index), so training
-    # is reproducible regardless of how many configs ran before it in this
-    # process. This seeds only what happens before the loop.
+    # Seed torch too: the Sobol draw and the split permutation are numpy, but
+    # model init, DataLoader shuffling, Opacus Poisson sampling and the DP noise
+    # itself all run off torch's global RNG. Without this, --seed does not make
+    # a run reproducible and the resume/validation seed guards promise more than
+    # they deliver.
     torch.manual_seed(args.seed)
     splits = load_splits(seed=args.seed)
-    train_fn, utility_fn, attack_fn = make_fns(splits, args.epochs, args.n_refs, args.device)
+    recipe = make_recipe(splits, args.epochs)
+    train_fn, utility_fn, attack_fn = build_campaign_fns(
+        recipe, splits, n_refs=args.n_refs, device=args.device, utility_metric="accuracy")
 
     campaign = Campaign(
         train_fn, utility_fn, attack_fn,

--- a/examples/mia/cifar/pet_optimization/validate_frontier.py
+++ b/examples/mia/cifar/pet_optimization/validate_frontier.py
@@ -27,20 +27,22 @@ import numpy as np
 import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from run_campaign import N_TARGET_TRAIN, load_splits, train_dpsgd_cnn  # noqa: E402
+from run_campaign import N_TARGET_TRAIN, load_splits, make_recipe  # noqa: E402
 
 from leakpro.optimization import (  # noqa: E402
     AttackScores,
     EvaluationRecord,
+    PETRecipe,
     confidence_signal,
     proxy_agreement,
+    train_with_dpsgd,
     validate_frontier,
 )
 from leakpro.optimization.validation import resolution_warning  # noqa: E402
 from leakpro.utils.logger import logger  # noqa: E402
 
 
-def make_revalidate_fn(splits: dict, epochs: int, n_refs: int, device: str,
+def make_revalidate_fn(splits: dict, recipe: PETRecipe, n_refs: int, device: str,
                        audit_size: int, seed: int = 99) -> callable:
     """Stronger attack: more matched references, larger audit set, fresh reference seed.
 
@@ -54,23 +56,24 @@ def make_revalidate_fn(splits: dict, epochs: int, n_refs: int, device: str,
 
     def revalidate_fn(config: dict) -> AttackScores:
         x, y = splits["x"], splits["y"]
-        target = train_dpsgd_cnn(config, splits, splits["target_train"], epochs, device)
+        kind = recipe.output_kind
+        target = train_with_dpsgd(recipe, config, splits["target_train"], device)
 
         ref_phi_m = np.zeros(len(members))
         ref_phi_n = np.zeros(len(nonmembers))
         rng = np.random.default_rng(rng_master.integers(1 << 30))
         for _ in range(n_refs):
             sub = rng.choice(splits["ref_pool"], size=N_TARGET_TRAIN, replace=False)
-            ref = train_dpsgd_cnn(config, splits, sub, epochs, device)
-            ref_phi_m += confidence_signal(ref, x[members], y[members], device, "logits") / n_refs
-            ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, "logits") / n_refs
+            ref = train_with_dpsgd(recipe, config, sub, device)
+            ref_phi_m += confidence_signal(ref, x[members], y[members], device, kind) / n_refs
+            ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, kind) / n_refs
             del ref
             if device.startswith("cuda"):
                 torch.cuda.empty_cache()
 
         scores = AttackScores(
-            member_scores=confidence_signal(target, x[members], y[members], device, "logits") - ref_phi_m,
-            nonmember_scores=confidence_signal(target, x[nonmembers], y[nonmembers], device, "logits") - ref_phi_n,
+            member_scores=confidence_signal(target, x[members], y[members], device, kind) - ref_phi_m,
+            nonmember_scores=confidence_signal(target, x[nonmembers], y[nonmembers], device, kind) - ref_phi_n,
         )
         del target
         if device.startswith("cuda"):
@@ -125,7 +128,8 @@ def main() -> None:
     if warning:
         logger.warning(warning)
 
-    revalidate_fn = make_revalidate_fn(splits, args.epochs, args.n_refs, args.device, args.audit_size)
+    recipe = make_recipe(splits, args.epochs)
+    revalidate_fn = make_revalidate_fn(splits, recipe, args.n_refs, args.device, args.audit_size)
 
     start = time.time()
     validated = validate_frontier(records, revalidate_fn, report_fprs=tuple(args.report_fprs))

--- a/leakpro/leakpro.py
+++ b/leakpro/leakpro.py
@@ -59,6 +59,10 @@ class LeakPro:
         except FileNotFoundError as e:
             raise FileNotFoundError(f"File {configs_path} not found") from e
 
+        # Deployment context for risk assessment, when declared in the config. Nothing is computed
+        # here: pass it to leakpro.risk.assess_risk together with the results of run_audit().
+        self.use_case_profile = configs.use_case
+
         # Create report directory
         self.report_dir = f"{configs.audit.output_dir}/results"
         Path(self.report_dir).mkdir(parents=True, exist_ok=True)

--- a/leakpro/optimization/__init__.py
+++ b/leakpro/optimization/__init__.py
@@ -13,7 +13,12 @@ from leakpro.optimization.objectives import (
     confidence_signal,
     tpr_at_fpr,
 )
-from leakpro.optimization.training import PETRecipe, build_campaign_fns, train_with_dpsgd
+from leakpro.optimization.training import (
+    PETRecipe,
+    build_campaign_fns,
+    make_opacus_compatible,
+    train_with_dpsgd,
+)
 from leakpro.optimization.validation import proxy_agreement, resolution_warning, validate_frontier
 
 __all__ = [
@@ -27,6 +32,7 @@ __all__ = [
     "clopper_pearson_ci",
     "confidence_signal",
     "default_dpsgd_space",
+    "make_opacus_compatible",
     "pareto_front",
     "plot_frontier",
     "proxy_agreement",

--- a/leakpro/optimization/__init__.py
+++ b/leakpro/optimization/__init__.py
@@ -13,6 +13,7 @@ from leakpro.optimization.objectives import (
     confidence_signal,
     tpr_at_fpr,
 )
+from leakpro.optimization.training import PETRecipe, build_campaign_fns, train_with_dpsgd
 from leakpro.optimization.validation import proxy_agreement, resolution_warning, validate_frontier
 
 __all__ = [
@@ -21,6 +22,8 @@ __all__ = [
     "EvaluationRecord",
     "Knob",
     "KnobSpace",
+    "PETRecipe",
+    "build_campaign_fns",
     "clopper_pearson_ci",
     "confidence_signal",
     "default_dpsgd_space",
@@ -29,5 +32,6 @@ __all__ = [
     "proxy_agreement",
     "resolution_warning",
     "tpr_at_fpr",
+    "train_with_dpsgd",
     "validate_frontier",
 ]

--- a/leakpro/optimization/adapters.py
+++ b/leakpro/optimization/adapters.py
@@ -16,48 +16,36 @@ loop replaces. Anything whose training loop cannot be expressed as
 callables directly instead.
 """
 
-import importlib.util
-import sys
-import uuid
-from collections.abc import Callable
 from pathlib import Path
 
 import numpy as np
 import torch
-from torch import nn, optim
+from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
+from leakpro.input_handler.user_imports import (
+    get_class_from_module,
+    get_optimizer_mapping,
+    import_module_from_file,
+)
 from leakpro.optimization.training import PETRecipe
 from leakpro.utils.logger import logger
 
-OPTIMIZERS: dict[str, Callable] = {"adam": optim.Adam, "sgd": optim.SGD, "adamw": optim.AdamW}
-
-
-def load_module(module_path: str | Path):  # noqa: ANN201
-    """Import a .py file under a unique name, so repeated loads never collide."""
-    module_path = Path(module_path)
-    if not module_path.exists():
-        raise FileNotFoundError(f"Architecture module not found: {module_path}")
-    name = f"leakpro_arch_{uuid.uuid4().hex}"
-    spec = importlib.util.spec_from_file_location(name, module_path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Could not load a module from {module_path}.")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
-
 
 def find_model_class(module, model_class: str | None = None) -> type:  # noqa: ANN001
-    """Pick the nn.Module subclass to train, by name or as the only candidate."""
+    """Pick the nn.Module subclass to train, by name or as the only candidate.
+
+    Named lookup delegates to ``user_imports.get_class_from_module``, the
+    repo's existing helper. Only the "exactly one candidate, infer it" case is
+    added here, which the webapp needs because an uploaded arch.py usually
+    defines a single model and the user is not asked to name it.
+    """
+    if model_class:
+        return get_class_from_module(module, model_class)
     candidates = {
         name: obj for name, obj in vars(module).items()
         if isinstance(obj, type) and issubclass(obj, nn.Module) and obj.__module__ == module.__name__
     }
-    if model_class:
-        if model_class not in candidates:
-            raise KeyError(f"'{model_class}' is not an nn.Module defined in {module.__name__}; found {sorted(candidates)}.")
-        return candidates[model_class]
     if len(candidates) != 1:
         raise ValueError(
             f"Cannot choose a model class automatically: {sorted(candidates)}. Pass model_class explicitly."
@@ -78,7 +66,7 @@ def detect_binary(
     two-class problem may be modelled with one sigmoid output or two softmax
     ones. So instantiate the model once and look at what it produces.
     """
-    cls = find_model_class(load_module(module_path), model_class)
+    cls = find_model_class(import_module_from_file(str(module_path)), model_class)
     probe = cls(**dict(init_params or {}))
     probe.eval()
     with torch.no_grad():
@@ -111,13 +99,16 @@ def recipe_from_module(  # noqa: PLR0913
             what the attack reads confidences with.
 
     """
-    if optimizer_name not in OPTIMIZERS:
-        raise ValueError(f"Unknown optimizer '{optimizer_name}'; use one of {sorted(OPTIMIZERS)}.")
+    # torch.optim is the source of truth for what optimizers exist, via the
+    # repo's mapping — a hardcoded dict here would silently exclude the rest.
+    optimizers = get_optimizer_mapping()
+    if optimizer_name not in optimizers:
+        raise ValueError(f"Unknown optimizer '{optimizer_name}'; use one of {sorted(optimizers)}.")
 
-    module = load_module(module_path)
+    module = import_module_from_file(str(module_path))
     cls = find_model_class(module, model_class)
     kwargs = dict(init_params or {})
-    optimizer_cls = OPTIMIZERS[optimizer_name]
+    optimizer_cls = optimizers[optimizer_name]
 
     # A fresh model per config: the campaign must never resume a trained one.
     def make_model(_config: dict) -> nn.Module:

--- a/leakpro/optimization/adapters.py
+++ b/leakpro/optimization/adapters.py
@@ -1,0 +1,214 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Build a ``PETRecipe`` and its data splits from an architecture file.
+
+The campaign's contract is a set of factories plus five disjoint index sets
+(``leakpro.optimization.training``). Writing those by hand is fine in a script;
+a caller that only has "a module defining an nn.Module, a tensor dataset, and
+the settings the model was trained with" needs an adapter. That is this module.
+
+It deliberately does *not* go through ``AbstractInputHandler``: a user handler
+exists to supply a custom ``train()``, which is exactly what the shared DP-SGD
+loop replaces. Anything whose training loop cannot be expressed as
+(model, optimizer, loader, criterion, epochs) should build the campaign
+callables directly instead.
+"""
+
+import importlib.util
+import sys
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader, TensorDataset
+
+from leakpro.optimization.training import PETRecipe
+from leakpro.utils.logger import logger
+
+OPTIMIZERS: dict[str, Callable] = {"adam": optim.Adam, "sgd": optim.SGD, "adamw": optim.AdamW}
+
+
+def load_module(module_path: str | Path):  # noqa: ANN201
+    """Import a .py file under a unique name, so repeated loads never collide."""
+    module_path = Path(module_path)
+    if not module_path.exists():
+        raise FileNotFoundError(f"Architecture module not found: {module_path}")
+    name = f"leakpro_arch_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load a module from {module_path}.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def find_model_class(module, model_class: str | None = None) -> type:  # noqa: ANN001
+    """Pick the nn.Module subclass to train, by name or as the only candidate."""
+    candidates = {
+        name: obj for name, obj in vars(module).items()
+        if isinstance(obj, type) and issubclass(obj, nn.Module) and obj.__module__ == module.__name__
+    }
+    if model_class:
+        if model_class not in candidates:
+            raise KeyError(f"'{model_class}' is not an nn.Module defined in {module.__name__}; found {sorted(candidates)}.")
+        return candidates[model_class]
+    if len(candidates) != 1:
+        raise ValueError(
+            f"Cannot choose a model class automatically: {sorted(candidates)}. Pass model_class explicitly."
+        )
+    return next(iter(candidates.values()))
+
+
+def detect_binary(
+    module_path: str | Path,
+    x: torch.Tensor,
+    model_class: str | None = None,
+    init_params: dict | None = None,
+) -> bool:
+    """Report whether this architecture emits a single logit per sample.
+
+    The loss, the label dtype and the way the attack reads confidences all
+    follow from this, and it cannot be inferred from the class count alone: a
+    two-class problem may be modelled with one sigmoid output or two softmax
+    ones. So instantiate the model once and look at what it produces.
+    """
+    cls = find_model_class(load_module(module_path), model_class)
+    probe = cls(**dict(init_params or {}))
+    probe.eval()
+    with torch.no_grad():
+        out = probe(x[:2].float())
+    return out.ndim == 1 or out.shape[-1] == 1
+
+
+def recipe_from_module(  # noqa: PLR0913
+    module_path: str | Path,
+    x: torch.Tensor,
+    y: torch.Tensor,
+    epochs: int,
+    model_class: str | None = None,
+    init_params: dict | None = None,
+    optimizer_name: str = "adam",
+    binary: bool = False,
+) -> PETRecipe:
+    """Assemble a recipe from an architecture file and an in-memory tensor dataset.
+
+    Args:
+        module_path: a .py file defining the architecture.
+        x: full feature tensor; loaders index into it.
+        y: full label tensor.
+        epochs: training epochs, held fixed across the campaign.
+        model_class: which nn.Module to use; inferred when the file defines one.
+        init_params: keyword arguments for the model constructor.
+        optimizer_name: "adam", "adamw" or "sgd"; the learning rate is a searched knob.
+        binary: single-logit head trained with BCEWithLogitsLoss rather than
+            multiclass cross-entropy. Sets ``output_kind`` to match, which is
+            what the attack reads confidences with.
+
+    """
+    if optimizer_name not in OPTIMIZERS:
+        raise ValueError(f"Unknown optimizer '{optimizer_name}'; use one of {sorted(OPTIMIZERS)}.")
+
+    module = load_module(module_path)
+    cls = find_model_class(module, model_class)
+    kwargs = dict(init_params or {})
+    optimizer_cls = OPTIMIZERS[optimizer_name]
+
+    # A fresh model per config: the campaign must never resume a trained one.
+    def make_model(_config: dict) -> nn.Module:
+        return cls(**kwargs)
+
+    def make_optimizer(params, config: dict):  # noqa: ANN001, ANN202
+        return optimizer_cls(params, lr=config["learning_rate"])
+
+    def make_loader(indices: np.ndarray, config: dict) -> DataLoader:
+        return DataLoader(
+            TensorDataset(x[indices], y[indices]),
+            batch_size=int(config["batch_size"]),
+            shuffle=True,
+        )
+
+    logger.info(f"Recipe built from {Path(module_path).name}: {cls.__name__}({kwargs}), {optimizer_name}, {epochs} epochs.")
+    return PETRecipe(
+        make_model=make_model,
+        make_optimizer=make_optimizer,
+        make_loader=make_loader,
+        criterion=nn.BCEWithLogitsLoss() if binary else nn.CrossEntropyLoss(),
+        epochs=epochs,
+        output_kind="binary_logits" if binary else "logits",
+    )
+
+
+def carve_splits(  # noqa: PLR0913
+    x: torch.Tensor,
+    y: torch.Tensor,
+    seed: int = 0,
+    target_fraction: float = 0.4,
+    ref_fraction: float = 0.4,
+    audit_size: int = 2000,
+) -> dict:
+    """Carve the five disjoint roles a matched-reference campaign needs.
+
+    The reference pool is the expensive requirement: it must be disjoint from
+    the target's training set, so it comes out of the same dataset and the
+    target trains on less data than it otherwise would. Callers should surface
+    that, because it means the frontier describes a smaller-data model than a
+    plain audit of the user's own model does.
+
+    Members are drawn from the target's training set; nonmembers and the
+    utility split come from what is left, and never overlap each other.
+    """
+    if not 0 < target_fraction < 1 or not 0 < ref_fraction < 1:
+        raise ValueError("target_fraction and ref_fraction must each be in (0, 1).")
+    if target_fraction + ref_fraction >= 1:
+        raise ValueError(
+            f"target_fraction + ref_fraction = {target_fraction + ref_fraction:.2f} leaves nothing "
+            "for the audit and utility splits; they must sum to less than 1."
+        )
+
+    n = len(x)
+    order = np.random.default_rng(seed).permutation(n)
+    n_target = int(n * target_fraction)
+    n_ref = int(n * ref_fraction)
+
+    target_train = order[:n_target]
+    ref_pool = order[n_target:n_target + n_ref]
+    rest = order[n_target + n_ref:]
+
+    # Nonmembers and the utility split share `rest`, so the audit set cannot
+    # grow past half of it without the two overlapping.
+    n_audit = min(audit_size, len(target_train), len(rest) // 2)
+
+    # Every role has to be non-empty for the campaign to mean anything: no
+    # reference pool means no matched attack, no nonmembers means no attack
+    # metric, no utility split means no quality axis.
+    empty = [
+        name for name, size in (
+            ("target_train", len(target_train)),
+            ("ref_pool", len(ref_pool)),
+            ("audit set", n_audit),
+            ("utility_eval", len(rest) - n_audit),
+        ) if size == 0
+    ]
+    if empty:
+        raise ValueError(
+            f"Dataset of {n} samples is too small: {', '.join(empty)} would be empty at "
+            f"target_fraction={target_fraction}, ref_fraction={ref_fraction}."
+        )
+    if n_audit < audit_size:
+        logger.warning(f"Audit set capped at {n_audit} (requested {audit_size}) by the available disjoint data.")
+
+    return {
+        "x": x,
+        "y": y,
+        "target_train": target_train,
+        "ref_pool": ref_pool,
+        "audit_members": target_train[:n_audit],
+        "audit_nonmembers": rest[:n_audit],
+        "utility_eval": rest[n_audit:],
+    }

--- a/leakpro/optimization/training.py
+++ b/leakpro/optimization/training.py
@@ -49,9 +49,11 @@ class PETRecipe:
         make_loader: (indices, config) -> training DataLoader (reads e.g. ``batch_size``).
         criterion: loss module shared by target and reference models.
         epochs: fixed number of training epochs.
-        output_kind: "logits" for raw multiclass logits (CrossEntropyLoss models),
-            "binary_probs" for a single sigmoid output column (BCELoss models).
-            Decides how membership confidence is extracted.
+        output_kind: how membership confidence is read from the model output.
+            "logits" — raw multiclass logits (CrossEntropyLoss models);
+            "binary_probs" — a single sigmoid probability column (BCELoss models);
+            "binary_logits" — a single raw logit column (BCEWithLogitsLoss
+            models, e.g. GRU-D).
 
     """
 
@@ -64,8 +66,9 @@ class PETRecipe:
 
     def __post_init__(self) -> None:
         """Validate the output kind."""
-        if self.output_kind not in ("logits", "binary_probs"):
-            raise ValueError(f"output_kind must be 'logits' or 'binary_probs', got '{self.output_kind}'.")
+        valid = ("logits", "binary_probs", "binary_logits")
+        if self.output_kind not in valid:
+            raise ValueError(f"output_kind must be one of {valid}, got '{self.output_kind}'.")
 
 
 def _patch_residual_blocks(model: Module) -> None:

--- a/leakpro/optimization/training.py
+++ b/leakpro/optimization/training.py
@@ -232,8 +232,11 @@ def _evaluate_utility(model: Module, metric: str | Callable, x: torch.Tensor,
     if metric == "accuracy":
         correct = 0
         for i in range(0, len(x), 1024):
-            pred = model(x[i:i + 1024].to(device)).argmax(dim=1).cpu()
-            correct += int((pred == y[i:i + 1024]).sum())
+            out = model(x[i:i + 1024].to(device)).cpu()
+            # A single-logit head is a binary classifier: threshold at 0, don't
+            # argmax (argmax over one column is always 0 — silently 0% or 100%).
+            pred = (out.reshape(-1) > 0).long() if (out.ndim == 1 or out.shape[-1] == 1) else out.argmax(dim=1)
+            correct += int((pred == y[i:i + 1024].reshape(-1).long()).sum())
         return correct / len(x)
     if metric == "auc":
         from sklearn.metrics import roc_auc_score

--- a/leakpro/optimization/training.py
+++ b/leakpro/optimization/training.py
@@ -1,0 +1,207 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Structured PET recipe and the shared DP-SGD training path.
+
+A ``PETRecipe`` is the plan's structured training contract: instead of a
+monolithic ``train(data) -> model``, the user provides factories the optimizer
+can intervene in. Every factory receives the sampled knob configuration and
+picks out what it needs — ``make_loader`` reads ``batch_size``,
+``make_optimizer`` reads ``learning_rate``. Unused knobs are ignored, which is
+what makes further PETs cheap: a regularization bundle is just ``make_model``
+reading ``dropout`` and ``make_optimizer`` reading ``weight_decay``.
+
+``train_with_dpsgd`` is the single Opacus path (privacy engine, physical-batch
+cap, ε accounting) previously duplicated per example. ``build_campaign_fns``
+turns a recipe plus data splits into the three callables a ``Campaign`` needs;
+exotic training loops that do not fit the recipe keep the escape hatch of
+writing those callables directly.
+"""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+
+import numpy as np
+import torch
+from opacus import PrivacyEngine
+from opacus.utils.batch_memory_manager import BatchMemoryManager
+from torch.nn import Module, Parameter
+from torch.nn.modules.loss import _Loss
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader
+
+from leakpro.optimization.objectives import AttackScores, confidence_signal
+from leakpro.utils.logger import logger
+
+REQUIRED_SPLIT_KEYS = ("x", "y", "target_train", "ref_pool", "audit_members", "audit_nonmembers", "utility_eval")
+
+
+@dataclass(frozen=True)
+class PETRecipe:
+    """Structured training recipe: the factories a PET optimizer may intervene in.
+
+    Args:
+        make_model: config -> a fresh, untrained model.
+        make_optimizer: (parameters, config) -> optimizer (reads e.g. ``learning_rate``).
+        make_loader: (indices, config) -> training DataLoader (reads e.g. ``batch_size``).
+        criterion: loss module shared by target and reference models.
+        epochs: fixed number of training epochs.
+        output_kind: "logits" for raw multiclass logits (CrossEntropyLoss models),
+            "binary_probs" for a single sigmoid output column (BCELoss models).
+            Decides how membership confidence is extracted.
+
+    """
+
+    make_model: Callable[[dict], Module]
+    make_optimizer: Callable[[Iterable[Parameter], dict], Optimizer]
+    make_loader: Callable[[np.ndarray, dict], DataLoader]
+    criterion: _Loss
+    epochs: int
+    output_kind: str = field(default="logits")
+
+    def __post_init__(self) -> None:
+        """Validate the output kind."""
+        if self.output_kind not in ("logits", "binary_probs"):
+            raise ValueError(f"output_kind must be 'logits' or 'binary_probs', got '{self.output_kind}'.")
+
+
+def train_with_dpsgd(  # noqa: PLR0913
+    recipe: PETRecipe,
+    config: dict,
+    train_indices: np.ndarray,
+    device: str,
+    delta: float = 1e-5,
+    max_physical_batch: int = 256,
+) -> Module:
+    """Train one model under the sampled config; the single shared Opacus path.
+
+    ``noise_multiplier > 0`` wraps the loop in a PrivacyEngine with the physical
+    batch capped at ``max_physical_batch`` (per-example gradients cost
+    batch x params memory; the sampled batch size and the accounting are
+    unchanged). ``noise_multiplier == 0`` runs the plain loop — the non-private
+    anchor, ε = ∞.
+
+    The formal (ε, δ) is stored on the returned model as ``campaign_extras``,
+    which ``Campaign`` records next to the empirical attack result.
+    """
+    loader = recipe.make_loader(train_indices, config)
+    model = recipe.make_model(config).to(device)
+    optimizer = recipe.make_optimizer(model.parameters(), config)
+    private = config.get("noise_multiplier", 0) > 0
+
+    def run_epochs(epoch_loader) -> None:  # noqa: ANN001
+        for _ in range(recipe.epochs):
+            for xb, yb in epoch_loader:
+                optimizer.zero_grad()
+                loss = recipe.criterion(model(xb.to(device)), yb.to(device))
+                loss.backward()
+                optimizer.step()
+
+    model.train()
+    if private:
+        engine = PrivacyEngine(accountant="rdp")
+        model, optimizer, loader = engine.make_private(
+            module=model,
+            optimizer=optimizer,
+            data_loader=loader,
+            noise_multiplier=config["noise_multiplier"],
+            max_grad_norm=config["max_grad_norm"],
+        )
+        with BatchMemoryManager(data_loader=loader, max_physical_batch_size=max_physical_batch,
+                                optimizer=optimizer) as mem_loader:
+            run_epochs(mem_loader)
+        epsilon = engine.get_epsilon(delta=delta)
+    else:
+        run_epochs(loader)
+        epsilon = float("inf")
+
+    logger.info(f"Trained model: formal epsilon = {epsilon:.2f} (delta = {delta}).")
+    model.campaign_extras = {"epsilon": epsilon, "delta": delta}
+    return model.eval()
+
+
+def _free_cuda(device: str) -> None:
+    if device.startswith("cuda"):
+        torch.cuda.empty_cache()
+
+
+@torch.no_grad()
+def _evaluate_utility(model: Module, metric: str | Callable, x: torch.Tensor,
+                      y: torch.Tensor, device: str) -> float:
+    if callable(metric):
+        return float(metric(model, x, y, device))
+    if metric == "accuracy":
+        correct = 0
+        for i in range(0, len(x), 1024):
+            pred = model(x[i:i + 1024].to(device)).argmax(dim=1).cpu()
+            correct += int((pred == y[i:i + 1024]).sum())
+        return correct / len(x)
+    if metric == "auc":
+        from sklearn.metrics import roc_auc_score
+        scores = [model(x[i:i + 4096].to(device)).cpu().reshape(-1) for i in range(0, len(x), 4096)]
+        return float(roc_auc_score(y.numpy().ravel(), torch.cat(scores).numpy()))
+    raise ValueError(f"Unknown utility_metric '{metric}'; use 'accuracy', 'auc' or a callable.")
+
+
+def build_campaign_fns(  # noqa: PLR0913
+    recipe: PETRecipe,
+    splits: dict,
+    n_refs: int,
+    device: str,
+    utility_metric: str | Callable = "accuracy",
+    ref_seed: int = 1,
+) -> tuple[Callable, Callable, Callable]:
+    """Turn a recipe + data splits into a Campaign's (train_fn, utility_fn, attack_fn).
+
+    Args:
+        recipe: the structured training recipe.
+        splits: dict with keys ``x, y, target_train, ref_pool, audit_members,
+            audit_nonmembers, utility_eval`` (audit members must be a subset of
+            ``target_train``; the reference pool must be disjoint from it).
+        n_refs: matched reference models per attack — full mimicry: references
+            are trained with the candidate's config via the same recipe.
+        device: torch device string.
+        utility_metric: "accuracy", "auc", or a callable (model, x, y, device) -> float.
+        ref_seed: seed for reference-pool subsampling.
+
+    """
+    missing = [k for k in REQUIRED_SPLIT_KEYS if k not in splits]
+    if missing:
+        raise KeyError(f"splits is missing {missing}; required keys are {REQUIRED_SPLIT_KEYS}.")
+    if len(splits["ref_pool"]) == 0:
+        raise ValueError("Reference pool is empty; the matched attack needs disjoint training data.")
+
+    def train_fn(config: dict) -> Module:
+        _free_cuda(device)
+        return train_with_dpsgd(recipe, config, splits["target_train"], device)
+
+    def utility_fn(model: Module) -> float:
+        idx = splits["utility_eval"]
+        return _evaluate_utility(model, utility_metric, splits["x"][idx], splits["y"][idx], device)
+
+    def attack_fn(model: Module, config: dict) -> AttackScores:
+        rng = np.random.default_rng(ref_seed)
+        x, y = splits["x"], splits["y"]
+        members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
+        n_ref_train = min(len(splits["target_train"]), len(splits["ref_pool"]))
+
+        # References are trained one at a time and freed after scoring (GPU memory).
+        ref_phi_m = np.zeros(len(members))
+        ref_phi_n = np.zeros(len(nonmembers))
+        for _ in range(n_refs):
+            sub = rng.choice(splits["ref_pool"], size=n_ref_train, replace=False)
+            ref = train_with_dpsgd(recipe, config, sub, device)
+            ref_phi_m += confidence_signal(ref, x[members], y[members], device, recipe.output_kind) / n_refs
+            ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, recipe.output_kind) / n_refs
+            del ref
+            _free_cuda(device)
+
+        return AttackScores(
+            member_scores=confidence_signal(model, x[members], y[members], device, recipe.output_kind) - ref_phi_m,
+            nonmember_scores=(
+                confidence_signal(model, x[nonmembers], y[nonmembers], device, recipe.output_kind) - ref_phi_n
+            ),
+        )
+
+    return train_fn, utility_fn, attack_fn

--- a/leakpro/optimization/training.py
+++ b/leakpro/optimization/training.py
@@ -93,11 +93,20 @@ def _patch_residual_blocks(model: Module) -> None:
         out = self.bn3(self.conv3(out))
         return self.relu(out + identity)
 
+    # Only patch blocks that still use the stock forward. A subclass overriding
+    # forward (SE, attention, anything custom) would be silently replaced by the
+    # vanilla residual path, changing the model instead of just making it
+    # Opacus-safe.
     for module in model.modules():
-        if isinstance(module, BasicBlock):
+        if isinstance(module, BasicBlock) and type(module).forward is BasicBlock.forward:
             module.forward = MethodType(basic_forward, module)
-        elif isinstance(module, Bottleneck):
+        elif isinstance(module, Bottleneck) and type(module).forward is Bottleneck.forward:
             module.forward = MethodType(bottleneck_forward, module)
+        elif isinstance(module, (BasicBlock, Bottleneck)):
+            logger.warning(
+                f"{type(module).__name__} overrides forward; leaving it untouched. If it adds the "
+                "residual in place, Opacus will reject it — rewrite that forward out of place."
+            )
 
 
 def make_opacus_compatible(model: Module) -> Module:
@@ -135,12 +144,19 @@ def train_with_dpsgd(  # noqa: PLR0913
 ) -> Module:
     """Train one model under the sampled config; the single shared Opacus path.
 
-    ``noise_multiplier > 0`` runs the model through ``make_opacus_compatible``
-    and wraps the loop in a PrivacyEngine with the physical batch capped at
-    ``max_physical_batch`` (per-example gradients cost batch x params memory;
-    the sampled batch size and the accounting are unchanged).
-    ``noise_multiplier == 0`` runs the plain loop, untouched — the non-private
-    anchor, ε = ∞.
+    Every model goes through ``make_opacus_compatible`` regardless of noise, so
+    all points on one frontier share an architecture: applying the BatchNorm to
+    GroupNorm rewrite only to private configs would leave the non-private anchor
+    a structurally different model, and its utility gap would then mix the cost
+    of DP noise with the cost of an architecture change. The submitted
+    architecture is therefore not necessarily what gets trained — check the log
+    for the ModuleValidator notice.
+
+    ``noise_multiplier > 0`` wraps the loop in a PrivacyEngine with the physical
+    batch capped at ``max_physical_batch`` (per-example gradients cost
+    batch x params memory; the sampled batch size and the accounting are
+    unchanged). ``noise_multiplier == 0`` runs the plain loop — the non-private
+    anchor, ε = ∞. The key is required either way: see below.
 
     ``accountant`` must match whatever else in the pipeline reports ε, or the
     numbers are not comparable: PRV is tighter than RDP, so the same noise reads
@@ -150,12 +166,22 @@ def train_with_dpsgd(  # noqa: PLR0913
     The formal (ε, δ) is stored on the returned model as ``campaign_extras``,
     which ``Campaign`` records next to the empirical attack result.
     """
+    # Never default this: a missing or misspelled key would silently train a
+    # fully non-private model from a function whose whole purpose is DP-SGD.
+    # Non-private runs must say so by passing an explicit 0.
+    if "noise_multiplier" not in config:
+        raise KeyError(
+            "config has no 'noise_multiplier'. Pass an explicit 0.0 for the non-private anchor; "
+            "defaulting it would silently disable DP-SGD."
+        )
+    private = config["noise_multiplier"] > 0
+
     loader = recipe.make_loader(train_indices, config)
-    model = recipe.make_model(config).to(device)
-    private = config.get("noise_multiplier", 0) > 0
-    if private:
-        # Before the optimizer: fixing the model can replace parameter objects.
-        model = make_opacus_compatible(model).to(device)
+    # Applied on both branches so every point on a frontier shares one
+    # architecture: rewriting BatchNorm only for private configs would make the
+    # non-private anchor a different model, and its utility gap would then mix
+    # the cost of DP noise with the cost of an architecture change.
+    model = make_opacus_compatible(recipe.make_model(config)).to(device)
     optimizer = recipe.make_optimizer(model.parameters(), config)
 
     def run_epochs(epoch_loader) -> None:  # noqa: ANN001
@@ -185,7 +211,11 @@ def train_with_dpsgd(  # noqa: PLR0913
         epsilon = float("inf")
 
     logger.info(f"Trained model: formal epsilon = {epsilon:.2f} (delta = {delta}).")
-    model.campaign_extras = {"epsilon": epsilon, "delta": delta}
+    # The accountant travels with the number: PRV and RDP epsilons are not
+    # comparable, so a record that does not name its accountant cannot be
+    # safely compared with one from another run.
+    model.campaign_extras = {"epsilon": epsilon, "delta": delta,
+                             "accountant": accountant if private else None}
     return model.eval()
 
 
@@ -207,8 +237,16 @@ def _evaluate_utility(model: Module, metric: str | Callable, x: torch.Tensor,
         return correct / len(x)
     if metric == "auc":
         from sklearn.metrics import roc_auc_score
-        scores = [model(x[i:i + 4096].to(device)).cpu().reshape(-1) for i in range(0, len(x), 4096)]
-        return float(roc_auc_score(y.numpy().ravel(), torch.cat(scores).numpy()))
+        outs = [model(x[i:i + 4096].to(device)).cpu() for i in range(0, len(x), 4096)]
+        scores = torch.cat(outs)
+        # Flattening a multiclass output would interleave class scores with
+        # sample labels and produce a meaningless number, so refuse instead.
+        if scores.ndim > 1 and scores.shape[-1] != 1:
+            raise ValueError(
+                f"utility_metric='auc' needs a single-column model output, got shape {tuple(scores.shape)}. "
+                "Use 'accuracy' for multiclass models, or pass a callable."
+            )
+        return float(roc_auc_score(y.numpy().ravel(), scores.reshape(-1).numpy()))
     raise ValueError(f"Unknown utility_metric '{metric}'; use 'accuracy', 'auc' or a callable.")
 
 
@@ -247,6 +285,15 @@ def build_campaign_fns(  # noqa: PLR0913
         raise KeyError(f"splits is missing {missing}; required keys are {REQUIRED_SPLIT_KEYS}.")
     if len(splits["ref_pool"]) == 0:
         raise ValueError("Reference pool is empty; the matched attack needs disjoint training data.")
+    # Full mimicry means references train on as much data as the target. Quietly
+    # shrinking them would weaken the attack and make the audit read safer than
+    # it is, so a short reference pool is an error, not a silent downgrade.
+    if len(splits["ref_pool"]) < len(splits["target_train"]):
+        raise ValueError(
+            f"Reference pool ({len(splits['ref_pool'])}) is smaller than the target's training set "
+            f"({len(splits['target_train'])}). Full mimicry needs at least as many reference samples; "
+            "shrinking them silently would bias the audit optimistic."
+        )
 
     train_kwargs = {"delta": delta, "max_physical_batch": max_physical_batch, "accountant": accountant}
 
@@ -262,7 +309,7 @@ def build_campaign_fns(  # noqa: PLR0913
         rng = np.random.default_rng(ref_seed)
         x, y = splits["x"], splits["y"]
         members, nonmembers = splits["audit_members"], splits["audit_nonmembers"]
-        n_ref_train = min(len(splits["target_train"]), len(splits["ref_pool"]))
+        n_ref_train = len(splits["target_train"])  # guaranteed <= ref_pool by the check above
 
         # References are trained one at a time and freed after scoring (GPU memory).
         ref_phi_m = np.zeros(len(members))

--- a/leakpro/optimization/training.py
+++ b/leakpro/optimization/training.py
@@ -21,11 +21,13 @@ writing those callables directly.
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from types import MethodType
 
 import numpy as np
 import torch
 from opacus import PrivacyEngine
 from opacus.utils.batch_memory_manager import BatchMemoryManager
+from opacus.validators import ModuleValidator
 from torch.nn import Module, Parameter
 from torch.nn.modules.loss import _Loss
 from torch.optim import Optimizer
@@ -66,6 +68,62 @@ class PETRecipe:
             raise ValueError(f"output_kind must be 'logits' or 'binary_probs', got '{self.output_kind}'.")
 
 
+def _patch_residual_blocks(model: Module) -> None:
+    """Rewrite torchvision residual blocks to add the skip connection out of place.
+
+    ``ModuleValidator`` cannot fix this: ``out += identity`` lives in the block's
+    ``forward``, not in a submodule, and the in-place add overwrites the tensor
+    Opacus's backward hooks need. Silently does nothing if torchvision is absent.
+    """
+    try:
+        from torchvision.models.resnet import BasicBlock, Bottleneck
+    except ImportError:
+        return
+
+    def basic_forward(self: Module, x: torch.Tensor) -> torch.Tensor:
+        identity = x if self.downsample is None else self.downsample(x)
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        return self.relu(out + identity)
+
+    def bottleneck_forward(self: Module, x: torch.Tensor) -> torch.Tensor:
+        identity = x if self.downsample is None else self.downsample(x)
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.relu(self.bn2(self.conv2(out)))
+        out = self.bn3(self.conv3(out))
+        return self.relu(out + identity)
+
+    for module in model.modules():
+        if isinstance(module, BasicBlock):
+            module.forward = MethodType(basic_forward, module)
+        elif isinstance(module, Bottleneck):
+            module.forward = MethodType(bottleneck_forward, module)
+
+
+def make_opacus_compatible(model: Module) -> Module:
+    """Rewrite a module until Opacus can attach per-sample gradient hooks to it.
+
+    Three incompatibilities, in the order they bite: BatchNorm mixes samples
+    within a batch, so ``ModuleValidator`` swaps it for GroupNorm; in-place
+    activations overwrite tensors the hooks still need; and torchvision's
+    residual blocks add their skip connection in place (see
+    ``_patch_residual_blocks``).
+
+    Returns the fixed module, which may be a different object than the input —
+    build the optimizer from *this* model's parameters, not the original's.
+    """
+    if ModuleValidator.validate(model, strict=False):
+        model = ModuleValidator.fix(model)
+        logger.info("Model was not Opacus-compatible; ModuleValidator.fix() applied (BatchNorm -> GroupNorm).")
+
+    for module in model.modules():
+        if isinstance(getattr(module, "inplace", None), bool):
+            module.inplace = False
+
+    _patch_residual_blocks(model)
+    return model
+
+
 def train_with_dpsgd(  # noqa: PLR0913
     recipe: PETRecipe,
     config: dict,
@@ -73,22 +131,32 @@ def train_with_dpsgd(  # noqa: PLR0913
     device: str,
     delta: float = 1e-5,
     max_physical_batch: int = 256,
+    accountant: str = "prv",
 ) -> Module:
     """Train one model under the sampled config; the single shared Opacus path.
 
-    ``noise_multiplier > 0`` wraps the loop in a PrivacyEngine with the physical
-    batch capped at ``max_physical_batch`` (per-example gradients cost
-    batch x params memory; the sampled batch size and the accounting are
-    unchanged). ``noise_multiplier == 0`` runs the plain loop — the non-private
+    ``noise_multiplier > 0`` runs the model through ``make_opacus_compatible``
+    and wraps the loop in a PrivacyEngine with the physical batch capped at
+    ``max_physical_batch`` (per-example gradients cost batch x params memory;
+    the sampled batch size and the accounting are unchanged).
+    ``noise_multiplier == 0`` runs the plain loop, untouched — the non-private
     anchor, ε = ∞.
+
+    ``accountant`` must match whatever else in the pipeline reports ε, or the
+    numbers are not comparable: PRV is tighter than RDP, so the same noise reads
+    as a smaller ε under "prv". It defaults to "prv" for agreement with the
+    webapp's DP-SGD path.
 
     The formal (ε, δ) is stored on the returned model as ``campaign_extras``,
     which ``Campaign`` records next to the empirical attack result.
     """
     loader = recipe.make_loader(train_indices, config)
     model = recipe.make_model(config).to(device)
-    optimizer = recipe.make_optimizer(model.parameters(), config)
     private = config.get("noise_multiplier", 0) > 0
+    if private:
+        # Before the optimizer: fixing the model can replace parameter objects.
+        model = make_opacus_compatible(model).to(device)
+    optimizer = recipe.make_optimizer(model.parameters(), config)
 
     def run_epochs(epoch_loader) -> None:  # noqa: ANN001
         for _ in range(recipe.epochs):
@@ -100,7 +168,7 @@ def train_with_dpsgd(  # noqa: PLR0913
 
     model.train()
     if private:
-        engine = PrivacyEngine(accountant="rdp")
+        engine = PrivacyEngine(accountant=accountant)
         model, optimizer, loader = engine.make_private(
             module=model,
             optimizer=optimizer,
@@ -151,6 +219,9 @@ def build_campaign_fns(  # noqa: PLR0913
     device: str,
     utility_metric: str | Callable = "accuracy",
     ref_seed: int = 1,
+    delta: float = 1e-5,
+    max_physical_batch: int = 256,
+    accountant: str = "prv",
 ) -> tuple[Callable, Callable, Callable]:
     """Turn a recipe + data splits into a Campaign's (train_fn, utility_fn, attack_fn).
 
@@ -164,6 +235,11 @@ def build_campaign_fns(  # noqa: PLR0913
         device: torch device string.
         utility_metric: "accuracy", "auc", or a callable (model, x, y, device) -> float.
         ref_seed: seed for reference-pool subsampling.
+        delta: privacy-accounting δ, passed to every training run.
+        max_physical_batch: per-example-gradient memory cap; does not change the
+            sampled batch size or the accounting.
+        accountant: Opacus accountant ("prv", "rdp", "gdp"). Reference models use
+            the same one as the target, so mimicry stays exact.
 
     """
     missing = [k for k in REQUIRED_SPLIT_KEYS if k not in splits]
@@ -172,9 +248,11 @@ def build_campaign_fns(  # noqa: PLR0913
     if len(splits["ref_pool"]) == 0:
         raise ValueError("Reference pool is empty; the matched attack needs disjoint training data.")
 
+    train_kwargs = {"delta": delta, "max_physical_batch": max_physical_batch, "accountant": accountant}
+
     def train_fn(config: dict) -> Module:
         _free_cuda(device)
-        return train_with_dpsgd(recipe, config, splits["target_train"], device)
+        return train_with_dpsgd(recipe, config, splits["target_train"], device, **train_kwargs)
 
     def utility_fn(model: Module) -> float:
         idx = splits["utility_eval"]
@@ -194,6 +272,7 @@ def build_campaign_fns(  # noqa: PLR0913
             ref = train_with_dpsgd(recipe, config, sub, device)
             ref_phi_m += confidence_signal(ref, x[members], y[members], device, recipe.output_kind) / n_refs
             ref_phi_n += confidence_signal(ref, x[nonmembers], y[nonmembers], device, recipe.output_kind) / n_refs
+            ref = train_with_dpsgd(recipe, config, sub, device, **train_kwargs)
             del ref
             _free_cuda(device)
 

--- a/leakpro/reporting/report_handler.py
+++ b/leakpro/reporting/report_handler.py
@@ -8,10 +8,12 @@ import subprocess
 
 from leakpro.metrics.attack_result import GIAResults
 from leakpro.reporting.mia_result import MIAResult
+from leakpro.risk.render import to_latex
+from leakpro.risk.schemas import RiskAssessment
 from leakpro.synthetic_data_attacks.inference_utils import InferenceResults
 from leakpro.synthetic_data_attacks.linkability_utils import LinkabilityResults
 from leakpro.synthetic_data_attacks.singling_out_utils import SinglingOutResults
-from leakpro.utils.import_helper import Self, Union
+from leakpro.utils.import_helper import Optional, Self, Union
 from leakpro.utils.logger import logger
 
 ResultList = Union[list[MIAResult],
@@ -25,11 +27,17 @@ ResultList = Union[list[MIAResult],
 class ReportHandler():
     """Implementation of the report handler."""
 
-    def __init__(self:Self, results:ResultList, report_dir: str) -> None:
+    def __init__(self:Self, results:ResultList, report_dir: str,
+                 risk_assessment: Optional[RiskAssessment] = None) -> None:
         logger.info("Initializing report handler...")
 
         self.report_dir = report_dir
         logger.info(f"report_dir set to: {self.report_dir}")
+
+        # Optional use-case risk assessment, produced by leakpro.risk.assess_risk. run_audit builds
+        # its own ReportHandler and knows nothing about risk, so this is only populated when the
+        # caller constructs the handler directly.
+        self.risk_assessment = risk_assessment
 
         self.pdf_results = {}
         self.leakpro_types = {"MIAResult" : MIAResult,
@@ -81,6 +89,10 @@ class ReportHandler():
 
         # Create initial part of the document.
         self._init_pdf()
+
+        # Risk assessment first: it frames the attack results that follow.
+        if self.risk_assessment is not None:
+            self.latex_content += to_latex(self.risk_assessment)
 
         # Append all results to the document
         for result_type in self.leakpro_types:

--- a/leakpro/risk/__init__.py
+++ b/leakpro/risk/__init__.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Leakage risk assessment: from measured attack success to a use-case risk statement.
+
+The audit measures how well an attack succeeds. Turning that into risk needs one thing LeakPro cannot
+observe: how bad a successful attack would be for the people in the training data. This package keeps
+those two halves visibly separate and combines them without inventing weights.
+
+Usage::
+
+    from leakpro import LeakPro
+    from leakpro.risk import UseCaseProfile, assess_risk
+
+    leakpro = LeakPro(MyHandler, "audit.yaml")
+    results = leakpro.run_audit()
+
+    profile = UseCaseProfile(tolerated_fpr=0.01, attacker_prior=0.01, data_type_sensitivity=3.0)
+    assessment = assess_risk(results, profile, num_train=leakpro.handler.target_model_metadata.num_train)
+    assessment.save(f"{leakpro.report_dir}/risk_assessment.json")
+
+A profile declared in ``audit.yaml`` under a top-level ``use_case:`` block is available as
+``leakpro.use_case_profile``. Assessment is always an explicit call: ``run_audit`` neither computes
+nor writes it.
+
+Version 1 covers membership inference only. Model inversion, gradient inversion and synthetic data
+each need their own definition of attack success before they can produce a
+:class:`~leakpro.risk.schemas.VulnerabilityMeasurement`.
+"""
+
+from leakpro.risk.assessment import assess_risk, loss_magnitude, positive_predictive_value
+from leakpro.risk.policy import (
+    POLICY_VERSION,
+    SUGGESTED_SENSITIVITY_SCALE,
+    VULNERABILITY_BANDS,
+    resolve_vulnerability_band,
+)
+from leakpro.risk.render import to_latex, to_markdown
+from leakpro.risk.schemas import (
+    CombinedRisk,
+    DeclaredInputs,
+    MiaVulnerability,
+    RiskAssessment,
+    UseCaseProfile,
+    VulnerabilityMeasurement,
+)
+from leakpro.risk.vulnerability import (
+    InvertedResultError,
+    NoUsableResultError,
+    UnresolvableOperatingPointError,
+    measure_mia,
+    result_from_mapping,
+    strongest_for_risk,
+)
+
+__all__ = [
+    "POLICY_VERSION",
+    "SUGGESTED_SENSITIVITY_SCALE",
+    "VULNERABILITY_BANDS",
+    "CombinedRisk",
+    "DeclaredInputs",
+    "InvertedResultError",
+    "MiaVulnerability",
+    "NoUsableResultError",
+    "RiskAssessment",
+    "UnresolvableOperatingPointError",
+    "UseCaseProfile",
+    "VulnerabilityMeasurement",
+    "assess_risk",
+    "loss_magnitude",
+    "measure_mia",
+    "positive_predictive_value",
+    "resolve_vulnerability_band",
+    "result_from_mapping",
+    "strongest_for_risk",
+    "to_latex",
+    "to_markdown",
+]

--- a/leakpro/risk/assessment.py
+++ b/leakpro/risk/assessment.py
@@ -1,0 +1,294 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Combination of measured vulnerability with declared harm parameters.
+
+The structure follows Sion et al. (*Privacy Risk Assessment for Data Subject-aware Threat Modeling*,
+IWPE 2019, doi:10.1109/SPW.2019.00023):
+
+.. code-block:: text
+
+    Risk = LM x LEF
+    LM   = DTS x NR x DST x NDS          all four declared by the data controller
+    LEF  = V x (RP x TEF)                V is the probability of a successful attack
+
+LeakPro's contribution is that ``V`` is *measured* rather than elicited from experts: it is the true
+positive rate of the strongest attack at the operating point the user chose. ``RP x TEF`` (retention
+period times threat event frequency) is assumed to be 1, i.e. a single attack attempt against a
+retained model, because LeakPro cannot observe adversary behaviour. That assumption is recorded in
+the output rather than hidden.
+
+Precision is reported per Jayaraman et al. (*Revisiting Membership Inference Under Realistic
+Assumptions*, PoPETs 2021, Theorem 4.2): ``PPV = TPR / (TPR + gamma * FPR)`` with
+``gamma = (1 - pi) / pi``. Reporting it is not optional decoration. A balanced audit implies
+``pi = 0.5``, and at realistic priors the same measurement can mean a very different threat.
+
+Nothing in this module imports from ``leakpro.attacks``; it consumes the family-agnostic measured
+block so that other attack families can feed the same combination later.
+"""
+
+from leakpro.risk.policy import POLICY_VERSION, resolve_vulnerability_band
+from leakpro.risk.schemas import (
+    CombinedRisk,
+    DeclaredInputs,
+    MiaVulnerability,
+    RiskAssessment,
+    UseCaseProfile,
+)
+from leakpro.risk.vulnerability import measure_mia, strongest_for_risk
+from leakpro.utils.import_helper import Any, List, Optional, Tuple
+
+LEAKPRO_VERSION = "0.1.0"
+
+_BALANCED_PRIOR = 0.5
+
+
+def positive_predictive_value(success_rate: float, alpha: float, prior: float) -> float:
+    """Return the attacker's precision at a given membership prior.
+
+    Implements ``PPV = TPR / (TPR + gamma * alpha)`` with ``gamma = (1 - prior) / prior``
+    (Jayaraman et al., PoPETs 2021, Theorem 4.2). Algebraically identical to
+    ``prior * TPR / (prior * TPR + (1 - prior) * alpha)``.
+
+    Args:
+    ----
+        success_rate: True positive rate at the operating point, as a fraction.
+        alpha: Operating point (false-positive rate), as a fraction.
+        prior: Probability that a candidate record is a member.
+
+    Returns:
+    -------
+        Precision in [0, 1]. Zero when the attack flags nothing.
+
+    """
+    gamma = (1.0 - prior) / prior
+    denominator = success_rate + gamma * alpha
+    if denominator <= 0.0:
+        return 0.0
+    return success_rate / denominator
+
+
+def loss_magnitude(profile: UseCaseProfile, n_subjects: Optional[int]) -> Optional[float]:
+    """Return Sion's Loss Magnitude, ``DTS x NR x DST x NDS``.
+
+    Args:
+    ----
+        profile: The declared use-case profile.
+        n_subjects: Resolved number of data subjects (NDS), or None when unknown.
+
+    Returns:
+    -------
+        The product, or None when the number of subjects is unknown.
+
+    """
+    if n_subjects is None:
+        return None
+    return (profile.data_type_sensitivity
+            * profile.records_per_subject
+            * profile.subject_type_weight
+            * float(n_subjects))
+
+
+def _resolve_n_subjects(profile: UseCaseProfile, num_train: Optional[int]) -> Tuple[Optional[int], str]:
+    """Decide how many data subjects the assessment scales to, and say where the number came from.
+
+    Args:
+    ----
+        profile: The declared use-case profile.
+        num_train: Training-set size of the target model, when the caller supplied it.
+
+    Returns:
+    -------
+        ``(n_subjects, source)``.
+
+    """
+    if profile.n_subjects is not None:
+        return profile.n_subjects, "declared"
+    if num_train is not None:
+        return int(num_train), "target num_train"
+    return None, "unavailable"
+
+
+def _build_assumptions(profile: UseCaseProfile,
+                       measured: MiaVulnerability,
+                       n_subjects_source: str,
+                       extrapolated: Optional[float]) -> List[str]:
+    """Collect one assumption string per derived figure or degraded path.
+
+    Args:
+    ----
+        profile: The declared use-case profile.
+        measured: The measured block.
+        n_subjects_source: Where the subject count came from.
+        extrapolated: The extrapolated exposed-record count, when one was produced.
+
+    Returns:
+    -------
+        The assumption strings, in reporting order.
+
+    """
+    assumptions = [
+        f"Vulnerability is measured: TPR={measured.success_rate:.4f} at FPR={measured.operating_point} from attack "
+        f"'{measured.attack_name}'.",
+        "Loss Event Frequency equals the measured success rate: Sion's retention period times threat event frequency "
+        "(RP x TEF) is assumed to be 1, i.e. a single attack attempt against a retained model. LeakPro cannot observe "
+        "adversary behaviour, so raise this factor yourself if repeated attempts are plausible.",
+        "Risk = LM x LEF treats the four Loss Magnitude factors as independent. Sion et al. section VI-B flags this as "
+        "a simplification of reality.",
+        f"Precision (PPV) is reported at the declared attacker prior pi={profile.attacker_prior}. The audit protocol "
+        f"itself is balanced, which corresponds to pi=0.5 and is reported separately as ppv_balanced.",
+        f"Number of data subjects: {n_subjects_source}.",
+    ]
+    if profile.cost_per_exposed_subject is None:
+        assumptions.append("No cost per exposed subject was declared, so no monetary figure is reported. This is "
+                           "deliberate: a default cost would be fabricated.")
+    if measured.n_exposed_audit is None:
+        assumptions.append("The result carries no per-record signal values, so the exposed-member count could not be "
+                           "computed. Rates are reported without absolute counts.")
+    if extrapolated is not None:
+        assumptions.append(
+            f"Extrapolation from {measured.n_members_audit} audited members to the training population assumes the "
+            "audit sample is representative. Per-record vulnerability is strongly non-uniform (the privacy onion "
+            "effect), so treat the extrapolated count as an estimate, not a measurement."
+        )
+    return assumptions
+
+
+def _build_warnings(profile: UseCaseProfile, measured: MiaVulnerability, skipped: List[str]) -> List[str]:
+    """Collect conditions that make the assessment unsafe to quote without qualification.
+
+    Args:
+    ----
+        profile: The declared use-case profile.
+        measured: The measured block.
+        skipped: Reasons emitted while selecting the strongest attack.
+
+    Returns:
+    -------
+        The warning strings.
+
+    """
+    warnings = list(skipped)
+    if not measured.resolvable:
+        warnings.append(
+            f"alpha={measured.operating_point} is finer than the audit set can resolve (minimum "
+            f"{measured.min_resolvable_fpr:.2e} with {measured.n_non_members_audit} non-members). Derived figures are "
+            "withheld: a TPR of 0 here means 'not measurable', not 'no leakage'."
+        )
+    if profile.attacker_prior == _BALANCED_PRIOR:
+        warnings.append(
+            "The attacker prior is 0.5, the balanced-audit assumption. Real candidate pools are usually far more "
+            "skewed, and precision falls steeply with the prior. Declare a realistic pi before quoting these figures."
+        )
+    if measured.n_exposed_audit is not None and 0 < measured.n_exposed_audit <= 5:
+        warnings.append(
+            f"Only {measured.n_exposed_audit} members were flagged at this operating point. High precision over a "
+            "handful of records is a weak basis for a risk statement."
+        )
+    return warnings
+
+
+def assess_risk(results: Any,
+                profile: UseCaseProfile,
+                *,
+                num_train: Optional[int] = None,
+                train_test_gap: Optional[float] = None,
+                dp_epsilon: Optional[float] = None,
+                bands: Optional[List[Tuple[float, str]]] = None,
+                strict: bool = True) -> RiskAssessment:
+    """Assess use-case risk for a set of MIA results.
+
+    Called explicitly after ``LeakPro.run_audit`` rather than from inside it, so that one expensive
+    audit can be re-assessed cheaply under different operating points and priors::
+
+        results = leakpro.run_audit()
+        assessment = assess_risk(results, profile, num_train=leakpro.handler.target_model_metadata.num_train)
+        assessment.save("risk_assessment.json")
+
+    Args:
+    ----
+        results: A ``MIAResult`` or a list of them.
+        profile: Declared harm parameters.
+        num_train: Training-set size of the target model. Without it the assessment reports audit-set
+            figures only rather than guessing a population size.
+        train_test_gap: Optional context: target train accuracy minus test accuracy.
+        dp_epsilon: Optional context: DP-SGD epsilon of the target model.
+        bands: Optional override for the advisory vulnerability bands.
+        strict: When True, an operating point the audit set cannot resolve raises. When False, the
+            assessment is returned with derived figures withheld and a warning attached.
+
+    Returns:
+    -------
+        The full assessment.
+
+    """
+    candidates = list(results) if isinstance(results, (list, tuple)) else [results]
+    best, skipped = strongest_for_risk(candidates, profile.tolerated_fpr)
+    measured = measure_mia(best,
+                           alpha=profile.tolerated_fpr,
+                           strict=strict,
+                           train_test_gap=train_test_gap,
+                           dp_epsilon=dp_epsilon)
+
+    n_subjects, n_subjects_source = _resolve_n_subjects(profile, num_train)
+    magnitude = loss_magnitude(profile, n_subjects)
+
+    # Derived figures are withheld entirely when the operating point was not measurable, because a
+    # success rate of 0.0 there is an absence of measurement rather than an absence of leakage.
+    if measured.resolvable:
+        ppv = positive_predictive_value(measured.success_rate, measured.operating_point, profile.attacker_prior)
+        ppv_balanced = positive_predictive_value(measured.success_rate, measured.operating_point, _BALANCED_PRIOR)
+        risk = magnitude * measured.success_rate if magnitude is not None else None
+        expected_exposed = measured.success_rate * n_subjects if n_subjects is not None else None
+        band = resolve_vulnerability_band(measured.lift, bands)
+    else:
+        ppv, ppv_balanced, risk, expected_exposed, band = None, None, None, None, None
+
+    expected_cost = None
+    if expected_exposed is not None and profile.cost_per_exposed_subject is not None:
+        expected_cost = expected_exposed * profile.cost_per_exposed_subject
+
+    extrapolated = None
+    if (profile.extrapolate_to_population
+            and measured.resolvable
+            and measured.n_exposed_audit is not None
+            and measured.n_members_audit > 0
+            and num_train is not None):
+        extrapolated = measured.n_exposed_audit * (float(num_train) / measured.n_members_audit)
+
+    combined = CombinedRisk(
+        ppv=ppv,
+        ppv_balanced=ppv_balanced,
+        gamma=(1.0 - profile.attacker_prior) / profile.attacker_prior,
+        loss_magnitude=magnitude,
+        loss_event_frequency=measured.success_rate,
+        risk=risk,
+        expected_exposed_subjects=expected_exposed,
+        expected_cost=expected_cost,
+        extrapolated_exposed_records=extrapolated,
+        vulnerability_band=band,
+    )
+
+    declared = DeclaredInputs(
+        tolerated_fpr=profile.tolerated_fpr,
+        attacker_prior=profile.attacker_prior,
+        n_subjects=n_subjects,
+        n_subjects_source=n_subjects_source,
+        records_per_subject=profile.records_per_subject,
+        data_type_sensitivity=profile.data_type_sensitivity,
+        subject_type_weight=profile.subject_type_weight,
+        cost_per_exposed_subject=profile.cost_per_exposed_subject,
+        extrapolate_to_population=profile.extrapolate_to_population,
+        notes=profile.notes,
+    )
+
+    return RiskAssessment(
+        measured=measured,
+        declared=declared,
+        combined=combined,
+        assumptions=_build_assumptions(profile, measured, n_subjects_source, extrapolated),
+        warnings=_build_warnings(profile, measured, skipped),
+        policy_version=POLICY_VERSION,
+        leakpro_version=LEAKPRO_VERSION,
+    )

--- a/leakpro/risk/policy.py
+++ b/leakpro/risk/policy.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Advisory policy data for the risk layer, with the provenance of every value.
+
+Two things live here, and neither is a measurement.
+
+**Suggested sensitivity scale.** Sion et al. (*Privacy Risk Assessment for Data Subject-aware Threat
+Modeling*, IWPE 2019, doi:10.1109/SPW.2019.00023) define Loss Magnitude as a product of numeric
+factors but deliberately supply no values for them: section III-G states every input is an analyst
+estimate, and section VI-A points at "GDPR sensitivity interpretations" and "the severity scale from
+the CNIL PIA knowledge bases" as sources for reusable sensitivity values. :data:`SUGGESTED_SENSITIVITY_SCALE`
+reproduces the CNIL PIA severity levels (PIA-3, *Knowledge Bases*, February 2018 edition: negligible,
+limited, significant, maximum) as a starting point. It is a suggestion, not a default: the profile
+field defaults to a neutral 1.0 and users are expected to substitute their own scale.
+
+**Vulnerability bands.** :data:`VULNERABILITY_BANDS` label the measured lift (TPR at alpha divided by
+alpha). They are ``heuristic``: no published source defines thresholds for this quantity, and we do
+not pretend otherwise. They exist so a UI can colour a card, and they deliberately describe *only*
+the measured side.
+
+There is no combined risk band. A label over the combination of a measurement and a value judgement
+would require weights nobody has published, which is exactly the failure mode this module replaces.
+Report :attr:`leakpro.risk.schemas.CombinedRisk.risk` and the expected exposure count as numbers,
+next to the inputs that produced them.
+"""
+
+from leakpro.utils.import_helper import Dict, List, Optional, Tuple
+
+POLICY_VERSION = "2026-08-17.1"
+
+# CNIL PIA-3 "Knowledge Bases" (Feb 2018) severity levels, offered as a starting scale for the
+# Data Type Sensitivity (DTS) and Data Subject Type (DST) factors. Sourced, not invented, but still
+# a policy choice: substitute your own scale when you have one.
+SUGGESTED_SENSITIVITY_SCALE: Dict[str, float] = {
+    "negligible": 1.0,
+    "limited": 2.0,
+    "significant": 3.0,
+    "maximum": 4.0,
+}
+SUGGESTED_SENSITIVITY_SOURCE = (
+    "CNIL, Privacy Impact Assessment (PIA-3): Knowledge Bases, February 2018 - severity scale "
+    "(negligible / limited / significant / maximum), as recommended by Sion et al. IWPE 2019 SVI-A."
+)
+
+# (lower bound on lift, inclusive) -> label. Heuristic: see the module docstring.
+VULNERABILITY_BANDS: List[Tuple[float, str]] = [
+    (100.0, "SEVERE"),
+    (10.0, "HIGH"),
+    (3.0, "MODERATE"),
+    (1.0, "LOW"),
+    (0.0, "NONE"),
+]
+VULNERABILITY_BANDS_SOURCE = (
+    "heuristic - no published thresholds exist for TPR/alpha lift. Round numbers chosen so that "
+    "'NONE' means no better than random at the operating point and 'SEVERE' means two orders of "
+    "magnitude better. Override with your own bands rather than treating these as calibrated."
+)
+
+
+def resolve_vulnerability_band(lift: float, bands: Optional[List[Tuple[float, str]]] = None) -> str:
+    """Return the advisory band label for a measured lift.
+
+    Args:
+    ----
+        lift: Measured TPR at alpha divided by alpha.
+        bands: Optional override, as ``(lower_bound, label)`` pairs sorted from highest bound down.
+
+    Returns:
+    -------
+        The label of the first band whose lower bound the lift meets.
+
+    """
+    table = bands if bands is not None else VULNERABILITY_BANDS
+    for lower_bound, label in table:
+        if lift >= lower_bound:
+            return label
+    return table[-1][1]

--- a/leakpro/risk/render.py
+++ b/leakpro/risk/render.py
@@ -1,0 +1,199 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Rendering of a risk assessment to markdown and LaTeX.
+
+Both renderers follow the same rule: a band or a derived number never appears without the inputs that
+produced it. The assumption list and the policy version are part of the output, not an appendix.
+"""
+
+from leakpro.risk.policy import VULNERABILITY_BANDS_SOURCE
+from leakpro.risk.schemas import RiskAssessment
+from leakpro.utils.import_helper import Optional
+
+
+def _fmt(value: Optional[float], digits: int = 4) -> str:
+    """Format an optional float for display.
+
+    Args:
+    ----
+        value: The value, possibly None.
+        digits: Decimal places.
+
+    Returns:
+    -------
+        The formatted value, or an em dash placeholder when absent.
+
+    """
+    if value is None:
+        return "not reported"
+    return f"{value:.{digits}f}"
+
+
+def _fmt_count(value: Optional[float]) -> str:
+    """Format an optional count for display.
+
+    Args:
+    ----
+        value: The count, possibly None or fractional.
+
+    Returns:
+    -------
+        The formatted count, or a placeholder when absent.
+
+    """
+    if value is None:
+        return "not reported"
+    return f"{value:,.1f}" if value % 1 else f"{int(value):,}"
+
+
+def to_markdown(assessment: RiskAssessment) -> str:
+    """Render an assessment as markdown.
+
+    Args:
+    ----
+        assessment: The assessment to render.
+
+    Returns:
+    -------
+        A markdown document.
+
+    """
+    m, d, c = assessment.measured, assessment.declared, assessment.combined
+    lines = [
+        "# Leakage risk assessment",
+        "",
+        f"Attack: **{m.attack_name}** · operating point alpha = **{d.tolerated_fpr}** · "
+        f"policy {assessment.policy_version} · LeakPro {assessment.leakpro_version}",
+        "",
+        "## Measured (reproducible from the audit)",
+        "",
+        "| Quantity | Value |",
+        "|---|---|",
+        f"| TPR at alpha | {_fmt(m.success_rate)} |",
+        f"| Advantage (TPR - alpha) | {_fmt(m.advantage)} |",
+        f"| Lift (TPR / alpha) | {_fmt(m.lift, 1)}x |",
+        f"| Members flagged at alpha | {_fmt_count(m.n_exposed_audit)} of {m.n_members_audit} audited members |",
+        f"| Audit set | {m.n_members_audit} members, {m.n_non_members_audit} non-members |",
+        f"| Finest resolvable FPR | {m.min_resolvable_fpr:.2e} |",
+        f"| ROC AUC (context only) | {_fmt(m.roc_auc)} |",
+        f"| Train-test gap (context only) | {_fmt(m.train_test_gap)} |",
+        f"| DP-SGD epsilon (context only) | {_fmt(m.dp_epsilon)} |",
+        "",
+        "## Declared (your inputs, not measured)",
+        "",
+        "| Factor | Value |",
+        "|---|---|",
+        f"| Attacker prior pi | {d.attacker_prior} (gamma = {_fmt(c.gamma, 2)}) |",
+        f"| Data subjects (NDS) | {_fmt_count(d.n_subjects)} ({d.n_subjects_source}) |",
+        f"| Records per subject (NR) | {d.records_per_subject} |",
+        f"| Data type sensitivity (DTS) | {d.data_type_sensitivity} |",
+        f"| Subject type weight (DST) | {d.subject_type_weight} |",
+        f"| Cost per exposed subject | {_fmt(d.cost_per_exposed_subject, 2)} |",
+        "",
+        "## Combined",
+        "",
+        "| Quantity | Value |",
+        "|---|---|",
+        f"| Attacker precision at your pi | {_fmt(c.ppv)} |",
+        f"| Attacker precision at pi = 0.5 | {_fmt(c.ppv_balanced)} (the audit protocol's own assumption) |",
+        f"| Loss Magnitude (DTS x NR x DST x NDS) | {_fmt_count(c.loss_magnitude)} |",
+        f"| Loss Event Frequency | {_fmt(c.loss_event_frequency)} |",
+        f"| Risk (LM x LEF) | {_fmt_count(c.risk)} sensitivity-weighted expected exposed records |",
+        f"| Expected exposed subjects | {_fmt_count(c.expected_exposed_subjects)} |",
+        f"| Expected cost | {_fmt(c.expected_cost, 2)} |",
+        f"| Extrapolated exposed records | {_fmt_count(c.extrapolated_exposed_records)} |",
+        f"| Vulnerability band (advisory) | {c.vulnerability_band or 'not reported'} |",
+        "",
+        f"Band provenance: {VULNERABILITY_BANDS_SOURCE}",
+        "",
+        "## Assumptions",
+        "",
+    ]
+    lines += [f"{i}. {a}" for i, a in enumerate(assessment.assumptions, start=1)]
+    if assessment.warnings:
+        lines += ["", "## Warnings", ""]
+        lines += [f"- {w}" for w in assessment.warnings]
+    if d.notes:
+        lines += ["", "## Notes", "", d.notes]
+    return "\n".join(lines) + "\n"
+
+
+def _tex_escape(text: str) -> str:
+    """Escape LaTeX special characters in free text.
+
+    Args:
+    ----
+        text: Raw text.
+
+    Returns:
+    -------
+        Text safe to inline in a LaTeX document.
+
+    """
+    for char, replacement in (("\\", r"\textbackslash{}"), ("&", r"\&"), ("%", r"\%"), ("$", r"\$"),
+                              ("#", r"\#"), ("_", r"\_"), ("{", r"\{"), ("}", r"\}"),
+                              ("~", r"\textasciitilde{}"), ("^", r"\textasciicircum{}")):
+        text = text.replace(char, replacement)
+    return text
+
+
+def to_latex(assessment: RiskAssessment) -> str:
+    """Render an assessment as a LaTeX section for the PDF report.
+
+    Args:
+    ----
+        assessment: The assessment to render.
+
+    Returns:
+    -------
+        LaTeX markup, suitable for appending to the report document body.
+
+    """
+    m, d, c = assessment.measured, assessment.declared, assessment.combined
+    rows = [
+        ("TPR at alpha", _fmt(m.success_rate)),
+        ("Advantage", _fmt(m.advantage)),
+        ("Lift", f"{_fmt(m.lift, 1)}x"),
+        ("Members flagged", f"{_fmt_count(m.n_exposed_audit)} of {m.n_members_audit}"),
+        ("Attacker precision at declared prior", _fmt(c.ppv)),
+        ("Attacker precision at prior 0.5", _fmt(c.ppv_balanced)),
+        ("Loss Magnitude", _fmt_count(c.loss_magnitude)),
+        ("Risk (LM x LEF)", _fmt_count(c.risk)),
+        ("Expected exposed subjects", _fmt_count(c.expected_exposed_subjects)),
+        ("Expected cost", _fmt(c.expected_cost, 2)),
+        ("Vulnerability band (advisory)", c.vulnerability_band or "not reported"),
+    ]
+    body = "\n".join(f"        {_tex_escape(label)} & {_tex_escape(value)} \\\\" for label, value in rows)
+    assumptions = "\n".join(f"        \\item {_tex_escape(a)}" for a in assessment.assumptions)
+    latex = f"""
+        \\section{{Risk assessment}}
+        Attack {_tex_escape(m.attack_name)}, operating point $\\alpha = {d.tolerated_fpr}$,
+        declared attacker prior $\\pi = {d.attacker_prior}$, policy {_tex_escape(assessment.policy_version)}.
+
+        \\begin{{tabularx}}{{\\textwidth}}{{lX}}
+        \\hline
+{body}
+        \\hline
+        \\end{{tabularx}}
+
+        \\subsection*{{Assumptions}}
+        \\begin{{enumerate}}
+{assumptions}
+        \\end{{enumerate}}
+        """
+    if assessment.warnings:
+        warnings = "\n".join(f"        \\item {_tex_escape(w)}" for w in assessment.warnings)
+        latex += f"""
+        \\subsection*{{Warnings}}
+        \\begin{{itemize}}
+{warnings}
+        \\end{{itemize}}
+        """
+    if d.notes:
+        latex += f"""
+        \\subsection*{{Notes}}
+        {_tex_escape(d.notes)}
+        """
+    return latex

--- a/leakpro/risk/schemas.py
+++ b/leakpro/risk/schemas.py
@@ -1,0 +1,205 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Schemas for the leakage risk assessment layer.
+
+The assessment is reported as three blocks that are never collapsed into a single opaque score:
+
+* :class:`VulnerabilityMeasurement` (and its MIA subclass) holds what the audit *measured*. Every
+  field is reproducible by re-running the audit.
+* :class:`DeclaredInputs` echoes what the data controller *declared*. None of it is measurable by
+  LeakPro, and it is reproduced verbatim in the output so a reader can see what was assumed.
+* :class:`CombinedRisk` holds figures derived from the two blocks above. Every one of them is
+  traceable to measured or declared inputs, and :attr:`RiskAssessment.assumptions` names the
+  assumption behind each derived quantity.
+
+See ``leakpro/risk/policy.py`` for the provenance of the advisory bands and the suggested
+sensitivity scale.
+"""
+
+import json
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from leakpro.utils.import_helper import List, Optional, Self
+
+
+class UseCaseProfile(BaseModel):
+    """Harm parameters declared by the data controller.
+
+    These cannot be measured by LeakPro: they describe the deployment context, not the model. The
+    factor names follow the Loss Magnitude decomposition of Sion et al. (IWPE 2019,
+    doi:10.1109/SPW.2019.00023), ``LM = DTS x NR x DST x NDS``, so that a reader can map each field
+    onto the published model. That paper deliberately supplies no numeric values for the factors;
+    see :data:`leakpro.risk.policy.SUGGESTED_SENSITIVITY_SCALE` for a cited starting point.
+    """
+
+    tolerated_fpr: float = Field(..., gt=0.0, lt=1.0,
+                                 description="Operating point alpha: the false-positive rate the attacker is assumed to "
+                                             "tolerate. Required on purpose - it changes the headline number and the "
+                                             "choice belongs to you. Use 0.01 unless you have a reason to go lower; "
+                                             "smaller values are unresolvable on small audit sets.")
+    attacker_prior: float = Field(default=0.5, gt=0.0, lt=1.0,
+                                  description="pi: probability that a record in the attacker's candidate pool is "
+                                              "actually a member. The default 0.5 is the balanced-audit assumption "
+                                              "baked into every TPR and AUC LeakPro reports, and it overstates "
+                                              "precision for realistic pools (Jayaraman et al., PoPETs 2021).")
+    n_subjects: Optional[int] = Field(default=None, ge=1,
+                                      description="NDS: number of data subjects in the training population. Defaults "
+                                                  "to the target model's num_train when available.")
+    records_per_subject: float = Field(default=1.0, gt=0.0,
+                                       description="NR: records of this data type per data subject. Fractions are "
+                                                   "allowed when only some subjects contribute the data type.")
+    data_type_sensitivity: float = Field(default=1.0, gt=0.0,
+                                         description="DTS: sensitivity of the leaked data type on a numeric scale you "
+                                                     "choose. 1.0 is neutral. See policy.SUGGESTED_SENSITIVITY_SCALE.")
+    subject_type_weight: float = Field(default=1.0, gt=0.0,
+                                       description="DST: weight for the data subject type, capturing vulnerable "
+                                                   "subjects such as minors or patients. 1.0 is neutral.")
+    cost_per_exposed_subject: Optional[float] = Field(default=None, ge=0.0,
+                                                      description="Cost to the organization per exposed subject, in any "
+                                                                  "unit you choose. Left unset, no monetary figure is "
+                                                                  "reported at all rather than a fabricated one.")
+    extrapolate_to_population: bool = Field(default=False,
+                                            description="Scale the exposed-record count from the audit set up to the "
+                                                        "training population. Off by default: per-record vulnerability "
+                                                        "is strongly non-uniform, so the extrapolation is an estimate "
+                                                        "under an assumption, not a measurement.")
+    notes: str = Field(default="", description="Free text kept in the output for the audit trail.")
+
+    model_config = ConfigDict(extra="forbid")  # Prevent extra fields
+
+
+class VulnerabilityMeasurement(BaseModel):
+    """Family-agnostic measured block.
+
+    Any attack family that wants to feed the risk layer produces one of these. Only MIA is
+    implemented in v1 (:class:`MiaVulnerability`); model inversion, gradient inversion and synthetic
+    data each need their own success definition first. Nothing in ``assessment.py`` may depend on
+    fields below this class.
+    """
+
+    attack_name: str = Field(..., description="Attack the measurement came from")
+    operating_point: float = Field(..., gt=0.0, lt=1.0, description="alpha for MIA; family-specific elsewhere")
+    success_rate: float = Field(..., ge=0.0, le=1.0, description="TPR at the operating point for MIA")
+    baseline_rate: float = Field(..., gt=0.0, lt=1.0, description="Random-guess rate at the operating point (alpha)")
+    n_at_risk: int = Field(..., ge=0, description="Records the measurement covers (audit-set members for MIA)")
+    resolvable: bool = Field(..., description="False when the audit set cannot resolve the operating point")
+    provenance: dict = Field(default_factory=dict, description="Attack config and result id")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MiaVulnerability(VulnerabilityMeasurement):
+    """Measured block for membership inference."""
+
+    roc_auc: Optional[float] = Field(default=None, description="Context only. Not used in any risk figure")
+    advantage: float = Field(..., description="TPR(alpha) - alpha: absolute gain over random guessing")
+    lift: float = Field(..., ge=0.0, description="TPR(alpha) / alpha: multiplicative gain over random guessing")
+    n_members_audit: int = Field(..., ge=0, description="Members in the audit set")
+    n_non_members_audit: int = Field(..., ge=0, description="Non-members in the audit set")
+    n_exposed_audit: Optional[int] = Field(default=None, ge=0,
+                                           description="Members flagged at the threshold yielding FPR <= alpha. None "
+                                                       "when the result carries no signal values")
+    exposed_audit_indices: Optional[List[int]] = Field(default=None,
+                                                       description="Dataset indices of the exposed members. Usually None: "
+                                                                   "the live MIAResult does not carry audit indices, so "
+                                                                   "exposed records can be counted but not named")
+    min_resolvable_fpr: float = Field(..., gt=0.0, description="1 / n_non_members_audit: the finest FPR this audit "
+                                                              "set can express")
+    train_test_gap: Optional[float] = Field(default=None, description="Context only: train accuracy minus test accuracy")
+    dp_epsilon: Optional[float] = Field(default=None, description="Context only: DP-SGD epsilon of the target")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class DeclaredInputs(BaseModel):
+    """Verbatim echo of the use-case profile, plus where n_subjects came from."""
+
+    tolerated_fpr: float
+    attacker_prior: float
+    n_subjects: Optional[int] = None
+    n_subjects_source: str = Field(..., description="'declared', 'target num_train', or 'unavailable'")
+    records_per_subject: float
+    data_type_sensitivity: float
+    subject_type_weight: float
+    cost_per_exposed_subject: Optional[float] = None
+    extrapolate_to_population: bool
+    notes: str = ""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class CombinedRisk(BaseModel):
+    """Figures derived from the measured and declared blocks."""
+
+    ppv: Optional[float] = Field(default=None, ge=0.0, le=1.0,
+                                 description="Precision of the attacker at the declared prior: "
+                                             "TPR / (TPR + gamma*alpha) with gamma = (1-pi)/pi. Jayaraman et al. Thm 4.2")
+    ppv_balanced: Optional[float] = Field(default=None, ge=0.0, le=1.0,
+                                          description="Same at pi = 0.5, the assumption built into the audit protocol")
+    gamma: float = Field(..., gt=0.0, description="(1 - attacker_prior) / attacker_prior")
+    loss_magnitude: Optional[float] = Field(default=None, ge=0.0,
+                                            description="Sion LM = DTS x NR x DST x NDS. None without n_subjects")
+    loss_event_frequency: float = Field(..., ge=0.0,
+                                        description="Sion LEF. Equals the measured success rate under the "
+                                                    "single-attempt assumption")
+    risk: Optional[float] = Field(default=None, ge=0.0,
+                                  description="Sion Risk = LM x LEF, in sensitivity-weighted expected exposed records. "
+                                              "With neutral factors this equals expected_exposed_subjects")
+    expected_exposed_subjects: Optional[float] = Field(default=None, ge=0.0,
+                                                       description="success_rate x n_subjects: unweighted and directly "
+                                                                   "interpretable")
+    expected_cost: Optional[float] = Field(default=None, ge=0.0,
+                                           description="Omitted unless a cost per exposed subject was declared")
+    extrapolated_exposed_records: Optional[float] = Field(default=None, ge=0.0,
+                                                          description="Audit-set exposed count scaled to the training "
+                                                                      "population. Only when explicitly requested")
+    vulnerability_band: Optional[str] = Field(default=None,
+                                              description="Advisory label over the measured lift only. Never a "
+                                                          "combined risk label - see policy.py")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class RiskAssessment(BaseModel):
+    """Complete assessment: measured, declared, combined, plus provenance."""
+
+    measured: MiaVulnerability
+    declared: DeclaredInputs
+    combined: CombinedRisk
+    assumptions: List[str] = Field(default_factory=list,
+                                   description="One entry per derived figure or degraded path, naming the assumption")
+    warnings: List[str] = Field(default_factory=list, description="Conditions that make the assessment unsafe to quote")
+    policy_version: str = Field(..., description="Version of the band policy used")
+    leakpro_version: str = Field(..., description="LeakPro version that produced the assessment")
+
+    model_config = ConfigDict(extra="forbid")
+
+    def save(self: Self, path: str) -> None:
+        """Write the assessment to ``path`` as JSON.
+
+        Args:
+        ----
+            path: Destination file path.
+
+        """
+        with open(path, "w") as f:
+            f.write(self.model_dump_json(indent=2))
+
+    @staticmethod
+    def load(path: str) -> "RiskAssessment":
+        """Read an assessment back from a JSON file written by :meth:`save`.
+
+        Args:
+        ----
+            path: Path to the JSON file.
+
+        Returns:
+        -------
+            The deserialized assessment.
+
+        """
+        with open(path) as f:
+            return RiskAssessment(**json.load(f))

--- a/leakpro/risk/vulnerability.py
+++ b/leakpro/risk/vulnerability.py
@@ -1,0 +1,396 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Extraction of the measured block from MIA results.
+
+This module is the only place in the risk layer that knows about membership inference. It turns a
+``MIAResult`` into a :class:`~leakpro.risk.schemas.MiaVulnerability`, enforcing four guards that each
+correspond to a way a naive implementation reports a confidently wrong number:
+
+1. *Resolution.* ``TPR`` at an FPR the audit set cannot express is not zero risk, it is no
+   measurement. An audit with ``n`` non-members cannot resolve an FPR below ``1/n``.
+2. *Orientation.* A result whose ROC AUC is below 0.5 is inverted, so a real leak reads as no leak.
+   Such results are rejected by name rather than folded into an aggregate.
+3. *Selection.* The attack that matters for risk is the one that wins at the user's operating point,
+   which is not always the one with the highest AUC.
+4. *Units.* Everything here is a fraction in [0, 1], validated in exactly one place. The live
+   ``MIAResult`` (``leakpro.reporting.mia_result``) stores ``fixed_fpr_table`` as fractions, while the
+   legacy ``leakpro.metrics.attack_result.find_tpr_at_fpr`` returns percentages. Only the former
+   feeds this module, and the validation catches the day someone wires up the latter.
+
+The TPR-at-alpha lookup is reimplemented locally rather than imported, because
+``leakpro.metrics.attack_result`` pulls in torch, matplotlib and torchvision at import time. The
+semantics are identical: the maximum TPR over ROC points whose FPR does not exceed alpha.
+"""
+
+import numpy as np
+
+from leakpro.risk.schemas import MiaVulnerability
+from leakpro.utils.import_helper import Any, List, Optional, Tuple
+
+# Accepted key spellings per operating point. MIAResult._get_result_fixed_fpr formats the percentage
+# with trailing zeros stripped ("TPR@1%FPR"), while the legacy metrics helper pads them
+# ("TPR@1.0%FPR"). Both are accepted so a saved result from either era can be read.
+_FIXED_FPR_KEYS = {
+    0.1: ("TPR@10%FPR", "TPR@10.0%FPR"),
+    0.01: ("TPR@1%FPR", "TPR@1.0%FPR"),
+    0.001: ("TPR@0.1%FPR",),
+    0.0001: ("TPR@0.01%FPR",),
+}
+
+
+class InvertedResultError(ValueError):
+    """Raised when a result's ROC is inverted, making it unusable for risk assessment."""
+
+
+class UnresolvableOperatingPointError(ValueError):
+    """Raised when the audit set is too small to express the requested false-positive rate."""
+
+
+class NoUsableResultError(ValueError):
+    """Raised when no attack result can support a risk assessment at the requested operating point."""
+
+
+def _as_array(values: Any) -> Optional[np.ndarray]:
+    """Coerce a result field to a 1-D float array, or None when absent.
+
+    Args:
+    ----
+        values: List, array or None as stored on a result object.
+
+    Returns:
+    -------
+        A 1-D array, or None when there is nothing to coerce.
+
+    """
+    if values is None:
+        return None
+    array = np.asarray(values, dtype=float).ravel()
+    return array if array.size else None
+
+
+def _tpr_at_fpr(fpr: np.ndarray, tpr: np.ndarray, alpha: float) -> float:
+    """Return the maximum TPR over ROC points with FPR <= alpha, as a fraction.
+
+    Args:
+    ----
+        fpr: False-positive rates of the ROC curve.
+        tpr: True-positive rates of the ROC curve.
+        alpha: Operating point.
+
+    Returns:
+    -------
+        TPR as a fraction in [0, 1]. Zero when no ROC point satisfies the constraint, which callers
+        must treat as "unmeasurable", not as "no leakage".
+
+    """
+    eligible = np.nonzero(fpr <= alpha)[0]
+    if eligible.size == 0:
+        return 0.0
+    return float(np.max(tpr[eligible]))
+
+
+def _tpr_from_fixed_table(table: dict, alpha: float) -> float:
+    """Read TPR at alpha from a result's fixed-FPR table.
+
+    Args:
+    ----
+        table: The ``fixed_fpr_table`` mapping on a ``MIAResult``, whose values are fractions.
+        alpha: Operating point; must be one of the tabulated rates.
+
+    Returns:
+    -------
+        TPR as a fraction in [0, 1].
+
+    Raises:
+    ------
+        ValueError: When alpha is not tabulated, or the stored value is not a fraction in [0, 1]. The
+            latter catches a percentage-valued table, e.g. one built by the legacy
+            ``leakpro.metrics.attack_result.find_tpr_at_fpr``, instead of silently reporting a TPR of
+            1030%.
+
+    """
+    keys = _FIXED_FPR_KEYS.get(alpha, ())
+    key = next((k for k in keys if k in table), None)
+    if key is None:
+        raise ValueError(
+            f"Cannot read TPR at alpha={alpha} from this result: tabulated operating points are "
+            f"{sorted(_FIXED_FPR_KEYS)} and the table holds {sorted(table)}. Pass a result that still carries its "
+            "fpr/tpr arrays to use other operating points."
+        )
+    value = float(table[key])
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(
+            f"Fixed-FPR table value {value} for {key} is not a fraction in [0, 1]. A percentage-valued table cannot be "
+            "used here: divide by 100 at the source rather than letting the unit error propagate into a risk figure."
+        )
+    return value
+
+
+def _tpr_of(result: Any, alpha: float) -> float:
+    """Return TPR at alpha for a result, from its ROC arrays when present, else its saved table.
+
+    Args:
+    ----
+        result: A ``MIAResult`` (in memory or loaded from disk).
+        alpha: Operating point.
+
+    Returns:
+    -------
+        TPR as a fraction in [0, 1].
+
+    """
+    fpr = _as_array(getattr(result, "fpr", None))
+    tpr = _as_array(getattr(result, "tpr", None))
+    if fpr is not None and tpr is not None and fpr.size == tpr.size:
+        return _tpr_at_fpr(fpr, tpr, alpha)
+    table = getattr(result, "fixed_fpr_table", None)
+    if table:
+        return _tpr_from_fixed_table(table, alpha)
+    raise ValueError(f"Result {getattr(result, 'id', '<unknown>')} carries neither ROC arrays nor a fixed-FPR table.")
+
+
+def _membership_labels(result: Any) -> Optional[np.ndarray]:
+    """Return the membership labels of a result.
+
+    The live ``MIAResult`` (``leakpro.reporting.mia_result``) stores them as ``true``; the legacy
+    class in ``leakpro.metrics.attack_result`` and results loaded from older JSON use
+    ``true_labels``. Both are accepted.
+
+    Args:
+    ----
+        result: A result object.
+
+    Returns:
+    -------
+        The labels as a 1-D array, or None when the result carries none.
+
+    """
+    for attribute in ("true", "true_labels"):
+        labels = _as_array(getattr(result, attribute, None))
+        if labels is not None:
+            return labels
+    return None
+
+
+def _label_counts(true_labels: Optional[np.ndarray]) -> Tuple[int, int]:
+    """Count members and non-members in the audit set.
+
+    Args:
+    ----
+        true_labels: Membership labels, 1 for members.
+
+    Returns:
+    -------
+        ``(n_members, n_non_members)``.
+
+    """
+    if true_labels is None:
+        return 0, 0
+    members = int(np.count_nonzero(true_labels == 1))
+    return members, int(true_labels.size - members)
+
+
+def _exposed_members(signal_values: Optional[np.ndarray],
+                     true_labels: Optional[np.ndarray],
+                     audit_indices: Optional[np.ndarray],
+                     alpha: float) -> Tuple[Optional[int], Optional[List[int]]]:
+    """Count the members an attacker flags at the threshold that yields FPR <= alpha.
+
+    The threshold is taken as the ``1 - alpha`` quantile of the non-member signal, i.e. the strictest
+    threshold that still lets through an alpha fraction of non-members. Orientation is assumed to be
+    higher-is-member, which the caller guarantees by rejecting results with AUC below 0.5.
+
+    Args:
+    ----
+        signal_values: Per-record attack scores.
+        true_labels: Membership labels, 1 for members.
+        audit_indices: Dataset indices of the audited records, when available.
+        alpha: Operating point.
+
+    Returns:
+    -------
+        ``(count, indices)``. Both None when the result carries no signal values; ``indices`` is None
+        when the result carries no audit indices.
+
+    """
+    if signal_values is None or true_labels is None or signal_values.size != true_labels.size:
+        return None, None
+
+    is_member = true_labels == 1
+    non_member_signal = signal_values[~is_member]
+    if non_member_signal.size == 0:
+        return None, None
+
+    threshold = float(np.quantile(non_member_signal, 1.0 - alpha))
+    exposed_mask = is_member & (signal_values > threshold)
+    count = int(np.count_nonzero(exposed_mask))
+
+    if audit_indices is None or audit_indices.size != signal_values.size:
+        return count, None
+    return count, [int(i) for i in audit_indices[exposed_mask]]
+
+
+class _MappingResult:
+    """Duck-typed view over a serialized MIA result, for callers that only have JSON."""
+
+    def __init__(self, payload: dict) -> None:
+        self.result_name = payload.get("attack_name") or payload.get("result_name") or "<unknown>"
+        self.roc_auc = payload.get("roc_auc")
+        self.fpr = payload.get("fpr")
+        self.tpr = payload.get("tpr")
+        self.true = payload.get("true_labels") if payload.get("true_labels") is not None else payload.get("true")
+        self.signal_values = payload.get("signal_values")
+        self.fixed_fpr_table = payload.get("tpr_at_fpr") or payload.get("fixed_fpr_table") or {}
+        self.audit_indices = payload.get("audit_indices")
+        self.id = payload.get("id") or self.result_name
+        self.metadata = payload.get("config") or payload.get("metadata") or {}
+
+
+def result_from_mapping(payload: dict) -> Any:
+    """Adapt a serialized MIA result to the shape this module reads.
+
+    Lets callers that hold JSON rather than live objects (the web app backend, or anything re-reading
+    a finished audit) reuse the same measurement path instead of reimplementing it.
+
+    Args:
+    ----
+        payload: A serialized result, as produced by the web app's ``_serialise_result`` or by
+            ``MIAResult.save``.
+
+    Returns:
+    -------
+        An object exposing the attributes :func:`measure_mia` reads.
+
+    """
+    return _MappingResult(payload)
+
+
+def measure_mia(result: Any,
+                *,
+                alpha: float,
+                strict: bool = True,
+                train_test_gap: Optional[float] = None,
+                dp_epsilon: Optional[float] = None) -> MiaVulnerability:
+    """Extract the measured block from a single MIA result.
+
+    Args:
+    ----
+        result: A ``MIAResult``, in memory or loaded from disk.
+        alpha: Operating point, the false-positive rate the attacker is assumed to tolerate.
+        strict: When True, an operating point the audit set cannot resolve raises. When False, the
+            measurement is returned with ``resolvable=False`` so callers can degrade explicitly.
+        train_test_gap: Optional context: target train accuracy minus test accuracy.
+        dp_epsilon: Optional context: DP-SGD epsilon of the target model.
+
+    Returns:
+    -------
+        The measured block.
+
+    Raises:
+    ------
+        InvertedResultError: When the result's ROC AUC is below 0.5.
+        UnresolvableOperatingPointError: When ``strict`` and alpha is finer than the audit set allows.
+
+    """
+    name = getattr(result, "result_name", None) or getattr(result, "resultname", None) or getattr(result, "id", "<unknown>")
+
+    roc_auc = getattr(result, "roc_auc", None)
+    roc_auc = float(roc_auc) if roc_auc is not None else None
+    if roc_auc is not None and roc_auc < 0.5:
+        raise InvertedResultError(
+            f"Attack '{name}' reports ROC AUC {roc_auc:.4f} < 0.5, so its scores are inverted and a real leak would "
+            "read as no leak. Fix the attack's score orientation before using it for risk assessment; do not average "
+            "it in with correctly oriented attacks."
+        )
+
+    true_labels = _membership_labels(result)
+    n_members, n_non_members = _label_counts(true_labels)
+    if n_non_members == 0:
+        raise ValueError(f"Attack '{name}' has no non-members in its audit set, so no false-positive rate is defined.")
+
+    min_resolvable_fpr = 1.0 / n_non_members
+    resolvable = alpha >= min_resolvable_fpr
+    if not resolvable and strict:
+        raise UnresolvableOperatingPointError(
+            f"alpha={alpha} is finer than attack '{name}' can resolve: {n_non_members} non-members give a minimum "
+            f"expressible FPR of {min_resolvable_fpr:.2e}. TPR at this alpha would read 0.0, which means 'not "
+            f"measurable', not 'no leakage'. Raise alpha to at least {min_resolvable_fpr:.2e} or audit more records."
+        )
+
+    success_rate = _tpr_of(result, alpha)
+    n_exposed, exposed_indices = _exposed_members(
+        _as_array(getattr(result, "signal_values", None)),
+        true_labels,
+        _as_array(getattr(result, "audit_indices", None)),
+        alpha,
+    )
+
+    return MiaVulnerability(
+        attack_name=str(name),
+        operating_point=alpha,
+        success_rate=success_rate,
+        baseline_rate=alpha,
+        n_at_risk=n_members,
+        resolvable=resolvable,
+        provenance={"result_id": str(getattr(result, "id", "") or ""), "config": getattr(result, "metadata", None) or {}},
+        roc_auc=roc_auc,
+        advantage=success_rate - alpha,
+        lift=success_rate / alpha,
+        n_members_audit=n_members,
+        n_non_members_audit=n_non_members,
+        n_exposed_audit=n_exposed,
+        exposed_audit_indices=exposed_indices,
+        min_resolvable_fpr=min_resolvable_fpr,
+        train_test_gap=train_test_gap,
+        dp_epsilon=dp_epsilon,
+    )
+
+
+def strongest_for_risk(results: List[Any], alpha: float) -> Tuple[Any, List[str]]:
+    """Select the attack that performs best at the operating point, not the one with the highest AUC.
+
+    ``MIAResult.get_strongest`` maximizes ROC AUC, which is an average-case measure. For risk the
+    relevant attack is the one that wins at the FPR the attacker tolerates; the two disagree
+    routinely.
+
+    Args:
+    ----
+        results: Candidate MIA results.
+        alpha: Operating point.
+
+    Returns:
+    -------
+        ``(best_result, skipped)`` where ``skipped`` holds one human-readable reason per rejected
+        result, for the caller to surface as warnings.
+
+    Raises:
+    ------
+        NoUsableResultError: When every candidate was rejected.
+
+    """
+    best: Optional[Any] = None
+    best_tpr = -1.0
+    skipped: List[str] = []
+
+    for result in results:
+        name = getattr(result, "result_name", None) or getattr(result, "resultname", None) or getattr(result, "id", "?")
+        roc_auc = getattr(result, "roc_auc", None)
+        if roc_auc is not None and float(roc_auc) < 0.5:
+            skipped.append(f"'{name}' skipped: inverted ROC (AUC {float(roc_auc):.4f} < 0.5)")
+            continue
+        try:
+            tpr = _tpr_of(result, alpha)
+        except ValueError as exc:
+            skipped.append(f"'{name}' skipped: {exc}")
+            continue
+        if tpr > best_tpr:
+            best, best_tpr = result, tpr
+
+    if best is None:
+        raise NoUsableResultError(
+            f"No attack result can support a risk assessment at alpha={alpha}. Reasons: " + "; ".join(skipped)
+            if skipped else f"No attack results were supplied for alpha={alpha}."
+        )
+    return best, skipped

--- a/leakpro/schemas.py
+++ b/leakpro/schemas.py
@@ -11,6 +11,8 @@ import optuna
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from torch.nn import Module
 
+from leakpro.risk.schemas import UseCaseProfile
+
 ArrayOrScalar = Union[np.ndarray, np.integer, int, list]
 
 class OptimizerConfig(BaseModel):
@@ -137,6 +139,9 @@ class LeakProConfig(BaseModel):
     target: TargetConfig
     shadow_model: Optional[ShadowModelConfig] = Field(None, description="Shadow model config")
     distillation_model: Optional[DistillationModelConfig] = Field(None, description="Distillation model config")
+    # Deployment context for risk assessment, not an audit parameter, hence top level. Declaring it
+    # does not trigger anything: assessment is an explicit assess_risk() call on the audit results.
+    use_case: Optional[UseCaseProfile] = Field(None, description="Use-case profile for risk assessment")
     model_config = ConfigDict(extra="forbid")  # Prevent extra fields
 
 

--- a/leakpro/tests/risk/conftest.py
+++ b/leakpro/tests/risk/conftest.py
@@ -1,0 +1,63 @@
+"""Fixtures for the risk layer tests.
+
+Real ``MIAResult`` objects are used wherever possible so the risk layer cannot drift from the class it
+consumes. Duck-typed stubs are only used for cases a real result cannot express, such as a
+percentage-valued fixed-FPR table.
+"""
+
+import numpy as np
+import pytest
+
+from leakpro.reporting.mia_result import MIAResult
+
+
+def make_result(n_members: int = 400,
+                n_non_members: int = 400,
+                separation: float = 1.0,
+                name: str = "lira",
+                seed: int = 0,
+                inverted: bool = False) -> MIAResult:
+    """Build a real MIAResult with a known member/non-member signal separation.
+
+    Args:
+    ----
+        n_members: Number of members in the audit set.
+        n_non_members: Number of non-members in the audit set.
+        separation: Mean shift of the member signal distribution.
+        name: Result name.
+        seed: RNG seed.
+        inverted: When True, members get the *lower* signal, mimicking an attack that passes a raw
+            loss to a "higher is member" comparison.
+
+    Returns:
+    -------
+        A MIAResult built from full scores.
+
+    """
+    rng = np.random.default_rng(seed)
+    shift = -separation if inverted else separation
+    labels = np.array([1] * n_members + [0] * n_non_members)
+    signals = np.concatenate([rng.normal(shift, 1.0, n_members), rng.normal(0.0, 1.0, n_non_members)])
+    return MIAResult.from_full_scores(true_membership=labels, signal_values=signals, result_name=name)
+
+
+class StubResult:
+    """Minimal duck-typed stand-in for cases a real MIAResult cannot express."""
+
+    def __init__(self, result_name: str, roc_auc: float = 0.8, fixed_fpr_table: dict = None,
+                 fpr: list = None, tpr: list = None, true: list = None, signal_values: list = None) -> None:
+        self.result_name = result_name
+        self.roc_auc = roc_auc
+        self.fixed_fpr_table = fixed_fpr_table
+        self.fpr = np.array(fpr) if fpr is not None else None
+        self.tpr = np.array(tpr) if tpr is not None else None
+        self.true = np.array(true) if true is not None else np.array([1] * 400 + [0] * 400)
+        self.signal_values = np.array(signal_values) if signal_values is not None else None
+        self.id = result_name
+        self.metadata = {}
+
+
+@pytest.fixture
+def result() -> MIAResult:
+    """Return a well-behaved real result: 400 members, 400 non-members, clear separation."""
+    return make_result()

--- a/leakpro/tests/risk/test_assessment.py
+++ b/leakpro/tests/risk/test_assessment.py
@@ -1,0 +1,157 @@
+"""Tests for the combination of measured vulnerability with declared harm parameters."""
+
+import pytest
+
+from leakpro.risk.assessment import assess_risk, loss_magnitude, positive_predictive_value
+from leakpro.risk.schemas import UseCaseProfile
+from leakpro.tests.risk.conftest import make_result
+
+
+class TestPositivePredictiveValue:
+    """PPV per Jayaraman et al. (PoPETs 2021) Theorem 4.2."""
+
+    @pytest.mark.parametrize(("prior", "expected"), [
+        # PPV = TPR / (TPR + gamma*alpha), gamma = (1-p)/p, with TPR = 0.10 and alpha = 0.01.
+        (0.5, 0.10 / (0.10 + 1.0 * 0.01)),          # gamma = 1     -> 0.9091
+        (0.01, 0.10 / (0.10 + 99.0 * 0.01)),        # gamma = 99    -> 0.0917
+        (0.001, 0.10 / (0.10 + 999.0 * 0.01)),      # gamma = 999   -> 0.0099
+    ])
+    def test_should_match_hand_computed_precision_at_each_prior(self, prior: float, expected: float) -> None:
+        """Precision collapses as the prior skews, which is the entire point of reporting it."""
+        assert positive_predictive_value(0.10, 0.01, prior) == pytest.approx(expected)
+
+    def test_should_equal_the_equivalent_prior_weighted_form(self) -> None:
+        """The gamma form and the prior-weighted form are algebraically identical."""
+        tpr, alpha, prior = 0.25, 0.001, 0.02
+        weighted = prior * tpr / (prior * tpr + (1 - prior) * alpha)
+        assert positive_predictive_value(tpr, alpha, prior) == pytest.approx(weighted)
+
+    def test_should_be_zero_when_the_attack_flags_nothing(self) -> None:
+        """A zero success rate yields zero precision rather than a division error."""
+        assert positive_predictive_value(0.0, 0.01, 0.5) == 0.0
+
+
+class TestLossMagnitude:
+    """Sion et al. LM = DTS x NR x DST x NDS."""
+
+    def test_should_multiply_all_four_declared_factors(self) -> None:
+        """The product is exactly the published decomposition, with no extra scaling."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, records_per_subject=2.0,
+                                 data_type_sensitivity=3.0, subject_type_weight=4.0)
+        assert loss_magnitude(profile, 1000) == pytest.approx(3.0 * 2.0 * 4.0 * 1000)
+
+    def test_should_reduce_to_the_subject_count_with_neutral_factors(self) -> None:
+        """Neutral factors leave the interpretable special case: one unit of harm per subject."""
+        assert loss_magnitude(UseCaseProfile(tolerated_fpr=0.01), 500) == pytest.approx(500.0)
+
+    def test_should_be_unavailable_without_a_subject_count(self) -> None:
+        """No population size means no loss magnitude, rather than a guessed one."""
+        assert loss_magnitude(UseCaseProfile(tolerated_fpr=0.01), None) is None
+
+
+class TestAssessRisk:
+    """End-to-end combination on real results."""
+
+    def test_should_derive_risk_as_loss_magnitude_times_success_rate(self, result) -> None:
+        """Risk is Sion's LM x LEF, with LEF the measured success rate."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=10_000, data_type_sensitivity=3.0)
+        assessment = assess_risk([result], profile)
+        expected = 3.0 * 1.0 * 1.0 * 10_000 * assessment.measured.success_rate
+        assert assessment.combined.risk == pytest.approx(expected)
+        assert assessment.combined.loss_event_frequency == pytest.approx(assessment.measured.success_rate)
+
+    def test_should_report_expected_exposed_subjects_unweighted(self, result) -> None:
+        """The interpretable count ignores the sensitivity weights on purpose."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=10_000, data_type_sensitivity=3.0)
+        assessment = assess_risk([result], profile)
+        assert assessment.combined.expected_exposed_subjects == pytest.approx(
+            assessment.measured.success_rate * 10_000)
+
+    def test_should_report_both_declared_and_balanced_precision(self, result) -> None:
+        """The balanced value is the audit protocol's own assumption and travels alongside."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, attacker_prior=0.001))
+        assert assessment.combined.ppv < assessment.combined.ppv_balanced
+        assert assessment.combined.gamma == pytest.approx(999.0)
+
+    def test_should_omit_cost_entirely_when_none_was_declared(self, result) -> None:
+        """No declared cost means no monetary figure, not a zero that reads as "no impact"."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, n_subjects=100))
+        assert assessment.combined.expected_cost is None
+        assert any("no monetary figure" in a for a in assessment.assumptions)
+
+    def test_should_compute_cost_when_one_was_declared(self, result) -> None:
+        """Cost scales the expected exposure by the declared per-subject cost."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=100, cost_per_exposed_subject=250.0)
+        assessment = assess_risk([result], profile)
+        assert assessment.combined.expected_cost == pytest.approx(
+            assessment.combined.expected_exposed_subjects * 250.0)
+
+    def test_should_take_the_subject_count_from_num_train_when_not_declared(self, result) -> None:
+        """The target's training-set size is the natural default, and its use is recorded."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01), num_train=1234)
+        assert assessment.declared.n_subjects == 1234
+        assert assessment.declared.n_subjects_source == "target num_train"
+
+    def test_should_report_audit_set_figures_only_without_a_population_size(self, result) -> None:
+        """Absent num_train and a declared count, population figures are withheld, not invented."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01))
+        assert assessment.declared.n_subjects_source == "unavailable"
+        assert assessment.combined.expected_exposed_subjects is None
+        assert assessment.combined.risk is None
+        assert assessment.combined.ppv is not None, "measured-side figures must survive"
+
+    def test_should_prefer_a_declared_subject_count_over_num_train(self, result) -> None:
+        """An explicit declaration wins: subjects and training records are not the same thing."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=50)
+        assessment = assess_risk([result], profile, num_train=99_999)
+        assert (assessment.declared.n_subjects, assessment.declared.n_subjects_source) == (50, "declared")
+
+    def test_should_extrapolate_only_when_requested_and_flag_the_assumption(self, result) -> None:
+        """Extrapolation is opt-in and always carries its representativeness caveat."""
+        off = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01), num_train=4000)
+        assert off.combined.extrapolated_exposed_records is None
+        assert not any("Extrapolation" in a for a in off.assumptions)
+
+        on = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, extrapolate_to_population=True),
+                         num_train=4000)
+        expected = on.measured.n_exposed_audit * (4000 / on.measured.n_members_audit)
+        assert on.combined.extrapolated_exposed_records == pytest.approx(expected)
+        assert any("privacy onion" in a for a in on.assumptions)
+
+    def test_should_warn_when_the_prior_is_the_balanced_default(self, result) -> None:
+        """Quoting balanced-prior precision as real-world risk is the mistake to flag."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01))
+        assert any("balanced-audit assumption" in w for w in assessment.warnings)
+
+    def test_should_record_the_single_attempt_and_independence_assumptions(self, result) -> None:
+        """Both simplifications inherited from the published model must be stated, not hidden."""
+        assumptions = " ".join(assess_risk([result], UseCaseProfile(tolerated_fpr=0.01)).assumptions)
+        assert "single attack attempt" in assumptions
+        assert "independent" in assumptions
+
+    def test_should_withhold_derived_figures_when_the_operating_point_is_unresolvable(self) -> None:
+        """A non-strict assessment degrades explicitly instead of reporting zero risk."""
+        small = make_result(n_members=200, n_non_members=200)
+        assessment = assess_risk([small], UseCaseProfile(tolerated_fpr=0.001, n_subjects=100),
+                                 strict=False)
+        assert assessment.measured.resolvable is False
+        assert (assessment.combined.ppv, assessment.combined.risk) == (None, None)
+        assert assessment.combined.vulnerability_band is None
+        assert any("not measurable" in w for w in assessment.warnings)
+
+    def test_should_accept_a_single_result_as_well_as_a_list(self, result) -> None:
+        """Callers should not have to wrap one result in a list."""
+        assert assess_risk(result, UseCaseProfile(tolerated_fpr=0.01)).measured.attack_name == "lira"
+
+    def test_should_be_deterministic_for_identical_inputs(self, result) -> None:
+        """The scored output carries no timestamps or randomness, so it must be byte-identical."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, n_subjects=1000, notes="run twice")
+        first = assess_risk([result], profile, num_train=1000)
+        second = assess_risk([result], profile, num_train=1000)
+        assert first.model_dump_json() == second.model_dump_json()
+
+    def test_should_carry_policy_and_version_provenance(self, result) -> None:
+        """Any band that is emitted must be traceable to a policy version."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01))
+        assert assessment.policy_version
+        assert assessment.leakpro_version

--- a/leakpro/tests/risk/test_e2e_risk.py
+++ b/leakpro/tests/risk/test_e2e_risk.py
@@ -1,0 +1,124 @@
+"""End-to-end wiring test: real audit -> assess_risk -> JSON and PDF section.
+
+Reuses the tiny-target machinery from the MIA end-to-end suite so this exercises the real attack
+pipeline rather than synthetic results. The audit population is small (72 records, ~32 members), so
+the operating point here is 10% FPR: anything stricter is genuinely unresolvable at that size, which
+is exactly what the resolution guard enforces.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from leakpro import LeakPro
+from leakpro.reporting.report_handler import ReportHandler
+from leakpro.risk import RiskAssessment, UseCaseProfile, assess_risk
+from leakpro.tests.mia_attacks.attacks.test_all_attacks_end_to_end import (
+    TinyImageInputHandler,
+    _clear_global_attack_cache,
+    _create_image_e2e_config,
+    _set_seed,
+)
+
+E2E_ALPHA = 0.1
+
+
+@pytest.fixture
+def audited(monkeypatch, tmp_path):
+    """Run a real LiRA audit on a tiny target and return (leakpro, results)."""
+    _set_seed()
+    with tempfile.TemporaryDirectory(prefix="risk_e2e_") as temp_dir:
+        temp_root = Path(temp_dir)
+        monkeypatch.chdir(temp_root)
+        _clear_global_attack_cache()
+        run_dir = temp_root / "lira"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        config_path = _create_image_e2e_config(run_dir, "lira")
+        leakpro = LeakPro(TinyImageInputHandler, str(config_path))
+        results = leakpro.run_audit(create_pdf=False, use_optuna=False)
+        yield leakpro, results, config_path
+
+
+class TestEndToEnd:
+    """The whole path, on results produced by a real audit."""
+
+    def test_should_assess_risk_on_real_audit_results(self, audited) -> None:
+        """assess_risk must consume what run_audit returns, with no adaptation by the caller."""
+        leakpro, results, _ = audited
+        profile = UseCaseProfile(tolerated_fpr=E2E_ALPHA, attacker_prior=0.01, data_type_sensitivity=3.0)
+        assessment = assess_risk(results, profile,
+                                 num_train=leakpro.handler.target_model_metadata.num_train)
+
+        assert assessment.measured.resolvable is True
+        assert 0.0 <= assessment.measured.success_rate <= 1.0
+        assert assessment.measured.n_members_audit > 0
+        assert assessment.combined.ppv is not None
+        assert assessment.combined.risk is not None
+        assert assessment.declared.n_subjects_source == "target num_train"
+
+    def test_should_write_a_self_contained_json_file(self, audited) -> None:
+        """The saved file is the deliverable: it must carry every block plus provenance."""
+        leakpro, results, _ = audited
+        assessment = assess_risk(results, UseCaseProfile(tolerated_fpr=E2E_ALPHA),
+                                 num_train=leakpro.handler.target_model_metadata.num_train)
+        path = Path(leakpro.report_dir) / "risk_assessment.json"
+        assessment.save(str(path))
+
+        assert path.exists() and path.stat().st_size > 0
+        payload = json.loads(path.read_text())
+        assert set(payload) >= {"measured", "declared", "combined", "assumptions", "warnings",
+                                "policy_version", "leakpro_version"}
+        assert RiskAssessment.load(str(path)).combined.gamma == assessment.combined.gamma
+
+    def test_should_add_a_risk_section_to_the_pdf_report(self, audited) -> None:
+        """A ReportHandler given an assessment emits the Risk section ahead of the attack sections."""
+        leakpro, results, _ = audited
+        assessment = assess_risk(results, UseCaseProfile(tolerated_fpr=E2E_ALPHA, n_subjects=100))
+        handler = ReportHandler(results=results, report_dir=leakpro.report_dir,
+                               risk_assessment=assessment)
+        handler.create_results()
+        handler._init_pdf()
+        from leakpro.risk.render import to_latex
+        handler.latex_content += to_latex(handler.risk_assessment)
+        assert "\\section{Risk assessment}" in handler.latex_content
+
+    def test_should_leave_run_audit_untouched_without_a_use_case_block(self, audited) -> None:
+        """A config with no use_case block must behave exactly as before."""
+        leakpro, results, _ = audited
+        assert leakpro.use_case_profile is None
+        assert isinstance(results, list) and results
+
+    def test_should_expose_a_profile_declared_in_the_audit_config(self, audited) -> None:
+        """A use_case block in audit.yaml is parsed and reachable, but triggers nothing by itself."""
+        _leakpro, _results, config_path = audited
+        config = yaml.safe_load(Path(config_path).read_text())
+        config["use_case"] = {
+            "tolerated_fpr": E2E_ALPHA,
+            "attacker_prior": 0.01,
+            "data_type_sensitivity": 4.0,
+            "notes": "declared in audit.yaml",
+        }
+        with open(config_path, "w") as f:
+            yaml.safe_dump(config, f, sort_keys=False)
+
+        reloaded = LeakPro(TinyImageInputHandler, str(config_path))
+        assert reloaded.use_case_profile is not None
+        assert reloaded.use_case_profile.tolerated_fpr == E2E_ALPHA
+        assert reloaded.use_case_profile.data_type_sensitivity == 4.0
+        assert reloaded.use_case_profile.notes == "declared in audit.yaml"
+
+    def test_should_reject_an_invalid_use_case_block_in_the_config(self, audited) -> None:
+        """A typo in the config must fail validation rather than be ignored."""
+        _leakpro, _results, config_path = audited
+        config = yaml.safe_load(Path(config_path).read_text())
+        config["use_case"] = {"tolerated_fpr": E2E_ALPHA, "sensitivity": "high"}
+        with open(config_path, "w") as f:
+            yaml.safe_dump(config, f, sort_keys=False)
+
+        with pytest.raises(Exception, match="use_case|sensitivity"):
+            LeakPro(TinyImageInputHandler, str(config_path))

--- a/leakpro/tests/risk/test_policy.py
+++ b/leakpro/tests/risk/test_policy.py
@@ -1,0 +1,95 @@
+"""Tests for the advisory policy data and the renderers."""
+
+import pytest
+
+from leakpro.risk.assessment import assess_risk
+from leakpro.risk.policy import (
+    POLICY_VERSION,
+    SUGGESTED_SENSITIVITY_SCALE,
+    VULNERABILITY_BANDS,
+    VULNERABILITY_BANDS_SOURCE,
+    resolve_vulnerability_band,
+)
+from leakpro.risk.render import to_latex, to_markdown
+from leakpro.risk.schemas import UseCaseProfile
+
+
+class TestVulnerabilityBands:
+    """Bands label the measured lift only, and are explicitly advisory."""
+
+    @pytest.mark.parametrize(("lift", "label"), [
+        (0.5, "NONE"), (1.0, "LOW"), (2.9, "LOW"), (3.0, "MODERATE"),
+        (9.9, "MODERATE"), (10.0, "HIGH"), (99.9, "HIGH"), (100.0, "SEVERE"), (5000.0, "SEVERE"),
+    ])
+    def test_should_map_lift_to_the_documented_band(self, lift: float, label: str) -> None:
+        """Boundaries are inclusive at the lower bound, as documented."""
+        assert resolve_vulnerability_band(lift) == label
+
+    def test_should_accept_a_caller_supplied_band_table(self) -> None:
+        """Users must be able to substitute their own policy, since ours is not calibrated."""
+        custom = [(50.0, "UNACCEPTABLE"), (0.0, "ACCEPTABLE")]
+        assert resolve_vulnerability_band(60.0, custom) == "UNACCEPTABLE"
+        assert resolve_vulnerability_band(10.0, custom) == "ACCEPTABLE"
+
+    def test_should_declare_the_bands_as_heuristic(self) -> None:
+        """The provenance string must not claim a source the bands do not have."""
+        assert "heuristic" in VULNERABILITY_BANDS_SOURCE
+
+    def test_should_keep_bands_sorted_from_highest_bound_down(self) -> None:
+        """Resolution walks the table in order, so ordering is a correctness property."""
+        bounds = [bound for bound, _ in VULNERABILITY_BANDS]
+        assert bounds == sorted(bounds, reverse=True)
+
+    def test_should_expose_a_policy_version(self) -> None:
+        """Any emitted band must be traceable to a version of this table."""
+        assert POLICY_VERSION
+
+
+class TestSuggestedSensitivityScale:
+    """The suggested scale is sourced, unlike the bands."""
+
+    def test_should_offer_the_four_cnil_severity_levels(self) -> None:
+        """CNIL PIA-3 defines negligible, limited, significant and maximum."""
+        assert set(SUGGESTED_SENSITIVITY_SCALE) == {"negligible", "limited", "significant", "maximum"}
+
+    def test_should_increase_monotonically_with_severity(self) -> None:
+        """A scale that is not ordered would silently invert the loss magnitude."""
+        values = [SUGGESTED_SENSITIVITY_SCALE[k] for k in ("negligible", "limited", "significant", "maximum")]
+        assert values == sorted(values)
+
+
+class TestRendering:
+    """Both renderers must show the inputs next to any derived figure."""
+
+    def test_markdown_should_show_measured_declared_and_combined_sections(self, result) -> None:
+        """A reader must be able to see which half of the assessment each number came from."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, n_subjects=1000))
+        markdown = to_markdown(assessment)
+        assert "## Measured" in markdown
+        assert "## Declared" in markdown
+        assert "## Combined" in markdown
+        assert "## Assumptions" in markdown
+
+    def test_markdown_should_print_band_provenance_next_to_the_band(self, result) -> None:
+        """A bare band label with no policy is the failure mode this layer replaces."""
+        markdown = to_markdown(assess_risk([result], UseCaseProfile(tolerated_fpr=0.01)))
+        assert "heuristic" in markdown
+
+    def test_markdown_should_label_absent_figures_rather_than_printing_zero(self, result) -> None:
+        """A withheld figure must read as withheld, never as zero risk."""
+        markdown = to_markdown(assess_risk([result], UseCaseProfile(tolerated_fpr=0.01)))
+        assert "not reported" in markdown
+
+    def test_latex_should_produce_a_risk_section_with_assumptions(self, result) -> None:
+        """The PDF section carries the same assumption list as the JSON."""
+        latex = to_latex(assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, n_subjects=10)))
+        assert "\\section{Risk assessment}" in latex
+        assert "\\subsection*{Assumptions}" in latex
+        assert "\\begin{tabularx}" in latex
+
+    def test_latex_should_escape_special_characters_from_free_text(self, result) -> None:
+        """User notes containing LaTeX metacharacters must not break compilation."""
+        profile = UseCaseProfile(tolerated_fpr=0.01, notes="100% of records & 50_000 subjects")
+        latex = to_latex(assess_risk([result], profile))
+        assert "100\\%" in latex or "100\\% of records" in latex
+        assert "50\\_000" in latex

--- a/leakpro/tests/risk/test_schemas.py
+++ b/leakpro/tests/risk/test_schemas.py
@@ -1,0 +1,76 @@
+"""Tests for the risk schemas, including the deliberate absence of defaults."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from leakpro.risk.assessment import assess_risk
+from leakpro.risk.schemas import RiskAssessment, UseCaseProfile
+
+
+class TestUseCaseProfile:
+    """Validation of the declared harm parameters."""
+
+    def test_should_require_the_operating_point(self) -> None:
+        """alpha has no default: the choice changes the headline number and belongs to the user."""
+        with pytest.raises(ValidationError, match="tolerated_fpr"):
+            UseCaseProfile()
+
+    def test_should_reject_unknown_fields(self) -> None:
+        """A typo in a profile must fail rather than be silently ignored."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(tolerated_fpr=0.01, sensitivity="high")
+
+    @pytest.mark.parametrize("alpha", [0.0, 1.0, -0.1, 1.5])
+    def test_should_reject_operating_points_outside_the_open_unit_interval(self, alpha: float) -> None:
+        """An FPR of 0 or 1 is not an operating point an attacker can occupy."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(tolerated_fpr=alpha)
+
+    @pytest.mark.parametrize("prior", [0.0, 1.0, -0.5])
+    def test_should_reject_priors_outside_the_open_unit_interval(self, prior: float) -> None:
+        """A prior of 0 or 1 makes precision undefined or trivial."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(tolerated_fpr=0.01, attacker_prior=prior)
+
+    @pytest.mark.parametrize("field", ["records_per_subject", "data_type_sensitivity", "subject_type_weight"])
+    def test_should_reject_non_positive_loss_magnitude_factors(self, field: str) -> None:
+        """A zero factor would silently zero out the whole loss magnitude product."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(**{"tolerated_fpr": 0.01, field: 0.0})
+
+    def test_should_default_to_neutral_factors_and_a_balanced_prior(self) -> None:
+        """Defaults are neutral, so an unconfigured profile weights nothing invisibly."""
+        profile = UseCaseProfile(tolerated_fpr=0.01)
+        assert (profile.data_type_sensitivity, profile.subject_type_weight, profile.records_per_subject) == (1.0, 1.0, 1.0)
+        assert profile.attacker_prior == 0.5
+        assert profile.cost_per_exposed_subject is None
+        assert profile.extrapolate_to_population is False
+
+    def test_should_reject_a_negative_cost(self) -> None:
+        """A negative cost per exposed subject is not a meaningful input."""
+        with pytest.raises(ValidationError):
+            UseCaseProfile(tolerated_fpr=0.01, cost_per_exposed_subject=-1.0)
+
+
+class TestRiskAssessmentSerialisation:
+    """Round-tripping an assessment through disk."""
+
+    def test_should_round_trip_through_json(self, result, tmp_path) -> None:
+        """A saved assessment must reload into an equal object, for later re-reporting."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01, n_subjects=100))
+        path = tmp_path / "risk_assessment.json"
+        assessment.save(str(path))
+        assert RiskAssessment.load(str(path)).model_dump_json() == assessment.model_dump_json()
+
+    def test_should_write_all_three_blocks_plus_provenance(self, result, tmp_path) -> None:
+        """The file must be self-contained: measured, declared, combined, assumptions, versions."""
+        assessment = assess_risk([result], UseCaseProfile(tolerated_fpr=0.01))
+        path = tmp_path / "risk_assessment.json"
+        assessment.save(str(path))
+        with open(path) as f:
+            payload = json.load(f)
+        assert set(payload) >= {"measured", "declared", "combined", "assumptions", "warnings",
+                                "policy_version", "leakpro_version"}
+        assert payload["assumptions"], "an assessment without stated assumptions is not auditable"

--- a/leakpro/tests/risk/test_vulnerability.py
+++ b/leakpro/tests/risk/test_vulnerability.py
@@ -1,0 +1,171 @@
+"""Tests for the measured block and its four guards."""
+
+import numpy as np
+import pytest
+
+from leakpro.risk.vulnerability import (
+    InvertedResultError,
+    NoUsableResultError,
+    UnresolvableOperatingPointError,
+    _tpr_at_fpr,
+    _tpr_from_fixed_table,
+    measure_mia,
+    result_from_mapping,
+    strongest_for_risk,
+)
+from leakpro.tests.risk.conftest import StubResult, make_result
+
+
+class TestMeasurement:
+    """Extraction of measured quantities from a result."""
+
+    def test_should_read_tpr_from_the_fixed_fpr_table_when_alpha_is_tabulated(self, result) -> None:
+        """The measured TPR should equal the result's own tabulated value at that operating point."""
+        measured = measure_mia(result, alpha=0.01)
+        assert measured.success_rate == pytest.approx(float(result.fixed_fpr_table["TPR@1%FPR"]))
+
+    def test_should_derive_advantage_and_lift_from_tpr_and_alpha(self, result) -> None:
+        """Advantage is TPR minus alpha and lift is their ratio."""
+        measured = measure_mia(result, alpha=0.01)
+        assert measured.advantage == pytest.approx(measured.success_rate - 0.01)
+        assert measured.lift == pytest.approx(measured.success_rate / 0.01)
+
+    def test_should_count_members_and_non_members_from_the_true_attribute(self, result) -> None:
+        """The live MIAResult stores membership in `true`, not `true_labels`."""
+        measured = measure_mia(result, alpha=0.01)
+        assert (measured.n_members_audit, measured.n_non_members_audit) == (400, 400)
+        assert measured.n_at_risk == 400
+
+    def test_should_count_exposed_members_at_the_operating_point(self, result) -> None:
+        """The exposed count is members scoring above the alpha quantile of the non-member signal."""
+        measured = measure_mia(result, alpha=0.01)
+        threshold = np.quantile(result.signal_values[result.true == 0], 0.99)
+        expected = int(np.count_nonzero((result.true == 1) & (result.signal_values > threshold)))
+        assert measured.n_exposed_audit == expected
+
+    def test_should_report_no_exposed_count_when_the_result_has_no_signal_values(self) -> None:
+        """A result without per-record scores yields rates but no absolute count."""
+        stub = StubResult("no-signals", fpr=[0.0, 0.01, 1.0], tpr=[0.0, 0.2, 1.0])
+        assert measure_mia(stub, alpha=0.01).n_exposed_audit is None
+
+
+class TestResolutionGuard:
+    """Guard 1: an FPR the audit set cannot express is not a measurement."""
+
+    def test_should_raise_when_alpha_is_finer_than_the_audit_set_can_resolve(self) -> None:
+        """200 non-members cannot express an FPR of 0.001, so asking for it must fail loudly."""
+        small = make_result(n_members=200, n_non_members=200)
+        with pytest.raises(UnresolvableOperatingPointError, match="not measurable"):
+            measure_mia(small, alpha=0.001)
+
+    def test_should_flag_instead_of_raising_when_not_strict(self) -> None:
+        """Non-strict callers get an explicit resolvable=False rather than a silent zero."""
+        small = make_result(n_members=200, n_non_members=200)
+        measured = measure_mia(small, alpha=0.001, strict=False)
+        assert measured.resolvable is False
+        assert measured.min_resolvable_fpr == pytest.approx(1 / 200)
+
+    def test_should_accept_alpha_exactly_at_the_resolution_limit(self) -> None:
+        """The boundary itself is measurable: 200 non-members can express an FPR of 0.005."""
+        small = make_result(n_members=200, n_non_members=200)
+        assert measure_mia(small, alpha=0.005).resolvable is True
+
+
+class TestOrientationGuard:
+    """Guard 2: an inverted ROC turns a real leak into a low-risk reading."""
+
+    def test_should_reject_an_inverted_result_and_name_the_attack(self) -> None:
+        """A result with AUC below 0.5 must be refused, with the attack named in the message."""
+        inverted = make_result(name="population", inverted=True)
+        assert inverted.roc_auc < 0.5
+        with pytest.raises(InvertedResultError, match="population"):
+            measure_mia(inverted, alpha=0.01)
+
+    def test_should_skip_inverted_results_when_selecting_the_strongest(self) -> None:
+        """Selection excludes inverted results instead of treating them as weak evidence."""
+        good = make_result(name="lira")
+        inverted = make_result(name="population", inverted=True)
+        best, skipped = strongest_for_risk([inverted, good], alpha=0.01)
+        assert best is good
+        assert any("population" in reason and "inverted" in reason for reason in skipped)
+
+    def test_should_raise_when_every_candidate_is_unusable(self) -> None:
+        """With nothing usable there is no fallback: refuse rather than report on an inverted result."""
+        with pytest.raises(NoUsableResultError):
+            strongest_for_risk([make_result(name="population", inverted=True)], alpha=0.01)
+
+
+class TestSelectionGuard:
+    """Guard 3: risk cares about the operating point, not average-case AUC."""
+
+    def test_should_prefer_the_attack_with_higher_tpr_at_alpha_over_higher_auc(self) -> None:
+        """A lower-AUC attack that wins at 1% FPR is the relevant one for risk."""
+        # Broad but shallow separation: high AUC, unremarkable at a strict threshold.
+        broad = StubResult("broad-auc", roc_auc=0.90, fpr=[0.0, 0.01, 0.5, 1.0], tpr=[0.0, 0.05, 0.85, 1.0])
+        # Narrow but extreme: lower AUC, far better at 1% FPR.
+        sharp = StubResult("sharp-tail", roc_auc=0.70, fpr=[0.0, 0.01, 0.5, 1.0], tpr=[0.0, 0.40, 0.60, 1.0])
+        best, _ = strongest_for_risk([broad, sharp], alpha=0.01)
+        assert best is sharp, "selection must not fall back to maximising ROC AUC"
+
+
+class TestUnitsGuard:
+    """Guard 4: TPR is a fraction everywhere in this layer."""
+
+    def test_should_read_a_fractional_fixed_fpr_table_unchanged(self) -> None:
+        """The live MIAResult tabulates fractions, which pass through as-is."""
+        assert _tpr_from_fixed_table({"TPR@1%FPR": 0.103}, 0.01) == pytest.approx(0.103)
+
+    def test_should_reject_a_percentage_valued_fixed_fpr_table(self) -> None:
+        """A percentage-valued table must fail rather than inflate the risk figure a hundredfold."""
+        with pytest.raises(ValueError, match="not a fraction"):
+            _tpr_from_fixed_table({"TPR@1%FPR": 10.3}, 0.01)
+
+    def test_should_accept_both_key_spellings_for_one_percent(self) -> None:
+        """Padded legacy keys and stripped live keys mean the same operating point."""
+        assert _tpr_from_fixed_table({"TPR@1.0%FPR": 0.2}, 0.01) == pytest.approx(0.2)
+
+    def test_should_raise_when_the_operating_point_is_not_tabulated(self) -> None:
+        """Asking for an untabulated alpha on a result without ROC arrays must fail explicitly."""
+        with pytest.raises(ValueError, match="tabulated operating points"):
+            _tpr_from_fixed_table({"TPR@1%FPR": 0.2}, 0.002)
+
+
+class TestSerialisedResults:
+    """The adapter used by the web app backend, which holds JSON rather than live objects."""
+
+    def test_should_measure_from_a_serialised_result(self, result) -> None:
+        """A round trip through the web app's serialisation must give the same measurement."""
+        payload = {
+            "attack_name": result.result_name,
+            "roc_auc": float(result.roc_auc),
+            "tpr_at_fpr": {k: float(v) for k, v in result.fixed_fpr_table.items()},
+            "fpr": result.fpr.tolist(),
+            "tpr": result.tpr.tolist(),
+            "signal_values": result.signal_values.tolist(),
+            "true_labels": result.true.tolist(),
+        }
+        direct = measure_mia(result, alpha=0.01)
+        adapted = measure_mia(result_from_mapping(payload), alpha=0.01)
+        assert adapted.success_rate == pytest.approx(direct.success_rate)
+        assert adapted.n_exposed_audit == direct.n_exposed_audit
+        assert adapted.n_members_audit == direct.n_members_audit
+
+    def test_should_reject_an_inverted_serialised_result(self) -> None:
+        """The guards apply to the web app path too, not just to live objects."""
+        payload = {"attack_name": "population", "roc_auc": 0.214, "true_labels": [1] * 10 + [0] * 10}
+        with pytest.raises(InvertedResultError, match="population"):
+            measure_mia(result_from_mapping(payload), alpha=0.01)
+
+
+class TestRocLookup:
+    """The local TPR-at-alpha helper."""
+
+    def test_should_return_the_max_tpr_among_points_within_alpha(self) -> None:
+        """Semantics match the library helper: maximum TPR over points with FPR <= alpha."""
+        fpr = np.array([0.0, 0.005, 0.01, 0.2])
+        tpr = np.array([0.0, 0.30, 0.25, 0.9])
+        assert _tpr_at_fpr(fpr, tpr, 0.01) == pytest.approx(0.30)
+
+    def test_should_return_zero_when_no_point_is_within_alpha(self) -> None:
+        """Zero here means unmeasurable, which is why the resolution guard exists above."""
+        assert _tpr_at_fpr(np.array([0.5, 1.0]), np.array([0.8, 1.0]), 0.001) == 0.0

--- a/leakpro/tests/test_optimization/test_adapters.py
+++ b/leakpro/tests/test_optimization/test_adapters.py
@@ -13,9 +13,9 @@ from leakpro.optimization.adapters import (
     carve_splits,
     detect_binary,
     find_model_class,
-    load_module,
     recipe_from_module,
 )
+from leakpro.input_handler.user_imports import import_module_from_file
 from leakpro.optimization.training import REQUIRED_SPLIT_KEYS
 
 MULTICLASS = """
@@ -66,25 +66,28 @@ def _xy(n=200, dim=6, classes=3, seed=0):
 
 class TestModelDiscovery:
     def test_single_class_is_found_without_naming_it(self, arch):
-        assert find_model_class(load_module(arch(MULTICLASS))).__name__ == "Net"
+        assert find_model_class(import_module_from_file(str(arch(MULTICLASS)))).__name__ == "Net"
 
     def test_ambiguous_module_requires_a_name(self, arch):
-        module = load_module(arch(TWO_MODELS))
+        module = import_module_from_file(str(arch(TWO_MODELS)))
         with pytest.raises(ValueError, match="Cannot choose a model class"):
             find_model_class(module)
         assert find_model_class(module, "Other").__name__ == "Other"
 
     def test_unknown_class_name_rejected(self, arch):
-        with pytest.raises(KeyError):
-            find_model_class(load_module(arch(MULTICLASS)), "Missing")
+        # user_imports.get_class_from_module raises ValueError, not KeyError.
+        with pytest.raises(ValueError, match="not found in module"):
+            find_model_class(import_module_from_file(str(arch(MULTICLASS))), "Missing")
 
     def test_missing_file_rejected(self, tmp_path):
         with pytest.raises(FileNotFoundError):
-            load_module(tmp_path / "nope.py")
+            import_module_from_file(str(tmp_path / "nope.py"))
 
-    def test_repeated_loads_do_not_collide(self, arch):
+    def test_repeated_loads_reuse_the_cached_module(self, arch):
+        # user_imports.import_module_from_file caches by module name and checks
+        # the path, so the same arch loaded twice is one import, not two.
         path = arch(MULTICLASS)
-        assert load_module(path).__name__ != load_module(path).__name__
+        assert import_module_from_file(str(path)) is import_module_from_file(str(path))
 
 
 class TestDetectBinary:
@@ -132,8 +135,12 @@ class TestRecipeFromModule:
 
     def test_unknown_optimizer_rejected(self, arch):
         x, y = _xy()
+        # Every torch.optim optimizer is valid now that the lookup comes from
+        # user_imports.get_optimizer_mapping, so "rmsprop" is accepted; only a
+        # name torch does not have is rejected.
+        assert recipe_from_module(arch(MULTICLASS), x, y.long(), epochs=1, optimizer_name="rmsprop")
         with pytest.raises(ValueError, match="Unknown optimizer"):
-            recipe_from_module(arch(MULTICLASS), x, y.long(), epochs=1, optimizer_name="rmsprop")
+            recipe_from_module(arch(MULTICLASS), x, y.long(), epochs=1, optimizer_name="not_an_optimizer")
 
 
 class TestCarveSplits:

--- a/leakpro/tests/test_optimization/test_adapters.py
+++ b/leakpro/tests/test_optimization/test_adapters.py
@@ -1,0 +1,210 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for building a recipe and splits from an architecture file (CPU, tiny models)."""
+
+import numpy as np
+import pytest
+import torch
+
+from leakpro.optimization import Campaign, Knob, KnobSpace, build_campaign_fns
+from leakpro.optimization.adapters import (
+    carve_splits,
+    detect_binary,
+    find_model_class,
+    load_module,
+    recipe_from_module,
+)
+from leakpro.optimization.training import REQUIRED_SPLIT_KEYS
+
+MULTICLASS = """
+import torch.nn as nn
+class Net(nn.Module):
+    def __init__(self, num_classes=3):
+        super().__init__()
+        self.fc = nn.Linear(6, num_classes)
+    def forward(self, x):
+        return self.fc(x)
+"""
+
+BINARY = """
+import torch.nn as nn
+class Net(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(6, 1)
+    def forward(self, x):
+        return self.fc(x)
+"""
+
+TWO_MODELS = MULTICLASS + """
+class Other(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(6, 2)
+    def forward(self, x):
+        return self.fc(x)
+"""
+
+
+@pytest.fixture()
+def arch(tmp_path):
+    def write(source: str):
+        path = tmp_path / "arch.py"
+        path.write_text(source)
+        return path
+    return write
+
+
+def _xy(n=200, dim=6, classes=3, seed=0):
+    rng = np.random.default_rng(seed)
+    x = torch.tensor(rng.normal(size=(n, dim)), dtype=torch.float32)
+    y = torch.tensor(rng.integers(0, classes, size=n))
+    return x, y
+
+
+class TestModelDiscovery:
+    def test_single_class_is_found_without_naming_it(self, arch):
+        assert find_model_class(load_module(arch(MULTICLASS))).__name__ == "Net"
+
+    def test_ambiguous_module_requires_a_name(self, arch):
+        module = load_module(arch(TWO_MODELS))
+        with pytest.raises(ValueError, match="Cannot choose a model class"):
+            find_model_class(module)
+        assert find_model_class(module, "Other").__name__ == "Other"
+
+    def test_unknown_class_name_rejected(self, arch):
+        with pytest.raises(KeyError):
+            find_model_class(load_module(arch(MULTICLASS)), "Missing")
+
+    def test_missing_file_rejected(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_module(tmp_path / "nope.py")
+
+    def test_repeated_loads_do_not_collide(self, arch):
+        path = arch(MULTICLASS)
+        assert load_module(path).__name__ != load_module(path).__name__
+
+
+class TestDetectBinary:
+    def test_single_logit_head(self, arch):
+        x, _ = _xy()
+        assert detect_binary(arch(BINARY), x) is True
+
+    def test_multiclass_head(self, arch):
+        x, _ = _xy()
+        assert detect_binary(arch(MULTICLASS), x) is False
+
+
+class TestRecipeFromModule:
+    def test_multiclass_recipe_shape(self, arch):
+        x, y = _xy()
+        recipe = recipe_from_module(arch(MULTICLASS), x, y.long(), epochs=1)
+        assert recipe.output_kind == "logits"
+        assert isinstance(recipe.criterion, torch.nn.CrossEntropyLoss)
+
+    def test_binary_recipe_shape(self, arch):
+        x, y = _xy(classes=2)
+        recipe = recipe_from_module(arch(BINARY), x, y.float(), epochs=1, binary=True)
+        assert recipe.output_kind == "binary_logits"
+        assert isinstance(recipe.criterion, torch.nn.BCEWithLogitsLoss)
+
+    def test_each_call_returns_an_untrained_model(self, arch):
+        # A campaign that resumed a trained model would silently measure the
+        # wrong thing, so make_model must never hand back the same object.
+        x, y = _xy()
+        recipe = recipe_from_module(arch(MULTICLASS), x, y.long(), epochs=1)
+        assert recipe.make_model({}) is not recipe.make_model({})
+
+    def test_loader_honours_sampled_batch_size(self, arch):
+        x, y = _xy()
+        recipe = recipe_from_module(arch(MULTICLASS), x, y.long(), epochs=1)
+        loader = recipe.make_loader(np.arange(64), {"batch_size": 16})
+        assert next(iter(loader))[0].shape[0] == 16
+
+    def test_optimizer_honours_sampled_learning_rate(self, arch):
+        x, y = _xy()
+        recipe = recipe_from_module(arch(MULTICLASS), x, y.long(), epochs=1, optimizer_name="sgd")
+        opt = recipe.make_optimizer(recipe.make_model({}).parameters(), {"learning_rate": 0.07})
+        assert isinstance(opt, torch.optim.SGD)
+        assert opt.param_groups[0]["lr"] == pytest.approx(0.07)
+
+    def test_unknown_optimizer_rejected(self, arch):
+        x, y = _xy()
+        with pytest.raises(ValueError, match="Unknown optimizer"):
+            recipe_from_module(arch(MULTICLASS), x, y.long(), epochs=1, optimizer_name="rmsprop")
+
+
+class TestCarveSplits:
+    def test_produces_every_required_key(self):
+        x, y = _xy(n=400)
+        splits = carve_splits(x, y)
+        assert all(k in splits for k in REQUIRED_SPLIT_KEYS)
+
+    def test_roles_are_disjoint_where_they_must_be(self):
+        x, y = _xy(n=400)
+        s = carve_splits(x, y)
+        # The reference pool must never touch the target's training data,
+        # otherwise the "reference" models are partly trained on members.
+        assert not set(s["target_train"]) & set(s["ref_pool"])
+        # Nonmembers must be non-members, and must not double as the utility split.
+        assert not set(s["audit_nonmembers"]) & set(s["target_train"])
+        assert not set(s["audit_nonmembers"]) & set(s["utility_eval"])
+        # Members are audited *because* they were trained on.
+        assert set(s["audit_members"]) <= set(s["target_train"])
+
+    def test_is_deterministic_for_a_seed(self):
+        x, y = _xy(n=400)
+        assert np.array_equal(carve_splits(x, y, seed=3)["target_train"],
+                              carve_splits(x, y, seed=3)["target_train"])
+        assert not np.array_equal(carve_splits(x, y, seed=3)["target_train"],
+                                  carve_splits(x, y, seed=4)["target_train"])
+
+    def test_audit_size_capped_by_available_data(self):
+        x, y = _xy(n=100)
+        s = carve_splits(x, y, audit_size=10_000)
+        assert len(s["audit_members"]) == len(s["audit_nonmembers"])
+        assert len(s["audit_members"]) <= len(s["target_train"])
+
+    def test_oversubscribed_fractions_rejected(self):
+        x, y = _xy(n=400)
+        with pytest.raises(ValueError, match="less than 1"):
+            carve_splits(x, y, target_fraction=0.6, ref_fraction=0.5)
+
+    @pytest.mark.parametrize("n", [2, 3])
+    def test_empty_role_rejected(self, n):
+        # carve_splits guards structure only: a role that comes out empty is an
+        # error. "Non-empty but far too small to resolve an FPR" is a separate
+        # judgement, and belongs to validation.resolution_warning.
+        x, y = _xy(n=n)
+        with pytest.raises(ValueError, match="too small"):
+            carve_splits(x, y, target_fraction=0.45, ref_fraction=0.45)
+
+    def test_smallest_workable_dataset_is_accepted(self):
+        x, y = _xy(n=400)
+        s = carve_splits(x, y, target_fraction=0.45, ref_fraction=0.45)
+        assert all(len(s[k]) > 0 for k in ("target_train", "ref_pool", "audit_members",
+                                           "audit_nonmembers", "utility_eval"))
+
+
+class TestAdapterDrivesACampaign:
+    def test_end_to_end_from_an_architecture_file(self, arch, tmp_path):
+        # The whole point of the adapter: a .py file plus a tensor dataset is
+        # enough to run a campaign, with no hand-written callables.
+        x, y = _xy(n=400)
+        recipe = recipe_from_module(arch(MULTICLASS), x, y.long(), epochs=1)
+        splits = carve_splits(x, y.long())
+        fns = build_campaign_fns(recipe, splits, n_refs=1, device="cpu")
+        space = KnobSpace([
+            Knob("noise_multiplier", 0.5, 2.0, log_scale=True),
+            Knob("max_grad_norm", 0.5, 2.0, log_scale=True),
+            Knob("learning_rate", 1e-3, 1e-1, log_scale=True),
+            Knob("batch_size", 32, 64, integer=True),
+        ])
+        records = Campaign(*fns, knob_space=space, output_dir=tmp_path / "out").run(2)
+
+        assert len(records) == 2
+        assert all(np.isfinite(r["epsilon"]) for r in records)
+        assert all(0.0 <= r["attack_tpr"] <= 1.0 for r in records)
+        assert (tmp_path / "out" / "evaluations.jsonl").exists()

--- a/leakpro/tests/test_optimization/test_training.py
+++ b/leakpro/tests/test_optimization/test_training.py
@@ -15,6 +15,7 @@ from leakpro.optimization import (
     PETRecipe,
     build_campaign_fns,
     confidence_signal,
+    make_opacus_compatible,
     train_with_dpsgd,
 )
 
@@ -144,3 +145,91 @@ class TestBuildCampaignFns:
             utility_metric=lambda model, x, y, device: 0.42)
         model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
         assert utility_fn(model) == 0.42
+
+
+def _batchnorm_recipe(splits, dim=8, classes=3, epochs=1):
+    """A model Opacus rejects as submitted: BatchNorm mixes samples within a batch."""
+    def make_loader(idx, cfg):
+        return DataLoader(TensorDataset(splits["x"][idx], splits["y"][idx]),
+                          batch_size=int(cfg["batch_size"]), shuffle=True)
+
+    return PETRecipe(
+        make_model=lambda cfg: nn.Sequential(
+            nn.Linear(dim, 16), nn.BatchNorm1d(16), nn.ReLU(inplace=True), nn.Linear(16, classes)),
+        make_optimizer=lambda params, cfg: optim.SGD(params, lr=cfg["learning_rate"]),
+        make_loader=make_loader,
+        criterion=nn.CrossEntropyLoss(),
+        epochs=epochs,
+    )
+
+
+class TestOpacusCompatibility:
+    def test_batchnorm_model_trains_under_dpsgd(self):
+        # Before the ModuleValidator pass this raised straight out of make_private.
+        splits = _toy_splits()
+        model = train_with_dpsgd(_batchnorm_recipe(splits), PRIVATE, splits["target_train"], "cpu")
+        assert np.isfinite(model.campaign_extras["epsilon"])
+
+    def test_batchnorm_is_replaced_and_inplace_disabled(self):
+        fixed = make_opacus_compatible(
+            nn.Sequential(nn.Linear(8, 16), nn.BatchNorm1d(16), nn.ReLU(inplace=True)))
+        assert not any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in fixed.modules())
+        assert not any(getattr(m, "inplace", False) for m in fixed.modules())
+
+    def test_nonprivate_path_leaves_batchnorm_alone(self):
+        # eps = inf means no Opacus, so there is no reason to rewrite the user's model.
+        splits = _toy_splits()
+        model = train_with_dpsgd(_batchnorm_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        assert any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in model.modules())
+
+    def test_compatible_model_is_returned_unchanged(self):
+        model = nn.Sequential(nn.Linear(8, 16), nn.GroupNorm(4, 16))
+        assert make_opacus_compatible(model) is model
+
+    def test_resnet_residual_block_trains_under_dpsgd(self):
+        # torchvision's `out += identity` is in-place and lives in forward, so
+        # ModuleValidator cannot see it; without the patch Opacus's hooks fail here.
+        torchvision = pytest.importorskip("torchvision")
+        rng = np.random.default_rng(0)
+        x = torch.tensor(rng.normal(size=(64, 4, 8, 8)), dtype=torch.float32)
+        y = torch.tensor(rng.integers(0, 3, size=64))
+        splits = {"x": x, "y": y, "target_train": np.arange(64), "ref_pool": np.arange(64),
+                  "audit_members": np.arange(8), "audit_nonmembers": np.arange(8), "utility_eval": np.arange(8)}
+
+        recipe = PETRecipe(
+            make_model=lambda cfg: nn.Sequential(
+                torchvision.models.resnet.BasicBlock(4, 4),
+                nn.AdaptiveAvgPool2d(1), nn.Flatten(), nn.Linear(4, 3)),
+            make_optimizer=lambda params, cfg: optim.SGD(params, lr=cfg["learning_rate"]),
+            make_loader=lambda idx, cfg: DataLoader(
+                TensorDataset(splits["x"][idx], splits["y"][idx]), batch_size=int(cfg["batch_size"]), shuffle=True),
+            criterion=nn.CrossEntropyLoss(),
+            epochs=1,
+        )
+        model = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu")
+        assert np.isfinite(model.campaign_extras["epsilon"])
+
+
+class TestAccountant:
+    def test_accountant_is_configurable_and_changes_epsilon(self):
+        splits = _toy_splits()
+        recipe = _toy_recipe(splits)
+        prv = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", accountant="prv")
+        rdp = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", accountant="rdp")
+        # PRV is the tighter bound, so it must not report a larger epsilon than RDP.
+        assert prv.campaign_extras["epsilon"] < rdp.campaign_extras["epsilon"]
+
+    def test_default_accountant_is_prv(self):
+        splits = _toy_splits()
+        recipe = _toy_recipe(splits)
+        default = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu")
+        prv = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", accountant="prv")
+        assert default.campaign_extras["epsilon"] == pytest.approx(prv.campaign_extras["epsilon"], rel=1e-9)
+
+    def test_build_campaign_fns_threads_accountant_through(self):
+        splits = _toy_splits()
+        train_fn, _, _ = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu", accountant="rdp")
+        direct = train_with_dpsgd(_toy_recipe(splits), PRIVATE, splits["target_train"], "cpu", accountant="rdp")
+        assert train_fn(PRIVATE).campaign_extras["epsilon"] == pytest.approx(
+            direct.campaign_extras["epsilon"], rel=1e-9)

--- a/leakpro/tests/test_optimization/test_training.py
+++ b/leakpro/tests/test_optimization/test_training.py
@@ -18,6 +18,7 @@ from leakpro.optimization import (
     make_opacus_compatible,
     train_with_dpsgd,
 )
+from leakpro.optimization.training import _patch_residual_blocks
 
 
 def _toy_splits(n=600, dim=8, classes=3, seed=0):
@@ -163,6 +164,18 @@ def _batchnorm_recipe(splits, dim=8, classes=3, epochs=1):
     )
 
 
+try:  # torchvision is optional; the subclass test skips without it
+    from torchvision.models.resnet import BasicBlock as _BasicBlock
+
+    class _CustomResidualBlock(_BasicBlock):
+        """A residual block with its own forward — must survive the Opacus patcher untouched."""
+
+        def forward(self, x):  # noqa: ANN001, ANN201, D102
+            return self.conv1(x) * 1.0
+except ImportError:  # pragma: no cover
+    _CustomResidualBlock = None
+
+
 class TestOpacusCompatibility:
     def test_batchnorm_model_trains_under_dpsgd(self):
         # Before the ModuleValidator pass this raised straight out of make_private.
@@ -176,11 +189,58 @@ class TestOpacusCompatibility:
         assert not any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in fixed.modules())
         assert not any(getattr(m, "inplace", False) for m in fixed.modules())
 
-    def test_nonprivate_path_leaves_batchnorm_alone(self):
-        # eps = inf means no Opacus, so there is no reason to rewrite the user's model.
+    def test_nonprivate_anchor_shares_the_private_architecture(self):
+        # Every point on a frontier must be the same model. If only private
+        # configs got BatchNorm -> GroupNorm, the anchor's utility gap would
+        # mix the cost of DP noise with the cost of an architecture change.
         splits = _toy_splits()
-        model = train_with_dpsgd(_batchnorm_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
-        assert any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in model.modules())
+        anchor = train_with_dpsgd(_batchnorm_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        private = train_with_dpsgd(_batchnorm_recipe(splits), PRIVATE, splits["target_train"], "cpu")
+        def leaves(model):
+            return [type(m).__name__ for m in model.modules() if not list(m.children())]
+
+        assert not any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in anchor.modules())
+        # Leaves only: the private model is additionally wrapped in Opacus's
+        # GradSampleModule, which is not an architecture difference.
+        assert leaves(anchor) == leaves(private)
+
+    def test_missing_noise_multiplier_is_rejected(self):
+        # Fail closed: defaulting the key would silently train non-privately.
+        splits = _toy_splits()
+        bad = {k: v for k, v in PRIVATE.items() if k != "noise_multiplier"}
+        with pytest.raises(KeyError, match="noise_multiplier"):
+            train_with_dpsgd(_toy_recipe(splits), bad, splits["target_train"], "cpu")
+
+    def test_accountant_is_recorded_with_the_epsilon(self):
+        splits = _toy_splits()
+        model = train_with_dpsgd(_toy_recipe(splits), PRIVATE, splits["target_train"], "cpu", accountant="rdp")
+        assert model.campaign_extras["accountant"] == "rdp"
+
+    def test_short_reference_pool_is_rejected(self):
+        # Full mimicry is a promise: shrinking references silently would weaken
+        # the attack and bias the audit optimistic.
+        splits = _toy_splits()
+        splits["ref_pool"] = splits["ref_pool"][:10]
+        with pytest.raises(ValueError, match="Full mimicry"):
+            build_campaign_fns(_toy_recipe(splits), splits, n_refs=1, device="cpu")
+
+    def test_auc_metric_refuses_multiclass_output(self):
+        splits = _toy_splits()
+        _, utility_fn, _ = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu", utility_metric="auc")
+        model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        with pytest.raises(ValueError, match="single-column"):
+            utility_fn(model)
+
+    def test_overridden_residual_forward_is_left_alone(self):
+        # The patcher works by assigning a bound method into the instance
+        # __dict__, so that is what "was it patched?" actually means.
+        torchvision = pytest.importorskip("torchvision")
+        custom = _CustomResidualBlock(8, 8)
+        stock = torchvision.models.resnet.BasicBlock(8, 8)
+        _patch_residual_blocks(nn.Sequential(custom, stock))
+        assert "forward" not in custom.__dict__   # subclass left untouched
+        assert "forward" in stock.__dict__        # stock block still patched
 
     def test_compatible_model_is_returned_unchanged(self):
         model = nn.Sequential(nn.Linear(8, 16), nn.GroupNorm(4, 16))

--- a/leakpro/tests/test_optimization/test_training.py
+++ b/leakpro/tests/test_optimization/test_training.py
@@ -1,0 +1,138 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for PETRecipe and the shared DP-SGD training path (CPU, tiny models)."""
+
+import numpy as np
+import pytest
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader, TensorDataset
+
+from leakpro.optimization import (
+    AttackScores,
+    PETRecipe,
+    build_campaign_fns,
+    confidence_signal,
+    train_with_dpsgd,
+)
+
+
+def _toy_splits(n=600, dim=8, classes=3, seed=0):
+    rng = np.random.default_rng(seed)
+    x = torch.tensor(rng.normal(size=(n, dim)), dtype=torch.float32)
+    y = torch.tensor(rng.integers(0, classes, size=n))
+    order = rng.permutation(n)
+    return {
+        "x": x, "y": y,
+        "target_train": order[:200],
+        "ref_pool": order[200:400],
+        "audit_members": order[:100],
+        "audit_nonmembers": order[400:500],
+        "utility_eval": order[500:],
+    }
+
+
+def _toy_recipe(splits=None, dim=8, classes=3, epochs=1):
+    def make_loader(idx, cfg):
+        return DataLoader(TensorDataset(splits["x"][idx], splits["y"][idx]),
+                          batch_size=int(cfg["batch_size"]), shuffle=True)
+
+    return PETRecipe(
+        make_model=lambda cfg: nn.Linear(dim, classes),
+        make_optimizer=lambda params, cfg: optim.SGD(params, lr=cfg["learning_rate"]),
+        make_loader=make_loader,
+        criterion=nn.CrossEntropyLoss(),
+        epochs=epochs,
+    )
+
+
+PRIVATE = {"noise_multiplier": 1.0, "max_grad_norm": 1.0, "learning_rate": 0.1, "batch_size": 64}
+NONPRIVATE = {"noise_multiplier": 0.0, "max_grad_norm": 1.0, "learning_rate": 0.1, "batch_size": 64}
+
+
+class TestTrainWithDPSGD:
+    def test_private_path_records_finite_epsilon(self):
+        splits = _toy_splits()
+        model = train_with_dpsgd(_toy_recipe(splits), PRIVATE, splits["target_train"], "cpu")
+        assert np.isfinite(model.campaign_extras["epsilon"])
+        assert model.campaign_extras["epsilon"] > 0
+
+    def test_nonprivate_path_is_epsilon_inf(self):
+        splits = _toy_splits()
+        model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        assert model.campaign_extras["epsilon"] == float("inf")
+
+    def test_physical_batch_cap_matches_uncapped_accounting(self):
+        splits = _toy_splits()
+        recipe = _toy_recipe(splits)
+        m_small = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", max_physical_batch=16)
+        m_large = train_with_dpsgd(recipe, PRIVATE, splits["target_train"], "cpu", max_physical_batch=512)
+        # The cap is a memory measure only: the accounting must be identical.
+        assert m_small.campaign_extras["epsilon"] == pytest.approx(m_large.campaign_extras["epsilon"], rel=1e-6)
+
+    def test_invalid_output_kind_rejected(self):
+        with pytest.raises(ValueError):
+            PETRecipe(
+                make_model=lambda cfg: nn.Linear(2, 2),
+                make_optimizer=lambda p, cfg: optim.SGD(p, lr=0.1),
+                make_loader=lambda idx, cfg: None,
+                criterion=nn.CrossEntropyLoss(),
+                epochs=1,
+                output_kind="probabilities",
+            )
+
+
+class TestConfidenceSignal:
+    def test_multiclass_prefers_true_class(self):
+        model = nn.Identity()  # "logits" are the inputs themselves
+        x = torch.eye(3).repeat(4, 1) * 5  # strongly peaked one-hot logits
+        y = torch.arange(3).repeat(4)
+        phi = confidence_signal(model, x, y, "cpu", output_kind="logits")
+        y_wrong = (y + 1) % 3
+        phi_wrong = confidence_signal(model, x, y_wrong, "cpu", output_kind="logits")
+        assert phi.min() > phi_wrong.max()
+
+    def test_binary_probs_symmetry(self):
+        model = nn.Identity()
+        p = torch.tensor([[0.9], [0.9]])
+        y = torch.tensor([[1.0], [0.0]])
+        phi = confidence_signal(model, p, y, "cpu", output_kind="binary_probs")
+        assert phi[0] == pytest.approx(-phi[1])  # log(0.9/0.1) vs log(0.1/0.9)
+
+
+class TestBuildCampaignFns:
+    def test_end_to_end_on_toy_data(self):
+        splits = _toy_splits()
+        train_fn, utility_fn, attack_fn = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu")
+        model = train_fn(NONPRIVATE)
+        acc = utility_fn(model)
+        assert 0.0 <= acc <= 1.0
+        scores = attack_fn(model, NONPRIVATE)
+        assert isinstance(scores, AttackScores)
+        assert len(scores.member_scores) == 100
+        assert len(scores.nonmember_scores) == 100
+
+    def test_missing_split_keys_rejected(self):
+        splits = _toy_splits()
+        del splits["ref_pool"]
+        with pytest.raises(KeyError):
+            build_campaign_fns(_toy_recipe(splits), splits, n_refs=1, device="cpu")
+
+    def test_unknown_utility_metric_rejected(self):
+        splits = _toy_splits()
+        _, utility_fn, _ = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu", utility_metric="f1")
+        model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        with pytest.raises(ValueError):
+            utility_fn(model)
+
+    def test_callable_utility_metric(self):
+        splits = _toy_splits()
+        _, utility_fn, _ = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu",
+            utility_metric=lambda model, x, y, device: 0.42)
+        model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
+        assert utility_fn(model) == 0.42

--- a/leakpro/tests/test_optimization/test_training.py
+++ b/leakpro/tests/test_optimization/test_training.py
@@ -101,6 +101,14 @@ class TestConfidenceSignal:
         phi = confidence_signal(model, p, y, "cpu", output_kind="binary_probs")
         assert phi[0] == pytest.approx(-phi[1])  # log(0.9/0.1) vs log(0.1/0.9)
 
+    def test_binary_logits_signed_by_label(self):
+        model = nn.Identity()
+        logit = torch.tensor([[2.0], [2.0]])
+        y = torch.tensor([[1.0], [0.0]])
+        phi = confidence_signal(model, logit, y, "cpu", output_kind="binary_logits")
+        assert phi[0] == pytest.approx(2.0)   # confident and correct
+        assert phi[1] == pytest.approx(-2.0)  # confident and wrong
+
 
 class TestBuildCampaignFns:
     def test_end_to_end_on_toy_data(self):

--- a/leakpro/tests/test_optimization/test_training.py
+++ b/leakpro/tests/test_optimization/test_training.py
@@ -147,6 +147,24 @@ class TestBuildCampaignFns:
         model = train_with_dpsgd(_toy_recipe(splits), NONPRIVATE, splits["target_train"], "cpu")
         assert utility_fn(model) == 0.42
 
+    def test_accuracy_metric_handles_single_logit_head(self):
+        # A binary head outputs one column; argmax over it is always 0, which
+        # would silently report 0% or 100%. Accuracy must threshold at 0 instead.
+        class PerfectBinary(nn.Module):
+            """Emits the label's sign as a logit: always correct, so accuracy == 1."""
+
+            def forward(self, x):  # noqa: ANN001, ANN201, D102
+                return x[:, :1] * 0.0 + x[:, :1]  # single column, keeps grad graph shape
+
+        n = 40
+        x = torch.cat([torch.full((n // 2, 4), 3.0), torch.full((n // 2, 4), -3.0)])
+        y = torch.cat([torch.ones(n // 2), torch.zeros(n // 2)])  # 1 where logit>0, 0 where <0
+        splits = {"x": x, "y": y, "target_train": np.arange(n), "ref_pool": np.arange(n),
+                  "audit_members": np.arange(4), "audit_nonmembers": np.arange(4), "utility_eval": np.arange(n)}
+        _, utility_fn, _ = build_campaign_fns(
+            _toy_recipe(splits), splits, n_refs=1, device="cpu", utility_metric="accuracy")
+        assert utility_fn(PerfectBinary()) == pytest.approx(1.0)
+
 
 def _batchnorm_recipe(splits, dim=8, classes=3, epochs=1):
     """A model Opacus rejects as submitted: BatchNorm mixes samples within a batch."""

--- a/leakpro/webapp/backend/dataset_modules.py
+++ b/leakpro/webapp/backend/dataset_modules.py
@@ -1,0 +1,59 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Make a job's uploaded dataset classes importable before unpickling its data.
+
+A pickled dataset records the module path its class came from, so unpickling
+fails with ``No module named ...`` unless that name resolves. The webapp stores
+the user's file as ``<job>/dataset_handler.py``, which is not the name it was
+written under, so the module has to be registered under the original name too.
+
+One implementation, used by every path that loads a job's dataset: the audit
+worker, the PET campaign runner, and the sample-data/sample-image endpoints.
+Three copies of this previously drifted apart, and the endpoints' copy existed
+only because a bug report showed images failing for models loaded from an
+earlier session.
+"""
+
+import sys
+from pathlib import Path
+
+from leakpro.input_handler.user_imports import import_module_from_file
+from leakpro.utils.logger import logger
+
+
+def register_job_dataset_modules(job_dir: str | Path) -> None:
+    """Register ``<job_dir>/dataset_handler.py`` under the names pickles expect.
+
+    Also puts the job directory on ``sys.path``, since a dataset may have been
+    pickled from another module sitting next to it. Safe to call repeatedly and
+    a no-op when the job has no uploaded handler.
+    """
+    job_dir = Path(job_dir)
+    if str(job_dir) not in sys.path:
+        sys.path.insert(0, str(job_dir))
+
+    path = job_dir / "dataset_handler.py"
+    if not path.exists():
+        return
+
+    try:
+        module = import_module_from_file(str(path))
+    except Exception as exc:  # noqa: BLE001 - a broken upload must not take the caller down
+        logger.warning(f"Could not import {path}: {exc}")
+        return
+
+    sys.modules.setdefault("dataset_handler", module)
+
+    # The handler class name encodes the original module name:
+    #   CelebADataHandler -> celebA_data_handler
+    #   CifarDataHandler  -> cifar_data_handler
+    for attr in dir(module):
+        obj = getattr(module, attr, None)
+        if isinstance(obj, type) and hasattr(obj, "UserDataset") and attr != "AbstractInputHandler":
+            original = attr.replace("DataHandler", "_data_handler").replace("InputHandler", "_input_handler")
+            original = original[0].lower() + original[1:]
+            if original not in sys.modules:
+                sys.modules[original] = module
+                logger.info(f"Registered {path.name} as '{original}' for unpickling.")

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import queue
 import shutil
+import sys
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -270,6 +271,7 @@ from .models import (
     JobSummary,
     ModelAttackConfig,
     ModelInfo,
+    PETStartParams,
     TrainParams,
 )
 from .worker import run_audit_job
@@ -1240,6 +1242,163 @@ async def get_sample_image(job_id: str, index: int):
     buf = io.BytesIO()
     Image.fromarray(img).save(buf, format="PNG")
     return Response(content=buf.getvalue(), media_type="image/png")
+
+
+# ---------------------------------------------------------------------------
+# PET optimization
+#
+# A campaign is n_configs x (1 + n_refs) full trainings, so it runs as a
+# detached subprocess rather than on _executor: it must outlive both the
+# request and a backend restart. Progress is read back off disk -- the runner
+# appends one JSON line per evaluated setting -- so there is no in-memory
+# state to lose, and killing the process is a resumable pause rather than a
+# lost run.
+# ---------------------------------------------------------------------------
+
+def _pet_dir(job_id: str, model_name: str) -> Path:
+    return _job_dir(job_id) / "pet" / model_name
+
+
+def _pet_read_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return None  # a status file caught mid-write; the next poll gets it
+
+
+def _pet_spawn(job_id: str, model_name: str, extra: list[str]) -> None:
+    """Launch the runner detached, so it survives this process exiting."""
+    import subprocess  # noqa: PLC0415
+
+    cmd = [sys.executable, "-m", "leakpro.webapp.backend.pet_runner",
+           str(_job_dir(job_id)), model_name, *extra]
+    subprocess.Popen(  # noqa: S603
+        cmd,
+        cwd=str(Path(__file__).parents[3]),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+@app.post("/jobs/{job_id}/pet/start")
+async def pet_start(job_id: str, model_name: str, params: PETStartParams) -> dict:
+    """Begin (or resume) a campaign for one model."""
+    job = _get_job(job_id)
+    if not any(m["name"] == model_name for m in job.get("models", [])):
+        raise HTTPException(status_code=404, detail=f"No model named '{model_name}' in this job.")
+
+    out = _pet_dir(job_id, model_name)
+    status = _pet_read_json(out / "status.json") or {}
+    if status.get("status") == "running":
+        raise HTTPException(status_code=409, detail="An optimization run is already in progress.")
+
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "request.json").write_text(json.dumps(params.model_dump(), indent=2))
+    # Written here rather than in the runner so a poll landing before the
+    # subprocess has started does not read the previous run's status.
+    (out / "status.json").write_text(json.dumps({"status": "running", "model_name": model_name}))
+    _pet_spawn(job_id, model_name, [])
+    return {"ok": True}
+
+
+@app.get("/jobs/{job_id}/pet/campaign")
+async def pet_campaign(job_id: str, model_name: str) -> dict:
+    """Everything the optimization view needs, read straight off disk."""
+    _get_job(job_id)
+    out = _pet_dir(job_id, model_name)
+    status = _pet_read_json(out / "status.json")
+    if status is None:
+        return {"status": "idle", "model_name": model_name, "settings": [], "best_indices": []}
+
+    settings: list[dict] = []
+    log = out / "evaluations.jsonl"
+    if log.exists():
+        for line in log.read_text().splitlines():
+            if line.strip():
+                try:
+                    settings.append(json.loads(line))
+                except json.JSONDecodeError:
+                    break  # a partially flushed final line; take what is complete
+
+    return {
+        "status": status.get("status", "idle"),
+        "model_name": model_name,
+        "n_configs": status.get("n_configs"),
+        "baseline_utility": status.get("baseline_utility"),
+        "settings": settings,
+        "best_indices": status.get("best_indices", []),
+        "resolution_warning": status.get("resolution_warning"),
+        "error": status.get("error"),
+    }
+
+
+@app.post("/jobs/{job_id}/pet/verify")
+async def pet_verify(job_id: str, model_name: str, body: dict) -> dict:
+    """Re-measure one setting with a stronger attack than the search used."""
+    _get_job(job_id)
+    index = int(body["index"])
+    out = _pet_dir(job_id, model_name)
+    if not (out / "evaluations.jsonl").exists():
+        raise HTTPException(status_code=404, detail="This model has no optimization results to verify.")
+
+    existing = _pet_read_json(out / f"verification_{index}.json")
+    if existing and existing.get("status") == "running":
+        return existing
+
+    _pet_spawn(job_id, model_name, ["--verify", str(index)])
+    return {"status": "running", "index": index, "estimated": {"attack_tpr": None, "utility": None}}
+
+
+@app.get("/jobs/{job_id}/pet/verify")
+async def pet_verify_status(job_id: str, model_name: str, index: int) -> dict:
+    """Poll a verification started by the POST above."""
+    _get_job(job_id)
+    result = _pet_read_json(_pet_dir(job_id, model_name) / f"verification_{index}.json")
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"No verification running for setting {index}.")
+    return result
+
+
+@app.post("/jobs/{job_id}/pet/adopt")
+async def pet_adopt(job_id: str, model_name: str, body: dict) -> dict:
+    """Record a verified setting as a result row of its own."""
+    job = _get_job(job_id)
+    index = int(body["index"])
+    out = _pet_dir(job_id, model_name)
+
+    verification = _pet_read_json(out / f"verification_{index}.json")
+    if not verification or verification.get("status") != "done":
+        raise HTTPException(status_code=409, detail="This setting has not been verified yet.")
+
+    settings = [json.loads(line) for line in (out / "evaluations.jsonl").read_text().splitlines() if line.strip()]
+    record = next((r for r in settings if r["index"] == index), None)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"No evaluated setting with index {index}.")
+
+    verified = verification["verified"]
+    base = next((m for m in job.get("models", []) if m["name"] == model_name), {})
+    adopted = {
+        "model_name": f"{model_name} (optimized)",
+        "source": "optimized",
+        "optimized": True,
+        "dpsgd": True,
+        "target_epsilon": verified.get("epsilon"),
+        "test_accuracy": verified.get("utility"),
+        "train_accuracy": None,
+        "model_class": base.get("model_class"),
+        "attacks": [],
+        "pet_config": record["config"],
+        "pet_attack_tpr": verified.get("attack_tpr"),
+        "pet_proxy_fpr": record.get("proxy_fpr", 0.01),
+    }
+    job.setdefault("results", [])
+    job["results"] = [r for r in job["results"] if r.get("model_name") != adopted["model_name"]]
+    job["results"].append(adopted)
+    _save_job(job_id)
+    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -250,6 +250,7 @@ from .models import (
     RiskResponse,
     TrainParams,
 )
+from .dataset_modules import register_job_dataset_modules
 from .worker import run_audit_job
 
 # ---------------------------------------------------------------------------
@@ -1202,40 +1203,6 @@ async def assess_job_risk(job_id: str, req: RiskRequest) -> RiskResponse:
     return RiskResponse(job_id=job_id, assessments=assessments, unassessable=unassessable)
 
 
-def _ensure_dataset_module(job_id: str) -> None:
-    """Make the job's dataset classes importable before unpickling its data.
-
-    Dataset pickles reference the module they were written from (e.g.
-    ``celebA_data_handler``). The audit worker and the PET runner register the
-    job's dataset_handler.py under that name before loading; these endpoints
-    must too, or a loaded model's Records tab 500s with "No module named ..."
-    on any backend that has not run an audit for the job yet.
-    """
-    import importlib.util  # noqa: PLC0415
-
-    job_dir = _job_dir(job_id)
-    if str(job_dir) not in sys.path:
-        sys.path.insert(0, str(job_dir))
-    path = job_dir / "dataset_handler.py"
-    if not path.exists():
-        return
-    spec = importlib.util.spec_from_file_location("dataset_handler", path)
-    if spec is None or spec.loader is None:
-        return
-    module = importlib.util.module_from_spec(spec)
-    try:
-        spec.loader.exec_module(module)
-    except Exception:  # noqa: BLE001 - a broken handler should not take the endpoint down
-        return
-    sys.modules.setdefault("dataset_handler", module)
-    # CelebADataHandler -> celebA_data_handler, CifarDataHandler -> cifar_data_handler
-    for attr in dir(module):
-        obj = getattr(module, attr, None)
-        if isinstance(obj, type) and hasattr(obj, "UserDataset") and attr != "AbstractInputHandler":
-            original = attr.replace("DataHandler", "_data_handler").replace("InputHandler", "_input_handler")
-            sys.modules.setdefault(original[0].lower() + original[1:], module)
-
-
 @app.get("/jobs/{job_id}/sample_data/{index}")
 async def get_sample_data(job_id: str, index: int):
     """Return tabular feature values for a single sample as JSON."""
@@ -1246,7 +1213,7 @@ async def get_sample_data(job_id: str, index: int):
     if not data_path or not Path(data_path).exists():
         raise HTTPException(status_code=404, detail="Dataset not found")
     try:
-        _ensure_dataset_module(job_id)
+        register_job_dataset_modules(_job_dir(job_id))
         dataset = joblib.load(data_path)
         row = dataset.data[index]
         if isinstance(row, torch.Tensor):
@@ -1279,7 +1246,7 @@ async def get_sample_image(job_id: str, index: int):
     if not data_path or not Path(data_path).exists():
         raise HTTPException(status_code=404, detail="Dataset not found")
 
-    _ensure_dataset_module(job_id)
+    register_job_dataset_modules(_job_dir(job_id))
     try:
         dataset = joblib.load(data_path)
     except Exception as e:  # noqa: BLE001 - a named 404 beats a bare 500 in the img tag

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -1270,13 +1270,19 @@ def _pet_read_json(path: Path) -> dict | None:
 
 def _pet_spawn(job_id: str, model_name: str, extra: list[str]) -> None:
     """Launch the runner detached, so it survives this process exiting."""
+    import os  # noqa: PLC0415
     import subprocess  # noqa: PLC0415
 
     cmd = [sys.executable, "-m", "leakpro.webapp.backend.pet_runner",
            str(_job_dir(job_id)), model_name, *extra]
+    # Let CUDA grow its allocation instead of pre-reserving fixed segments; the
+    # campaign trains many models back to back, so fragmentation is the common
+    # cause of a spurious out-of-memory long before the card is actually full.
+    env = {**os.environ, "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
     subprocess.Popen(  # noqa: S603
         cmd,
         cwd=str(Path(__file__).parents[3]),
+        env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         start_new_session=True,

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -270,6 +270,8 @@ from .models import (
     JobSummary,
     ModelAttackConfig,
     ModelInfo,
+    RiskRequest,
+    RiskResponse,
     TrainParams,
 )
 from .worker import run_audit_job
@@ -1172,6 +1174,56 @@ async def get_results(job_id: str) -> dict:
     for r in results:
         r["job_id"] = job_id
     return {"job_id": job_id, "results": results}
+
+
+@app.post("/jobs/{job_id}/risk", response_model=RiskResponse)
+async def assess_job_risk(job_id: str, req: RiskRequest) -> RiskResponse:
+    """Assess use-case risk for a finished job's attack results.
+
+    All scoring lives in leakpro.risk: this endpoint adapts the stored results, calls the library once
+    per model, and returns the assessments untouched. Nothing here decides what is risky.
+    """
+    from leakpro.risk import UseCaseProfile, assess_risk, result_from_mapping  # noqa: PLC0415
+
+    job = _get_job(job_id)
+    if job["status"] != JobStatus.done:
+        raise HTTPException(status_code=425, detail=f"Job status: {job['status']}")
+
+    profile_fields = req.model_dump(exclude={"model_name"})
+    try:
+        profile = UseCaseProfile(**profile_fields)
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=f"Invalid use-case profile: {e}") from e
+
+    assessments: dict[str, dict] = {}
+    unassessable: dict[str, str] = {}
+    for model in job.get("results", []):
+        name = model.get("model_name", "?")
+        if req.model_name is not None and name != req.model_name:
+            continue
+        results = [result_from_mapping(a) for a in model.get("attacks", [])]
+        if not results:
+            unassessable[name] = "no attack results"
+            continue
+        try:
+            gap = None
+            if model.get("train_accuracy") is not None and model.get("test_accuracy") is not None:
+                gap = float(model["train_accuracy"]) - float(model["test_accuracy"])
+            assessment = assess_risk(
+                results,
+                profile,
+                num_train=model.get("num_train"),
+                train_test_gap=gap,
+                dp_epsilon=model.get("target_epsilon"),
+                strict=False,
+            )
+            assessments[name] = assessment.model_dump()
+        except Exception as e:  # noqa: BLE001 - surfaced per model rather than failing the request
+            unassessable[name] = str(e)
+
+    if not assessments and not unassessable:
+        raise HTTPException(status_code=404, detail="No models found for this job")
+    return RiskResponse(job_id=job_id, assessments=assessments, unassessable=unassessable)
 
 
 @app.get("/jobs/{job_id}/sample_data/{index}")

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -38,46 +38,20 @@ def _default_train(loader, model, criterion, optimizer, epochs,
         from opacus import PrivacyEngine
         from opacus.accountants.utils import get_noise_multiplier
         from opacus.utils.batch_memory_manager import BatchMemoryManager
-        from opacus.validators import ModuleValidator
 
-        errors = ModuleValidator.validate(model, strict=False)
-        if errors:
-            model = ModuleValidator.fix(model)
+        from leakpro.optimization import make_opacus_compatible
+
+        # One implementation of the Opacus-compat rewrite (BatchNorm -> GroupNorm,
+        # in-place activations off, residual adds out of place) shared with the
+        # PET campaign path, so a model trained here and a model trained by a
+        # campaign are the same architecture.
+        fixed = make_opacus_compatible(model)
+        if fixed is not model:
+            model = fixed
             opt_cls = optimizer.__class__
             opt_cfg = {k: v for group in optimizer.param_groups
                        for k, v in group.items() if k != "params"}
             optimizer = opt_cls(model.parameters(), **opt_cfg)
-
-        for module in model.modules():
-            if hasattr(module, "inplace") and isinstance(module.inplace, bool):
-                module.inplace = False
-
-        # ModuleValidator.fix() replaces BatchNorm but leaves ResNet's skip-connection
-        # `out += identity` in-place, which Opacus's backward hooks forbid.
-        # Patch every BasicBlock/Bottleneck to use `out = out + identity` instead.
-        try:
-            import types as _types
-            from torchvision.models.resnet import BasicBlock as _BB, Bottleneck as _BN
-            def _bb_fwd(self, x):
-                identity = x
-                out = self.conv1(x); out = self.bn1(out); out = self.relu(out)
-                out = self.conv2(out); out = self.bn2(out)
-                if self.downsample is not None: identity = self.downsample(x)
-                return self.relu(out + identity)
-            def _bn_fwd(self, x):
-                identity = x
-                out = self.conv1(x); out = self.bn1(out); out = self.relu(out)
-                out = self.conv2(out); out = self.bn2(out); out = self.relu(out)
-                out = self.conv3(out); out = self.bn3(out)
-                if self.downsample is not None: identity = self.downsample(x)
-                return self.relu(out + identity)
-            for _m in model.modules():
-                if isinstance(_m, _BB):
-                    _m.forward = _types.MethodType(_bb_fwd, _m)
-                elif isinstance(_m, _BN):
-                    _m.forward = _types.MethodType(_bn_fwd, _m)
-        except ImportError:
-            pass
 
         if not os.path.exists(dpsgd_metadata_path):
             raise FileNotFoundError(f"DP-SGD config not found: {dpsgd_metadata_path}")

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -1202,6 +1202,40 @@ async def assess_job_risk(job_id: str, req: RiskRequest) -> RiskResponse:
     return RiskResponse(job_id=job_id, assessments=assessments, unassessable=unassessable)
 
 
+def _ensure_dataset_module(job_id: str) -> None:
+    """Make the job's dataset classes importable before unpickling its data.
+
+    Dataset pickles reference the module they were written from (e.g.
+    ``celebA_data_handler``). The audit worker and the PET runner register the
+    job's dataset_handler.py under that name before loading; these endpoints
+    must too, or a loaded model's Records tab 500s with "No module named ..."
+    on any backend that has not run an audit for the job yet.
+    """
+    import importlib.util  # noqa: PLC0415
+
+    job_dir = _job_dir(job_id)
+    if str(job_dir) not in sys.path:
+        sys.path.insert(0, str(job_dir))
+    path = job_dir / "dataset_handler.py"
+    if not path.exists():
+        return
+    spec = importlib.util.spec_from_file_location("dataset_handler", path)
+    if spec is None or spec.loader is None:
+        return
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:  # noqa: BLE001 - a broken handler should not take the endpoint down
+        return
+    sys.modules.setdefault("dataset_handler", module)
+    # CelebADataHandler -> celebA_data_handler, CifarDataHandler -> cifar_data_handler
+    for attr in dir(module):
+        obj = getattr(module, attr, None)
+        if isinstance(obj, type) and hasattr(obj, "UserDataset") and attr != "AbstractInputHandler":
+            original = attr.replace("DataHandler", "_data_handler").replace("InputHandler", "_input_handler")
+            sys.modules.setdefault(original[0].lower() + original[1:], module)
+
+
 @app.get("/jobs/{job_id}/sample_data/{index}")
 async def get_sample_data(job_id: str, index: int):
     """Return tabular feature values for a single sample as JSON."""
@@ -1212,6 +1246,7 @@ async def get_sample_data(job_id: str, index: int):
     if not data_path or not Path(data_path).exists():
         raise HTTPException(status_code=404, detail="Dataset not found")
     try:
+        _ensure_dataset_module(job_id)
         dataset = joblib.load(data_path)
         row = dataset.data[index]
         if isinstance(row, torch.Tensor):
@@ -1244,7 +1279,11 @@ async def get_sample_image(job_id: str, index: int):
     if not data_path or not Path(data_path).exists():
         raise HTTPException(status_code=404, detail="Dataset not found")
 
-    dataset = joblib.load(data_path)
+    _ensure_dataset_module(job_id)
+    try:
+        dataset = joblib.load(data_path)
+    except Exception as e:  # noqa: BLE001 - a named 404 beats a bare 500 in the img tag
+        raise HTTPException(status_code=404, detail=f"Cannot load dataset: {e}")
 
     try:
         img = dataset.data[index]

--- a/leakpro/webapp/backend/models.py
+++ b/leakpro/webapp/backend/models.py
@@ -111,6 +111,20 @@ class CompatResult(BaseModel):
 # Step 5 — Attack config
 # ---------------------------------------------------------------------------
 
+class PETStartParams(BaseModel):
+    """Request to begin a PET optimization run for one model."""
+
+    # Display-side constraint: it dims settings that fall below the user's
+    # quality floor, but never gates the search, so moving the slider
+    # afterwards re-reads the same results instead of invalidating them.
+    max_quality_loss: float = 0.05
+    # Any knob named here is pinned to that value; the rest stay searched.
+    advanced: dict[str, float] = {}
+    n_configs: int | None = None
+    n_refs: int | None = None
+    delta: float | None = None
+
+
 class AttackParams(BaseModel):
     attack: str
     params: dict[str, Any] = {}

--- a/leakpro/webapp/backend/models.py
+++ b/leakpro/webapp/backend/models.py
@@ -123,6 +123,9 @@ class PETStartParams(BaseModel):
     n_configs: int | None = None
     n_refs: int | None = None
     delta: float | None = None
+    # Per-sample-gradient memory cap under DP-SGD. Lower it to fit a big model
+    # or a busy GPU; it changes speed only, never the privacy accounting.
+    max_physical_batch: int = 32
 
 
 class AttackParams(BaseModel):

--- a/leakpro/webapp/backend/models.py
+++ b/leakpro/webapp/backend/models.py
@@ -153,4 +153,37 @@ class ModelResult(BaseModel):
     model_class: str | None = None   # e.g. "ResNet18_DPsgd"
     job_id: str | None = None        # originating job, used for sample image URLs
     train_meta: dict | None = None   # epochs, lr, batch_size, optimizer, data info
+    num_train: int | None = None     # target training-set size, used to scale risk to the population
     attacks: list[AttackResult] = []
+
+
+# ---------------------------------------------------------------------------
+# Risk assessment — see leakpro/risk/. All scoring happens in the library; the
+# frontend posts a use-case profile and renders whatever comes back.
+# ---------------------------------------------------------------------------
+
+class RiskRequest(BaseModel):
+    """A use-case profile plus the model it applies to.
+
+    Field names and semantics mirror leakpro.risk.schemas.UseCaseProfile; validation happens there so
+    there is exactly one definition of a valid profile.
+    """
+
+    model_name: str | None = None    # None assesses every model in the job
+    tolerated_fpr: float             # required, deliberately no default
+    attacker_prior: float = 0.5
+    n_subjects: int | None = None
+    records_per_subject: float = 1.0
+    data_type_sensitivity: float = 1.0
+    subject_type_weight: float = 1.0
+    cost_per_exposed_subject: float | None = None
+    extrapolate_to_population: bool = False
+    notes: str = ""
+
+
+class RiskResponse(BaseModel):
+    """One assessment per model, plus any model that could not be assessed and why."""
+
+    job_id: str
+    assessments: dict[str, dict] = {}   # model_name -> RiskAssessment.model_dump()
+    unassessable: dict[str, str] = {}   # model_name -> reason

--- a/leakpro/webapp/backend/pet_runner.py
+++ b/leakpro/webapp/backend/pet_runner.py
@@ -47,6 +47,7 @@ from leakpro.optimization import (
     tpr_at_fpr,
 )
 from leakpro.optimization.adapters import carve_splits, detect_binary, recipe_from_module
+from leakpro.webapp.backend.dataset_modules import register_job_dataset_modules
 from leakpro.utils.logger import logger
 
 DEFAULT_N_CONFIGS = 24
@@ -95,40 +96,10 @@ def write_status(out: Path, **fields: Any) -> None:
     (out / "status.json").write_text(json.dumps(json_safe(fields), indent=2))
 
 
-def _register_dataset_handler(job_dir: Path) -> None:
-    """Make a user-uploaded dataset_handler.py importable under its original name.
-
-    Population pickles reference the class path they were written with, so
-    unpickling fails unless that module name resolves. The audit worker solves
-    this the same way; the campaign has to, because it loads the same files.
-    """
-    path = job_dir / "dataset_handler.py"
-    if not path.exists():
-        return
-    spec = importlib.util.spec_from_file_location("dataset_handler", path)
-    if spec is None or spec.loader is None:
-        return
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    sys.modules.setdefault("dataset_handler", module)
-
-    # CelebADataHandler -> celebA_data_handler, CifarDataHandler -> cifar_data_handler
-    for attr in dir(module):
-        obj = getattr(module, attr, None)
-        if isinstance(obj, type) and hasattr(obj, "UserDataset") and attr != "AbstractInputHandler":
-            original = attr.replace("DataHandler", "_data_handler").replace("InputHandler", "_input_handler")
-            original = original[0].lower() + original[1:]
-            sys.modules.setdefault(original, module)
-            logger.info(f"Registered dataset_handler.py as '{original}' for unpickling.")
-
-
 def _load_dataset(data_path: str, job_dir: Path) -> tuple[torch.Tensor, torch.Tensor]:
     import joblib
 
-    _register_dataset_handler(job_dir)
-    # The job directory itself may hold the module a dataset was pickled from.
-    if str(job_dir) not in sys.path:
-        sys.path.insert(0, str(job_dir))
+    register_job_dataset_modules(job_dir)
     dataset = joblib.load(data_path)
     data = getattr(dataset, "data", None)
     targets = getattr(dataset, "targets", None)

--- a/leakpro/webapp/backend/pet_runner.py
+++ b/leakpro/webapp/backend/pet_runner.py
@@ -20,11 +20,19 @@ import argparse
 import importlib.util
 import json
 import math
+import os
 import pickle
 import sys
 import traceback
 from pathlib import Path
 from typing import Any
+
+# Set before torch touches CUDA. The spawner sets this too, but the runner is a
+# fresh process every launch, so setting it here means the fix cannot be defeated
+# by a stale (un-reloaded) backend. Lets CUDA grow its allocation instead of
+# pre-reserving fixed segments, which is the usual cause of a spurious OOM when
+# the campaign trains many models back to back.
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
 import numpy as np
 import torch
@@ -196,6 +204,32 @@ def _apply_advanced(space: KnobSpace, advanced: dict) -> KnobSpace:
     return space
 
 
+def _is_oom(exc: BaseException) -> bool:
+    """True for a CUDA out-of-memory error, however this torch version raises it."""
+    oom_type = getattr(torch.cuda, "OutOfMemoryError", ())
+    return isinstance(exc, oom_type) or "out of memory" in str(exc).lower()
+
+
+def _run_with_oom_backoff(build_fns, run, max_physical_batch: int, floor: int = 4):  # noqa: ANN001
+    """Run `run(train_fn, utility_fn, attack_fn)`, halving the batch cap on OOM.
+
+    The cap is a memory measure only, so shrinking it never changes a result.
+    The campaign resumes from its JSONL, so a retry re-runs only the config that
+    ran out of memory, not the whole sweep.
+    """
+    batch = max_physical_batch
+    while True:
+        try:
+            return run(*build_fns(batch))
+        except Exception as exc:  # noqa: BLE001
+            if not _is_oom(exc) or batch <= floor:
+                raise
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            batch = max(floor, batch // 2)
+            logger.warning(f"CUDA out of memory; retrying at max_physical_batch={batch}.")
+
+
 def run_campaign(job_dir: Path, model_name: str) -> None:
     """Run the whole sweep, then record the best trade-offs."""
     out = pet_dir(job_dir, model_name)
@@ -218,14 +252,20 @@ def run_campaign(job_dir: Path, model_name: str) -> None:
     write_status(out, status="running", model_name=model_name, n_configs=n_configs,
                  baseline_utility=model.get("test_accuracy"), resolution_warning=warning)
 
-    train_fn, utility_fn, attack_fn = build_campaign_fns(
-        recipe, splits, n_refs=n_refs, device=device,
-        utility_metric="accuracy",
-        delta=float(request.get("delta") or 1e-5),
-        max_physical_batch=max_physical_batch,
-    )
-    campaign = Campaign(train_fn, utility_fn, attack_fn, knob_space=space, output_dir=out, seed=int(job.get("seed", 0)))
-    records = campaign.run(n_configs)
+    delta = float(request.get("delta") or 1e-5)
+    seed = int(job.get("seed", 0))
+
+    def build_fns(batch: int):  # noqa: ANN202
+        return build_campaign_fns(
+            recipe, splits, n_refs=n_refs, device=device,
+            utility_metric="accuracy", delta=delta, max_physical_batch=batch,
+        )
+
+    def run_campaign_fns(train_fn, utility_fn, attack_fn):  # noqa: ANN001, ANN202
+        campaign = Campaign(train_fn, utility_fn, attack_fn, knob_space=space, output_dir=out, seed=seed)
+        return campaign.run(n_configs)
+
+    records = _run_with_oom_backoff(build_fns, run_campaign_fns, max_physical_batch)
 
     front = pareto_front(records)
     write_status(
@@ -255,16 +295,21 @@ def run_verification(job_dir: Path, model_name: str, index: int) -> None:
     max_physical_batch = int(request.get("max_physical_batch") or DEFAULT_MAX_PHYSICAL_BATCH)
     recipe, splits, _, _ = build(job, job_dir, model_name)
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    train_fn, utility_fn, attack_fn = build_campaign_fns(
-        recipe, splits, n_refs=VERIFY_N_REFS, device=device,
-        utility_metric="accuracy",
-        max_physical_batch=max_physical_batch,
-    )
-
     config = record["config"]
-    model = train_fn(config)
-    utility = float(utility_fn(model))
-    tpr, _, _ = tpr_at_fpr(attack_fn(model, config), record.get("proxy_fpr", 0.01))
+
+    def build_fns(batch: int):  # noqa: ANN202
+        return build_campaign_fns(
+            recipe, splits, n_refs=VERIFY_N_REFS, device=device,
+            utility_metric="accuracy", max_physical_batch=batch,
+        )
+
+    def verify_once(train_fn, utility_fn, attack_fn):  # noqa: ANN001, ANN202
+        model = train_fn(config)
+        util = float(utility_fn(model))
+        tpr_val, _, _ = tpr_at_fpr(attack_fn(model, config), record.get("proxy_fpr", 0.01))
+        return util, tpr_val, getattr(model, "campaign_extras", {}).get("epsilon")
+
+    utility, tpr, epsilon = _run_with_oom_backoff(build_fns, verify_once, max_physical_batch)
 
     target.write_text(json.dumps(json_safe({
         "status": "done",
@@ -273,7 +318,7 @@ def run_verification(job_dir: Path, model_name: str, index: int) -> None:
         "verified": {
             "attack_tpr": tpr,
             "utility": utility,
-            "epsilon": getattr(model, "campaign_extras", {}).get("epsilon"),
+            "epsilon": epsilon,
         },
     }), indent=2))
     logger.info(f"Verified setting {index}: TPR {tpr:.4f} (search estimated {estimated['attack_tpr']}).")

--- a/leakpro/webapp/backend/pet_runner.py
+++ b/leakpro/webapp/backend/pet_runner.py
@@ -1,0 +1,302 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Detached entry point for a webapp PET optimization run.
+
+Run as a subprocess, never on the API's thread pool. A campaign is
+``n_configs x (1 + n_refs)`` full trainings, which is minutes for a logistic
+regression and hours for anything convolutional, and the API demotes any job
+still marked running to failed when it restarts. Keeping the work in its own
+process means a restart costs nothing: ``Campaign`` appends one JSON line per
+evaluated setting and resumes from that file, so killing the process is also
+how cancellation works.
+
+Usage:
+    python -m leakpro.webapp.backend.pet_runner <job_dir> <model_name> [--verify N]
+"""
+
+import argparse
+import importlib.util
+import json
+import math
+import pickle
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from leakpro.optimization import (
+    Campaign,
+    KnobSpace,
+    build_campaign_fns,
+    default_dpsgd_space,
+    pareto_front,
+    resolution_warning,
+    tpr_at_fpr,
+)
+from leakpro.optimization.adapters import carve_splits, detect_binary, recipe_from_module
+from leakpro.utils.logger import logger
+
+DEFAULT_N_CONFIGS = 24
+DEFAULT_N_REFS = 2
+DEFAULT_EPOCHS = 10
+
+# The verification pass exists because the search runs a deliberately cheap
+# attack. It re-attacks one setting with more reference models so the number
+# the user adopts is not the one the search guessed with.
+VERIFY_N_REFS = 6
+
+# The false-alarm rate every reported figure uses, search and verification
+# alike, so the two are directly comparable.
+PROXY_FPR = 0.01
+
+
+def pet_dir(job_dir: Path, model_name: str) -> Path:
+    """Where one model's campaign keeps its evaluations and status."""
+    return job_dir / "pet" / model_name
+
+
+def json_safe(value: Any) -> Any:  # noqa: ANN401
+    """Make a record safe for `JSON.parse`.
+
+    Python writes a bare ``Infinity`` for ``float("inf")``, which every browser
+    rejects. The non-private anchor records exactly that as its epsilon, so
+    without this the frontend cannot read the file at all.
+    """
+    if isinstance(value, dict):
+        return {k: json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_safe(v) for v in value]
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, (np.integer, np.floating)):
+        return json_safe(value.item())
+    return value
+
+
+def write_status(out: Path, **fields: Any) -> None:
+    """Overwrite status.json; the API reads this rather than tracking the process."""
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "status.json").write_text(json.dumps(json_safe(fields), indent=2))
+
+
+def _register_dataset_handler(job_dir: Path) -> None:
+    """Make a user-uploaded dataset_handler.py importable under its original name.
+
+    Population pickles reference the class path they were written with, so
+    unpickling fails unless that module name resolves. The audit worker solves
+    this the same way; the campaign has to, because it loads the same files.
+    """
+    path = job_dir / "dataset_handler.py"
+    if not path.exists():
+        return
+    spec = importlib.util.spec_from_file_location("dataset_handler", path)
+    if spec is None or spec.loader is None:
+        return
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules.setdefault("dataset_handler", module)
+
+    # CelebADataHandler -> celebA_data_handler, CifarDataHandler -> cifar_data_handler
+    for attr in dir(module):
+        obj = getattr(module, attr, None)
+        if isinstance(obj, type) and hasattr(obj, "UserDataset") and attr != "AbstractInputHandler":
+            original = attr.replace("DataHandler", "_data_handler").replace("InputHandler", "_input_handler")
+            original = original[0].lower() + original[1:]
+            sys.modules.setdefault(original, module)
+            logger.info(f"Registered dataset_handler.py as '{original}' for unpickling.")
+
+
+def _load_dataset(data_path: str, job_dir: Path) -> tuple[torch.Tensor, torch.Tensor]:
+    import joblib
+
+    _register_dataset_handler(job_dir)
+    # The job directory itself may hold the module a dataset was pickled from.
+    if str(job_dir) not in sys.path:
+        sys.path.insert(0, str(job_dir))
+    dataset = joblib.load(data_path)
+    data = getattr(dataset, "data", None)
+    targets = getattr(dataset, "targets", None)
+    if data is None or targets is None:
+        raise ValueError(f"{data_path} has no .data/.targets; a campaign needs an indexable tensor dataset.")
+    x = data if isinstance(data, torch.Tensor) else torch.as_tensor(np.asarray(data))
+    y = targets if isinstance(targets, torch.Tensor) else torch.as_tensor(np.asarray(targets))
+    return x.float(), y
+
+
+def _init_params(model_dir: Path) -> dict:
+    meta_path = model_dir / "model_metadata.pkl"
+    if not meta_path.exists():
+        return {}
+    try:
+        with meta_path.open("rb") as f:
+            meta = pickle.load(f)  # noqa: S301
+    except Exception:  # noqa: BLE001
+        return {}
+    params = getattr(meta, "init_params", None)
+    if params is None and isinstance(meta, dict):
+        params = meta.get("init_params")
+    return dict(params or {})
+
+
+def build(job: dict, job_dir: Path, model_name: str) -> tuple:
+    """Assemble (recipe, splits, knob_space, settings) from persisted job state."""
+    model = next((m for m in job.get("models", []) if m["name"] == model_name), None)
+    if model is None:
+        raise KeyError(f"Job has no model named '{model_name}'.")
+
+    data_path = job.get("data_path")
+    if not data_path or not Path(data_path).exists():
+        raise FileNotFoundError("The job's dataset is missing; a campaign retrains from it.")
+
+    arch = job_dir / "arch.py"
+    if not arch.exists():
+        raise FileNotFoundError("arch.py is missing; a campaign needs the architecture to retrain.")
+
+    x, y = _load_dataset(data_path, job_dir)
+    train_params = model.get("train_params") or {}
+    model_class = model.get("model_class") or job.get("model_class")
+    init_params = _init_params(job_dir / "models" / model_name)
+
+    # The head shape decides the loss, the label dtype and how the attack reads
+    # confidences, so ask the model rather than guessing from the class count.
+    binary = detect_binary(arch, x, model_class, init_params)
+    y = y.float() if binary else y.long()
+
+    recipe = recipe_from_module(
+        module_path=arch,
+        x=x,
+        y=y,
+        epochs=int(train_params.get("epochs") or DEFAULT_EPOCHS),
+        model_class=model_class,
+        init_params=init_params,
+        optimizer_name=str(train_params.get("optimizer") or "adam").lower(),
+        binary=binary,
+    )
+    splits = carve_splits(x, y, seed=int(job.get("seed", 0)))
+    return recipe, splits, default_dpsgd_space(), model
+
+
+def _apply_advanced(space: KnobSpace, advanced: dict) -> KnobSpace:
+    """Pin any knob the user typed a value for; the rest stay searched."""
+    for name, value in (advanced or {}).items():
+        if value is None:
+            continue
+        try:
+            space = space.fix(name, float(value))
+        except KeyError:
+            logger.warning(f"Ignoring unknown knob '{name}'.")
+    return space
+
+
+def run_campaign(job_dir: Path, model_name: str) -> None:
+    """Run the whole sweep, then record the best trade-offs."""
+    out = pet_dir(job_dir, model_name)
+    job = json.loads((job_dir / "state.json").read_text())
+    request = json.loads((out / "request.json").read_text()) if (out / "request.json").exists() else {}
+    n_configs = int(request.get("n_configs") or DEFAULT_N_CONFIGS)
+    n_refs = int(request.get("n_refs") or DEFAULT_N_REFS)
+
+    recipe, splits, space, model = build(job, job_dir, model_name)
+    space = _apply_advanced(space, request.get("advanced") or {})
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    # Say so up front when the audit set cannot resolve the reported FPR:
+    # a frontier drawn from a handful of events looks identical to a real one.
+    warning = resolution_warning(len(splits["audit_nonmembers"]), PROXY_FPR)
+    if warning:
+        logger.warning(warning)
+
+    write_status(out, status="running", model_name=model_name, n_configs=n_configs,
+                 baseline_utility=model.get("test_accuracy"), resolution_warning=warning)
+
+    train_fn, utility_fn, attack_fn = build_campaign_fns(
+        recipe, splits, n_refs=n_refs, device=device,
+        utility_metric="auc" if recipe.output_kind != "logits" else "accuracy",
+        delta=float(request.get("delta") or 1e-5),
+    )
+    campaign = Campaign(train_fn, utility_fn, attack_fn, knob_space=space, output_dir=out, seed=int(job.get("seed", 0)))
+    records = campaign.run(n_configs)
+
+    front = pareto_front(records)
+    write_status(
+        out, status="done", model_name=model_name, n_configs=n_configs,
+        baseline_utility=model.get("test_accuracy"),
+        best_indices=[r["index"] for r in front],
+        resolution_warning=warning,
+    )
+    logger.info(f"Campaign finished: {len(records)} settings, {len(front)} on the frontier.")
+
+
+def run_verification(job_dir: Path, model_name: str, index: int) -> None:
+    """Re-measure one setting with a stronger attack than the search used."""
+    out = pet_dir(job_dir, model_name)
+    job = json.loads((job_dir / "state.json").read_text())
+    target = out / f"verification_{index}.json"
+
+    records = [json.loads(line) for line in (out / "evaluations.jsonl").read_text().splitlines() if line.strip()]
+    record = next((r for r in records if r["index"] == index), None)
+    if record is None:
+        raise KeyError(f"No evaluated setting with index {index}.")
+
+    estimated = {"attack_tpr": record.get("attack_tpr"), "utility": record["utility"]}
+    target.write_text(json.dumps(json_safe({"status": "running", "index": index, "estimated": estimated}), indent=2))
+
+    recipe, splits, _, _ = build(job, job_dir, model_name)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    train_fn, utility_fn, attack_fn = build_campaign_fns(
+        recipe, splits, n_refs=VERIFY_N_REFS, device=device,
+        utility_metric="auc" if recipe.output_kind != "logits" else "accuracy",
+    )
+
+    config = record["config"]
+    model = train_fn(config)
+    utility = float(utility_fn(model))
+    tpr, _, _ = tpr_at_fpr(attack_fn(model, config), record.get("proxy_fpr", 0.01))
+
+    target.write_text(json.dumps(json_safe({
+        "status": "done",
+        "index": index,
+        "estimated": estimated,
+        "verified": {
+            "attack_tpr": tpr,
+            "utility": utility,
+            "epsilon": getattr(model, "campaign_extras", {}).get("epsilon"),
+        },
+    }), indent=2))
+    logger.info(f"Verified setting {index}: TPR {tpr:.4f} (search estimated {estimated['attack_tpr']}).")
+
+
+def main() -> None:
+    """Dispatch to a campaign or a single verification, recording failures either way."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("job_dir")
+    parser.add_argument("model_name")
+    parser.add_argument("--verify", type=int, default=None)
+    args = parser.parse_args()
+
+    job_dir = Path(args.job_dir)
+    out = pet_dir(job_dir, args.model_name)
+    try:
+        if args.verify is None:
+            run_campaign(job_dir, args.model_name)
+        else:
+            run_verification(job_dir, args.model_name, args.verify)
+    except Exception as exc:  # noqa: BLE001
+        detail = f"{exc}\n{traceback.format_exc()}"
+        logger.error(f"PET run failed: {detail}")
+        if args.verify is None:
+            write_status(out, status="failed", model_name=args.model_name, error=str(exc))
+        else:
+            (out / f"verification_{args.verify}.json").write_text(
+                json.dumps({"status": "failed", "index": args.verify,
+                            "estimated": {"attack_tpr": None, "utility": None}, "error": str(exc)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/leakpro/webapp/backend/pet_runner.py
+++ b/leakpro/webapp/backend/pet_runner.py
@@ -306,22 +306,30 @@ def run_verification(job_dir: Path, model_name: str, index: int) -> None:
     def verify_once(train_fn, utility_fn, attack_fn):  # noqa: ANN001, ANN202
         model = train_fn(config)
         util = float(utility_fn(model))
-        tpr_val, _, _ = tpr_at_fpr(attack_fn(model, config), record.get("proxy_fpr", 0.01))
-        return util, tpr_val, getattr(model, "campaign_extras", {}).get("epsilon")
+        measured = tpr_at_fpr(attack_fn(model, config), record.get("proxy_fpr", PROXY_FPR))
+        return util, measured, getattr(model, "campaign_extras", {}).get("epsilon")
 
-    utility, tpr, epsilon = _run_with_oom_backoff(build_fns, verify_once, max_physical_batch)
+    utility, measured, epsilon = _run_with_oom_backoff(build_fns, verify_once, max_physical_batch)
 
     target.write_text(json.dumps(json_safe({
         "status": "done",
         "index": index,
         "estimated": estimated,
         "verified": {
-            "attack_tpr": tpr,
+            "attack_tpr": measured.tpr,
             "utility": utility,
             "epsilon": epsilon,
+            # The operating point behind the verified number. Without it the UI
+            # cannot tell a resolved measurement from one the audit set was too
+            # coarse to resolve — both arrive as a bare TPR.
+            "realized_fpr": measured.realized_fpr,
+            "resolution_warning": measured.warning,
         },
     }), indent=2))
-    logger.info(f"Verified setting {index}: TPR {tpr:.4f} (search estimated {estimated['attack_tpr']}).")
+    if measured.warning:
+        logger.warning(f"Verification of setting {index}: {measured.warning}")
+    logger.info(f"Verified setting {index}: TPR {measured.tpr:.4f} at realized FPR "
+                f"{measured.realized_fpr:.2%} (search estimated {estimated['attack_tpr']}).")
 
 
 def main() -> None:

--- a/leakpro/webapp/backend/pet_runner.py
+++ b/leakpro/webapp/backend/pet_runner.py
@@ -44,6 +44,9 @@ from leakpro.utils.logger import logger
 DEFAULT_N_CONFIGS = 24
 DEFAULT_N_REFS = 2
 DEFAULT_EPOCHS = 10
+# Per-sample-gradient memory cap under DP-SGD. 256 fits a small model but OOMs a
+# ResNet on a 24 GB card; 32 is the safe webapp default. Speed only, not accounting.
+DEFAULT_MAX_PHYSICAL_BATCH = 32
 
 # The verification pass exists because the search runs a deliberately cheap
 # attack. It re-attacks one setting with more reference models so the number
@@ -200,6 +203,7 @@ def run_campaign(job_dir: Path, model_name: str) -> None:
     request = json.loads((out / "request.json").read_text()) if (out / "request.json").exists() else {}
     n_configs = int(request.get("n_configs") or DEFAULT_N_CONFIGS)
     n_refs = int(request.get("n_refs") or DEFAULT_N_REFS)
+    max_physical_batch = int(request.get("max_physical_batch") or DEFAULT_MAX_PHYSICAL_BATCH)
 
     recipe, splits, space, model = build(job, job_dir, model_name)
     space = _apply_advanced(space, request.get("advanced") or {})
@@ -216,8 +220,9 @@ def run_campaign(job_dir: Path, model_name: str) -> None:
 
     train_fn, utility_fn, attack_fn = build_campaign_fns(
         recipe, splits, n_refs=n_refs, device=device,
-        utility_metric="auc" if recipe.output_kind != "logits" else "accuracy",
+        utility_metric="accuracy",
         delta=float(request.get("delta") or 1e-5),
+        max_physical_batch=max_physical_batch,
     )
     campaign = Campaign(train_fn, utility_fn, attack_fn, knob_space=space, output_dir=out, seed=int(job.get("seed", 0)))
     records = campaign.run(n_configs)
@@ -246,11 +251,14 @@ def run_verification(job_dir: Path, model_name: str, index: int) -> None:
     estimated = {"attack_tpr": record.get("attack_tpr"), "utility": record["utility"]}
     target.write_text(json.dumps(json_safe({"status": "running", "index": index, "estimated": estimated}), indent=2))
 
+    request = json.loads((out / "request.json").read_text()) if (out / "request.json").exists() else {}
+    max_physical_batch = int(request.get("max_physical_batch") or DEFAULT_MAX_PHYSICAL_BATCH)
     recipe, splits, _, _ = build(job, job_dir, model_name)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     train_fn, utility_fn, attack_fn = build_campaign_fns(
         recipe, splits, n_refs=VERIFY_N_REFS, device=device,
-        utility_metric="auc" if recipe.output_kind != "logits" else "accuracy",
+        utility_metric="accuracy",
+        max_physical_batch=max_physical_batch,
     )
 
     config = record["config"]

--- a/leakpro/webapp/backend/worker.py
+++ b/leakpro/webapp/backend/worker.py
@@ -401,6 +401,14 @@ def run_audit_job(
                     "n_samples":          _dm.get("n_samples"),
                 } if (_tp or _hc or _dm) else None
 
+                # Training-set size of the target, needed by leakpro.risk to scale exposure to the
+                # population. Read from the handler while it is still alive; saved results cannot
+                # recover it.
+                try:
+                    _num_train = int(lp.handler.target_model_metadata.num_train)
+                except Exception:  # noqa: BLE001 - metadata is optional for non-MIA handlers
+                    _num_train = None
+
                 model_results = {
                     "model_name": model_name,
                     "source": model_spec.get("source", "trained"),
@@ -410,6 +418,7 @@ def run_audit_job(
                     "test_accuracy": model_spec.get("test_accuracy"),
                     "model_class": _model_class,
                     "train_meta": _train_meta,
+                    "num_train": _num_train,
                     "attacks": [_serialise_result(r) for r in results],
                 }
                 all_results.append(model_results)

--- a/leakpro/webapp/backend/worker.py
+++ b/leakpro/webapp/backend/worker.py
@@ -12,6 +12,8 @@ import yaml
 from pathlib import Path
 from typing import Any
 
+from leakpro.webapp.backend.dataset_modules import register_job_dataset_modules
+
 logger = logging.getLogger("leakpro.webapp.worker")
 
 
@@ -292,29 +294,13 @@ def run_audit_job(
                 if str(_LEAKPRO_ROOT) not in sys.path:
                     sys.path.insert(0, str(_LEAKPRO_ROOT))
 
-                # Register dataset_handler.py under its original module name so joblib can
-                # deserialise population pickles that reference the original class path.
-                # Original name is inferred from the handler class name:
-                #   CelebADataHandler → celebA_data_handler
-                #   CifarDataHandler  → cifar_data_handler
-                _dh_path = job_dir / "dataset_handler.py"
-                if _dh_path.exists():
-                    import importlib.util as _ilu_dh
-                    _dh_spec = _ilu_dh.spec_from_file_location("dataset_handler", _dh_path)
-                    _dh_mod = _ilu_dh.module_from_spec(_dh_spec)
-                    _dh_spec.loader.exec_module(_dh_mod)
-                    sys.modules["dataset_handler"] = _dh_mod
-                    for _attr in dir(_dh_mod):
-                        _obj = getattr(_dh_mod, _attr, None)
-                        if (isinstance(_obj, type)
-                                and hasattr(_obj, "UserDataset")
-                                and _attr not in ("AbstractInputHandler", "object")):
-                            _orig = _attr.replace("DataHandler", "_data_handler") \
-                                        .replace("InputHandler", "_input_handler")
-                            _orig = _orig[0].lower() + _orig[1:]
-                            if _orig not in sys.modules:
-                                sys.modules[_orig] = _dh_mod
-                                log_q.put(f"[worker] Registered dataset_handler.py as '{_orig}' for pickle deserialization")
+                # Register dataset_handler.py under the module names the job's
+                # pickles were written with. One implementation, shared with the
+                # PET runner and the sample-data endpoints — three copies of
+                # this drifted apart before, and the endpoints' copy only
+                # existed because images broke for models loaded from an
+                # earlier session.
+                register_job_dataset_modules(job_dir)
 
                 # Stub out leakpro.dataset so joblib can deserialise old GeneralDataset pickles.
                 # MIAHandler._load_population accesses .data and .targets; the old class stored

--- a/leakpro/webapp/frontend/node_modules
+++ b/leakpro/webapp/frontend/node_modules
@@ -1,0 +1,1 @@
+/home/fazeleh/LeakPro/leakpro/webapp/frontend/node_modules

--- a/leakpro/webapp/frontend/src/api.ts
+++ b/leakpro/webapp/frontend/src/api.ts
@@ -271,6 +271,8 @@ export interface OptimizationRun {
   /** Unprotected quality this run is measured against, 0..1. */
   baseline_utility?: number;
   max_quality_loss?: number;
+  /** Set when the audit set is too small for the reported figure to mean much. */
+  resolution_warning?: string;
   error?: string;
 }
 

--- a/leakpro/webapp/frontend/src/api.ts
+++ b/leakpro/webapp/frontend/src/api.ts
@@ -84,6 +84,9 @@ export const api = {
 
   // Step 7
   getResults: (id: string) => get<{ job_id: string; results: ModelResult[] }>(`/jobs/${id}/results`),
+  // Risk assessment. All scoring happens in leakpro/risk on the backend; this posts the declared
+  // use-case profile and renders whatever comes back.
+  assessRisk: (id: string, profile: RiskRequest) => post<RiskResponse>(`/jobs/${id}/risk`, profile),
   getSampleData: (jobId: string, index: number) =>
     get<{ index: number; label: number; features: number[]; feature_names?: string[] }>(`/jobs/${jobId}/sample_data/${index}`),
 };
@@ -204,5 +207,67 @@ export interface ModelResult {
   model_class?: string;
   job_id?: string;
   train_meta?: TrainMeta;
+  num_train?: number;
   attacks: AttackResult[];
+}
+
+// ---------------------------------------------------------------------------
+// Risk assessment (mirrors leakpro/risk/schemas.py and backend models.py)
+// ---------------------------------------------------------------------------
+
+/** Declared harm parameters. Field names follow Sion et al.'s Loss Magnitude decomposition. */
+export interface RiskRequest {
+  model_name?: string;
+  tolerated_fpr: number;          // alpha; required on purpose, no default
+  attacker_prior?: number;        // pi
+  n_subjects?: number;            // NDS
+  records_per_subject?: number;   // NR
+  data_type_sensitivity?: number; // DTS
+  subject_type_weight?: number;   // DST
+  cost_per_exposed_subject?: number;
+  extrapolate_to_population?: boolean;
+  notes?: string;
+}
+
+export interface RiskMeasured {
+  attack_name: string;
+  operating_point: number;
+  success_rate: number;
+  advantage: number;
+  lift: number;
+  resolvable: boolean;
+  roc_auc?: number;
+  n_members_audit: number;
+  n_non_members_audit: number;
+  n_exposed_audit?: number;
+  min_resolvable_fpr: number;
+}
+
+export interface RiskCombined {
+  ppv?: number;
+  ppv_balanced?: number;
+  gamma: number;
+  loss_magnitude?: number;
+  loss_event_frequency: number;
+  risk?: number;
+  expected_exposed_subjects?: number;
+  expected_cost?: number;
+  extrapolated_exposed_records?: number;
+  vulnerability_band?: string;
+}
+
+export interface RiskAssessment {
+  measured: RiskMeasured;
+  declared: Record<string, unknown> & { n_subjects?: number; n_subjects_source: string; attacker_prior: number };
+  combined: RiskCombined;
+  assumptions: string[];
+  warnings: string[];
+  policy_version: string;
+  leakpro_version: string;
+}
+
+export interface RiskResponse {
+  job_id: string;
+  assessments: Record<string, RiskAssessment>;
+  unassessable: Record<string, string>;
 }

--- a/leakpro/webapp/frontend/src/api.ts
+++ b/leakpro/webapp/frontend/src/api.ts
@@ -219,6 +219,8 @@ export interface ModelResult {
   attacks: AttackResult[];
   /** Set when this row came from an adopted optimization result. */
   optimized?: boolean;
+  /** Original backend name, kept when the compare view renames a row for display. */
+  orig_model_name?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/leakpro/webapp/frontend/src/api.ts
+++ b/leakpro/webapp/frontend/src/api.ts
@@ -249,6 +249,15 @@ export interface Setting {
   attack_tpr_ci95?: [number, number];
   /** False-alarm rate the attack figure was measured at (0.01 == 1%). */
   proxy_fpr?: number;
+  /** The false-alarm rate actually achievable in the data, which can be below
+   *  `proxy_fpr` when the score distribution is coarse. */
+  attack_realized_fpr?: number;
+  attack_threshold?: number;
+  /** Set when the reported TPR is interpolated rather than observed: the audit
+   *  set could not resolve this operating point. Not evidence of privacy. */
+  attack_resolution_warning?: string | null;
+  /** Distinct nonmember score values — few means a saturated model. */
+  attack_distinct_nonmember_scores?: number;
   epsilon?: number;
   delta?: number;
   /** Present when the run skipped the attack for this setting. */
@@ -282,6 +291,12 @@ export interface Verification {
   status: "running" | "done" | "failed";
   index: number;
   estimated: { attack_tpr: number; utility: number };
-  verified?: { attack_tpr: number; utility: number; epsilon?: number };
+  verified?: {
+    attack_tpr: number;
+    utility: number;
+    epsilon?: number;
+    realized_fpr?: number;
+    resolution_warning?: string | null;
+  };
   error?: string;
 }

--- a/leakpro/webapp/frontend/src/api.ts
+++ b/leakpro/webapp/frontend/src/api.ts
@@ -86,6 +86,18 @@ export const api = {
   getResults: (id: string) => get<{ job_id: string; results: ModelResult[] }>(`/jobs/${id}/results`),
   getSampleData: (jobId: string, index: number) =>
     get<{ index: number; label: number; features: number[]; feature_names?: string[] }>(`/jobs/${jobId}/sample_data/${index}`),
+
+  // PET optimization
+  startOptimization: (id: string, model: string, params: OptimizationParams) =>
+    post<{ ok: boolean }>(`/jobs/${id}/pet/start?model_name=${encodeURIComponent(model)}`, params),
+  getOptimization: (id: string, model: string) =>
+    get<OptimizationRun>(`/jobs/${id}/pet/campaign?model_name=${encodeURIComponent(model)}`),
+  verifySetting: (id: string, model: string, index: number) =>
+    post<Verification>(`/jobs/${id}/pet/verify?model_name=${encodeURIComponent(model)}`, { index }),
+  getVerification: (id: string, model: string, index: number) =>
+    get<Verification>(`/jobs/${id}/pet/verify?model_name=${encodeURIComponent(model)}&index=${index}`),
+  adoptSetting: (id: string, model: string, index: number) =>
+    post<{ ok: boolean }>(`/jobs/${id}/pet/adopt?model_name=${encodeURIComponent(model)}`, { index }),
 };
 
 // ---------------------------------------------------------------------------
@@ -205,4 +217,67 @@ export interface ModelResult {
   job_id?: string;
   train_meta?: TrainMeta;
   attacks: AttackResult[];
+  /** Set when this row came from an adopted optimization result. */
+  optimized?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// PET optimization
+//
+// One Setting == one evaluated configuration, mirroring a line of the
+// campaign's evaluations.jsonl. Field names follow that file so the backend
+// can serve records without reshaping them.
+// ---------------------------------------------------------------------------
+
+export interface SettingConfig {
+  noise_multiplier?: number;
+  max_grad_norm?: number;
+  learning_rate?: number;
+  batch_size?: number;
+  [knob: string]: number | undefined;
+}
+
+export interface Setting {
+  index: number;
+  config: SettingConfig;
+  /** Task performance, 0..1. Higher is better. */
+  utility: number;
+  /** Attack success at `proxy_fpr`, 0..1. Lower is safer. Absent if not attacked. */
+  attack_tpr?: number;
+  attack_tpr_ci95?: [number, number];
+  /** False-alarm rate the attack figure was measured at (0.01 == 1%). */
+  proxy_fpr?: number;
+  epsilon?: number;
+  delta?: number;
+  /** Present when the run skipped the attack for this setting. */
+  attack_skipped?: string;
+}
+
+export interface OptimizationParams {
+  /** Fraction of baseline quality the user is willing to give up, 0..1. */
+  max_quality_loss: number;
+  /** Optional overrides; omitted keys keep the campaign's own defaults. */
+  advanced?: Record<string, number>;
+}
+
+export interface OptimizationRun {
+  status: "idle" | "running" | "done" | "failed";
+  model_name: string;
+  /** Total settings the run intends to test; absent until the run reports it. */
+  n_configs?: number;
+  settings: Setting[];
+  /** Indices of the best trade-offs, ascending by utility. */
+  best_indices: number[];
+  /** Unprotected quality this run is measured against, 0..1. */
+  baseline_utility?: number;
+  max_quality_loss?: number;
+  error?: string;
+}
+
+export interface Verification {
+  status: "running" | "done" | "failed";
+  index: number;
+  estimated: { attack_tpr: number; utility: number };
+  verified?: { attack_tpr: number; utility: number; epsilon?: number };
+  error?: string;
 }

--- a/leakpro/webapp/frontend/src/components/InfoButton.tsx
+++ b/leakpro/webapp/frontend/src/components/InfoButton.tsx
@@ -79,3 +79,21 @@ export default function InfoButton({
     </>
   );
 }
+
+/**
+ * Progressive disclosure inside an info modal: a one-line lead stays visible, the depth is one click
+ * further in. Native details/summary so there is no state to manage and it stays keyboard-accessible.
+ */
+export function Detail({ children, label = "More detail" }: { children: React.ReactNode; label?: string }) {
+  return (
+    <details className="group">
+      <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden text-xs font-bold text-primary hover:underline">
+        {label}
+        <span className="material-symbols-outlined align-middle text-sm ml-0.5 group-open:rotate-180 transition-transform">
+          expand_more
+        </span>
+      </summary>
+      <div className="mt-2 flex flex-col gap-2 text-slate-500 dark:text-slate-300">{children}</div>
+    </details>
+  );
+}

--- a/leakpro/webapp/frontend/src/components/InfoButton.tsx
+++ b/leakpro/webapp/frontend/src/components/InfoButton.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import ReactDOM from "react-dom";
+
+/**
+ * A small info affordance: an unobtrusive icon that opens a modal with the long explanation.
+ *
+ * The point is to keep prose out of the first view. Anything that would make a panel feel like
+ * documentation belongs behind one of these, not inline.
+ */
+export default function InfoButton({
+  label,
+  title,
+  children,
+  className = "",
+}: {
+  /** Short name of the thing being explained. Used for the tooltip and the aria-label. */
+  label: string;
+  /** Modal heading. Defaults to the label. */
+  title?: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={`About ${label}`}
+        title={label}
+        onClick={(e) => { e.stopPropagation(); setOpen(true); }}
+        className={`material-symbols-outlined align-middle text-slate-400 hover:text-primary transition-colors leading-none ${className}`}
+        style={{ fontSize: "1rem" }}
+      >
+        info
+      </button>
+
+      {open && ReactDOM.createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-white dark:bg-surface rounded-2xl shadow-2xl w-full max-w-2xl flex flex-col overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-surface-border">
+              <h3 className="font-bold text-lg">{title ?? label}</h3>
+              <button
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                className="text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+              >
+                <span className="material-symbols-outlined">close</span>
+              </button>
+            </div>
+            <div className="px-6 py-5 overflow-y-auto max-h-[70vh] text-sm text-slate-600 dark:text-slate-200 flex flex-col gap-3">
+              {children}
+            </div>
+            <div className="flex justify-end px-6 py-4 border-t border-slate-200 dark:border-surface-border">
+              <button
+                onClick={() => setOpen(false)}
+                className="px-5 py-2 rounded-lg bg-slate-700 text-cream border border-primary text-sm font-bold hover:bg-slate-600 transition-colors"
+              >
+                Got it
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/leakpro/webapp/frontend/src/components/results/Optimization.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Optimization.tsx
@@ -505,6 +505,14 @@ function SettingPanel({
                 {COPY.optimistic}
               </div>
             )}
+            {/* A low attack number can mean "well protected" or "we could not
+                measure it". Those must never look the same to the reader. */}
+            {verification.verified.resolution_warning && (
+              <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400 flex items-start gap-2">
+                <span className="material-symbols-outlined text-sm shrink-0">help</span>
+                <span><span className="font-bold">{COPY.notMeasurable}</span> {COPY.notMeasurableHelp}</span>
+              </div>
+            )}
             <div className="grid grid-cols-2 gap-3">
               <StatCard label={`${COPY.estimate} — attack`} value={`${(verification.estimated.attack_tpr * 100).toFixed(2)}%`} />
               <StatCard

--- a/leakpro/webapp/frontend/src/components/results/Optimization.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Optimization.tsx
@@ -328,6 +328,13 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
 
           {phase === "done" && <p className="text-sm text-slate-500">{COPY.resultsBlurb}</p>}
 
+          {run?.resolution_warning && (
+            <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 dark:text-amber-400 flex items-start gap-2">
+              <span className="material-symbols-outlined text-base shrink-0">warning</span>
+              <span><span className="font-bold">{COPY.lowResolution}</span> {run.resolution_warning}</span>
+            </div>
+          )}
+
           {run?.status === "failed" ? (
             <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-500">
               {run.error ?? COPY.failed}

--- a/leakpro/webapp/frontend/src/components/results/Optimization.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Optimization.tsx
@@ -49,19 +49,21 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
     run == null || run.status === "idle" ? "setup" : run.status === "running" ? "running" : "done";
 
   // ── polling ──────────────────────────────────────────────────────────────
-  const poll = useCallback(async () => {
+  // `silent` covers the first look: a model that has never been optimized has
+  // no run to fetch, which is the normal starting state, not a failure.
+  const poll = useCallback(async (silent = false) => {
     try {
       setRun(await api.getOptimization(jobId, model.model_name));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      if (!silent) setError(e instanceof Error ? e.message : String(e));
     }
   }, [jobId, model.model_name]);
 
-  useEffect(() => { poll(); }, [poll]);
+  useEffect(() => { poll(true); }, [poll]);
 
   useEffect(() => {
     if (run?.status !== "running") return;
-    pollRef.current = setInterval(poll, POLL_MS);
+    pollRef.current = setInterval(() => poll(true), POLL_MS);
     return () => { if (pollRef.current) clearInterval(pollRef.current); };
   }, [run?.status, poll]);
 

--- a/leakpro/webapp/frontend/src/components/results/Optimization.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Optimization.tsx
@@ -1,0 +1,519 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Plot from "react-plotly.js";
+import { api, ModelResult, OptimizationRun, Setting, Verification } from "../../api";
+import { COPY, tagsFor } from "./optimizationCopy";
+
+const ACCENT = "#193ce6";
+const TESTED = "#94a3b8";
+const POLL_MS = 2000;
+
+/** Relative worsening of attack success that makes an estimate "optimistic". */
+const OPTIMISTIC_MARGIN = 0.2;
+
+interface Props {
+  jobId: string;
+  model: ModelResult;
+  onBack: () => void;
+  onAdopted: (setting: Setting, verification: Verification) => void;
+}
+
+const pct = (v: number | undefined, digits = 1) =>
+  v === undefined ? "—" : `${(v * 100).toFixed(digits)}%`;
+
+/**
+ * Reduce the run's best settings to the 3-5 the view labels.
+ *
+ * The run returns however many are non-dominated, which can be one or twenty.
+ * Keep both ends of the trade-off and spread the rest evenly between them, so
+ * the labels always describe genuinely different choices.
+ */
+function pickHighlights(best: Setting[], max = 5): Setting[] {
+  if (best.length <= max) return best;
+  const step = (best.length - 1) / (max - 1);
+  return Array.from({ length: max }, (_, i) => best[Math.round(i * step)]);
+}
+
+export default function Optimization({ jobId, model, onBack, onAdopted }: Props) {
+  const [run, setRun] = useState<OptimizationRun | null>(null);
+  const [maxQualityLoss, setMaxQualityLoss] = useState(0.05);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [advanced, setAdvanced] = useState<Record<string, number>>({});
+  const [selected, setSelected] = useState<Setting | null>(null);
+  const [verification, setVerification] = useState<Verification | null>(null);
+  const [adopted, setAdopted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const phase: "setup" | "running" | "done" =
+    run == null || run.status === "idle" ? "setup" : run.status === "running" ? "running" : "done";
+
+  // ── polling ──────────────────────────────────────────────────────────────
+  const poll = useCallback(async () => {
+    try {
+      setRun(await api.getOptimization(jobId, model.model_name));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [jobId, model.model_name]);
+
+  useEffect(() => { poll(); }, [poll]);
+
+  useEffect(() => {
+    if (run?.status !== "running") return;
+    pollRef.current = setInterval(poll, POLL_MS);
+    return () => { if (pollRef.current) clearInterval(pollRef.current); };
+  }, [run?.status, poll]);
+
+  useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
+
+  const start = async () => {
+    setStarting(true);
+    setError(null);
+    try {
+      await api.startOptimization(jobId, model.model_name, { max_quality_loss: maxQualityLoss, advanced });
+      await poll();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  // ── derived ──────────────────────────────────────────────────────────────
+  const baseline = run?.baseline_utility ?? model.test_accuracy;
+  const qualityFloor = baseline !== undefined ? baseline * (1 - maxQualityLoss) : undefined;
+
+  const tested = useMemo(
+    () => (run?.settings ?? []).filter((s) => s.attack_tpr != null),
+    [run?.settings],
+  );
+
+  const highlights = useMemo(() => {
+    if (!run) return [];
+    const byIndex = new Map(run.settings.map((s) => [s.index, s]));
+    // Sorted safest-first so the tags line up with what they claim.
+    const best = run.best_indices
+      .map((i) => byIndex.get(i))
+      .filter((s): s is Setting => s != null && s.attack_tpr != null)
+      .sort((a, b) => a.attack_tpr! - b.attack_tpr!);
+    return pickHighlights(best);
+  }, [run]);
+
+  const tags = tagsFor(highlights.length);
+  const withinLimit = (s: Setting) => qualityFloor === undefined || s.utility >= qualityFloor;
+
+  // ── verification ─────────────────────────────────────────────────────────
+  const confirm = async (setting: Setting) => {
+    setAdopted(false);
+    setError(null);
+    try {
+      setVerification(await api.verifySetting(jobId, model.model_name, setting.index));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  useEffect(() => {
+    if (verification?.status !== "running" || !selected) return;
+    const id = setInterval(async () => {
+      try {
+        setVerification(await api.getVerification(jobId, model.model_name, selected.index));
+      } catch { /* keep the last state; the next tick retries */ }
+    }, POLL_MS);
+    return () => clearInterval(id);
+  }, [verification?.status, selected, jobId, model.model_name]);
+
+  const adopt = async () => {
+    if (!selected || !verification) return;
+    try {
+      await api.adoptSetting(jobId, model.model_name, selected.index);
+      setAdopted(true);
+      onAdopted(selected, verification);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const optimistic =
+    verification?.verified != null &&
+    verification.estimated.attack_tpr > 0 &&
+    verification.verified.attack_tpr > verification.estimated.attack_tpr * (1 + OPTIMISTIC_MARGIN);
+
+  // ── chart ────────────────────────────────────────────────────────────────
+  const highlightIndices = new Set(highlights.map((s) => s.index));
+  const backdrop = phase === "done" ? tested.filter((s) => !highlightIndices.has(s.index)) : tested;
+
+  const traces: Plotly.Data[] = [
+    {
+      x: backdrop.map((s) => s.attack_tpr! * 100),
+      y: backdrop.map((s) => s.utility * 100),
+      mode: "markers",
+      type: "scatter",
+      name: "Tested",
+      marker: {
+        size: 9,
+        color: phase === "done" ? TESTED : ACCENT,
+        opacity: phase === "done" ? 0.25 : 0.75,
+        line: { width: 0 },
+      },
+      hovertemplate: "Attack success %{x:.2f}%<br>Quality %{y:.2f}%<extra></extra>",
+    },
+  ];
+
+  if (phase === "done" && highlights.length > 0) {
+    traces.push({
+      x: highlights.map((s) => s.attack_tpr! * 100),
+      y: highlights.map((s) => s.utility * 100),
+      mode: "lines",
+      type: "scatter",
+      name: COPY.resultsTitle,
+      line: { color: ACCENT, width: 2 },
+      hoverinfo: "skip",
+      showlegend: false,
+    });
+    traces.push({
+      x: highlights.map((s) => s.attack_tpr! * 100),
+      y: highlights.map((s) => s.utility * 100),
+      text: highlights.map((_, i) => tags[i] ?? ""),
+      mode: "text+markers",
+      type: "scatter",
+      name: COPY.resultsTitle,
+      textposition: "top right",
+      textfont: { size: 12, color: ACCENT },
+      marker: {
+        size: 15,
+        color: ACCENT,
+        // plotly.js accepts a per-point opacity array here; its typings do not.
+        opacity: highlights.map((s) => (withinLimit(s) ? 1 : 0.3)) as unknown as number,
+        line: { width: 2, color: "#ffffff" },
+      },
+      customdata: highlights.map((s) => (withinLimit(s) ? "" : `<br><b>${COPY.exceedsLimit}</b>`)),
+      hovertemplate:
+        "Attack success %{x:.2f}%<br>Quality %{y:.2f}%%{customdata}<extra></extra>",
+    });
+  }
+
+  const shapes: Partial<Plotly.Shape>[] =
+    qualityFloor !== undefined && tested.length > 0
+      ? [{
+          type: "line", xref: "paper", x0: 0, x1: 1,
+          yref: "y", y0: qualityFloor * 100, y1: qualityFloor * 100,
+          line: { color: TESTED, width: 1, dash: "dash" },
+        }]
+      : [];
+
+  // ── render ───────────────────────────────────────────────────────────────
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-3xl font-black tracking-tight">{COPY.title}</h2>
+          <p className="text-slate-600 dark:text-slate-300 max-w-2xl">{COPY.intro}</p>
+          <p className="text-sm text-slate-400">
+            For <span className="font-semibold text-slate-600 dark:text-slate-300">{model.model_name}</span>
+          </p>
+        </div>
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg border border-slate-300 dark:border-slate-700 text-sm font-bold hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors shrink-0"
+        >
+          <span className="material-symbols-outlined text-base">arrow_back</span>
+          {COPY.back}
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-500">
+          {error}
+        </div>
+      )}
+
+      {/* Constraint — one control, everything else behind Advanced */}
+      <div className="rounded-xl border border-slate-200 dark:border-slate-800 p-5 flex flex-col gap-4">
+        <div className="flex items-center gap-6 flex-wrap">
+          <div className="flex-1 min-w-[280px]">
+            <label className="text-sm font-bold block mb-2">
+              {COPY.constraintLabel}:{" "}
+              <span className="text-primary font-mono">{(maxQualityLoss * 100).toFixed(0)}%</span>
+            </label>
+            <input
+              type="range" min={0} max={0.5} step={0.01}
+              value={maxQualityLoss}
+              onChange={(e) => setMaxQualityLoss(Number(e.target.value))}
+              className="w-full accent-primary"
+            />
+            <p className="text-xs text-slate-400 mt-1">{COPY.constraintHelp}</p>
+          </div>
+          <div className="flex gap-6 text-sm">
+            <div>
+              <p className="text-xs text-slate-400">{COPY.baselineLabel}</p>
+              <p className="font-mono font-bold text-lg">{pct(baseline)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-slate-400">{COPY.floorLabel}</p>
+              <p className="font-mono font-bold text-lg">{pct(qualityFloor)}</p>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <button
+            onClick={() => setAdvancedOpen(!advancedOpen)}
+            className="text-xs font-bold text-slate-500 hover:text-primary flex items-center gap-1 transition-colors"
+          >
+            <span className="material-symbols-outlined text-sm">
+              {advancedOpen ? "expand_less" : "expand_more"}
+            </span>
+            {COPY.advanced}
+          </button>
+          {advancedOpen && (
+            <div className="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <p className="col-span-full text-xs text-slate-400">{COPY.advancedHelp}</p>
+              {(["noise_multiplier", "max_grad_norm", "learning_rate", "batch_size"] as const).map((k) => (
+                <div key={k}>
+                  <label className="text-xs font-semibold text-slate-500 mb-1 block">{k}</label>
+                  <input
+                    type="number"
+                    placeholder="default"
+                    value={advanced[k] ?? ""}
+                    onChange={(e) => setAdvanced((prev) => {
+                      const next = { ...prev };
+                      if (e.target.value === "") delete next[k];
+                      else next[k] = Number(e.target.value);
+                      return next;
+                    })}
+                    className="w-full rounded border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-xs px-2 py-1.5 font-mono"
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {phase === "setup" && (
+          <button
+            onClick={start}
+            disabled={starting}
+            className="self-start px-8 py-2.5 rounded-lg bg-primary text-white font-bold hover:opacity-90 transition-opacity flex items-center gap-2 disabled:opacity-50"
+          >
+            <span className="material-symbols-outlined text-base">rocket_launch</span>
+            {starting ? "…" : COPY.start}
+          </button>
+        )}
+      </div>
+
+      {/* Progress + chart */}
+      {phase !== "setup" && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            {phase === "running" && (
+              <>
+                <span className="material-symbols-outlined text-primary animate-spin">sync</span>
+                <span className="font-semibold text-slate-600 dark:text-slate-300">{COPY.running}</span>
+              </>
+            )}
+            {phase === "done" && (
+              <>
+                <span className="material-symbols-outlined text-green-500">check_circle</span>
+                <span className="font-semibold">{COPY.resultsTitle}</span>
+              </>
+            )}
+            <span className="ml-auto text-sm font-mono text-slate-400">
+              {COPY.testedOf(tested.length, run?.n_configs)}
+            </span>
+          </div>
+
+          {phase === "done" && <p className="text-sm text-slate-500">{COPY.resultsBlurb}</p>}
+
+          {run?.status === "failed" ? (
+            <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-500">
+              {run.error ?? COPY.failed}
+            </div>
+          ) : tested.length === 0 && phase === "done" ? (
+            <p className="text-sm text-slate-400 italic">{COPY.noResults}</p>
+          ) : (
+            <>
+              <Plot
+                data={traces}
+                layout={{
+                  paper_bgcolor: "transparent",
+                  plot_bgcolor: "transparent",
+                  xaxis: { title: { text: COPY.axisAttack }, ticksuffix: "%", gridcolor: "#e2e8f0", rangemode: "tozero" },
+                  yaxis: { title: { text: COPY.axisQuality }, ticksuffix: "%", gridcolor: "#e2e8f0" },
+                  shapes,
+                  showlegend: false,
+                  margin: { t: 30, r: 40, b: 60, l: 60 },
+                  font: { family: "Inter, sans-serif", color: "#94a3b8" },
+                  hovermode: "closest",
+                  transition: { duration: 400, easing: "cubic-in-out" },
+                }}
+                config={{ responsive: true, displaylogo: false, modeBarButtons: [["toImage"]] }}
+                style={{ width: "100%", height: 440 }}
+                useResizeHandler
+                onClick={(e) => {
+                  // Only the highlighted trace is selectable; it is always drawn last.
+                  const point = e.points?.[0];
+                  if (point == null || point.curveNumber !== traces.length - 1) return;
+                  const hit = highlights[point.pointNumber];
+                  if (hit) { setSelected(hit); setVerification(null); setAdopted(false); }
+                }}
+              />
+              <p className="text-xs text-slate-400">{COPY.fprNote}</p>
+              {qualityFloor !== undefined && (
+                <p className="text-xs text-slate-400">
+                  <span className="inline-block w-6 border-t border-dashed border-slate-400 align-middle mr-1" />
+                  {COPY.qualityLimitLine} — {pct(qualityFloor)}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {selected && (
+        <SettingPanel
+          setting={selected}
+          verification={verification}
+          optimistic={!!optimistic}
+          adopted={adopted}
+          onClose={() => { setSelected(null); setVerification(null); setAdopted(false); }}
+          onConfirm={() => confirm(selected)}
+          onAdopt={adopt}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Side panel: the one place raw hyperparameters are appropriate.
+// ---------------------------------------------------------------------------
+
+function StatCard({ label, value, tone }: { label: string; value: string; tone?: "amber" }) {
+  return (
+    <div className={`rounded-lg px-4 py-3 border ${
+      tone === "amber"
+        ? "border-amber-500/40 bg-amber-500/10"
+        : "border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900"
+    }`}>
+      <p className="text-xs text-slate-400">{label}</p>
+      <p className="font-mono font-bold text-lg">{value}</p>
+    </div>
+  );
+}
+
+function SettingPanel({
+  setting, verification, optimistic, adopted, onClose, onConfirm, onAdopt,
+}: {
+  setting: Setting;
+  verification: Verification | null;
+  optimistic: boolean;
+  adopted: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  onAdopt: () => void;
+}) {
+  // The non-private anchor carries eps = inf, which JSON cannot represent: the
+  // backend has to send null (or a string) for it, so treat anything
+  // non-finite or absent as "no protection" rather than printing NaN.
+  const epsilon = setting.epsilon;
+  const epsilonLabel =
+    epsilon == null ? "none" : Number.isFinite(epsilon) ? epsilon.toFixed(2) : "none";
+
+  const rows: Array<[string, string]> = [
+    ["Privacy budget (ε)", epsilonLabel],
+    ["Noise multiplier", setting.config.noise_multiplier?.toFixed(3) ?? "—"],
+    ["Clipping norm", setting.config.max_grad_norm?.toFixed(3) ?? "—"],
+    ["Learning rate", setting.config.learning_rate?.toExponential(2) ?? "—"],
+    ["Batch size", setting.config.batch_size?.toString() ?? "—"],
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <aside className="relative w-full max-w-md h-full overflow-y-auto bg-white dark:bg-slate-900 border-l border-slate-200 dark:border-slate-800 p-6 flex flex-col gap-6">
+        <div className="flex items-start justify-between">
+          <h3 className="text-xl font-black">{COPY.panelTitle}</h3>
+          <button onClick={onClose} className="material-symbols-outlined text-slate-400 hover:text-slate-600">close</button>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <StatCard label={COPY.estimatedAttack} value={`${(setting.attack_tpr! * 100).toFixed(2)}%`} />
+          <StatCard label={COPY.estimatedQuality} value={`${(setting.utility * 100).toFixed(2)}%`} />
+        </div>
+
+        <div className="rounded-lg border border-slate-200 dark:border-slate-800 divide-y divide-slate-200 dark:divide-slate-800">
+          {rows.map(([label, value]) => (
+            <div key={label} className="flex items-center justify-between px-4 py-2.5 text-sm">
+              <span className="text-slate-500">{label}</span>
+              <span className="font-mono font-semibold">{value}</span>
+            </div>
+          ))}
+        </div>
+
+        {verification == null && (
+          <button
+            onClick={onConfirm}
+            className="px-6 py-2.5 rounded-lg bg-primary text-white font-bold hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+          >
+            <span className="material-symbols-outlined text-base">verified</span>
+            {COPY.confirm}
+          </button>
+        )}
+
+        {verification?.status === "running" && (
+          <div className="rounded-xl border border-slate-200 dark:border-slate-800 px-4 py-4 flex flex-col gap-2">
+            <div className="flex items-center gap-3">
+              <span className="material-symbols-outlined text-primary animate-spin">sync</span>
+              <span className="font-semibold text-sm">{COPY.verifying}</span>
+            </div>
+            <p className="text-xs text-slate-400">{COPY.verifyingHelp}</p>
+          </div>
+        )}
+
+        {verification?.status === "failed" && (
+          <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-500">
+            {verification.error ?? COPY.failed}
+          </div>
+        )}
+
+        {verification?.verified && (
+          <div className="flex flex-col gap-3">
+            {optimistic && (
+              <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs font-bold text-amber-600 dark:text-amber-400 flex items-center gap-2">
+                <span className="material-symbols-outlined text-sm">warning</span>
+                {COPY.optimistic}
+              </div>
+            )}
+            <div className="grid grid-cols-2 gap-3">
+              <StatCard label={`${COPY.estimate} — attack`} value={`${(verification.estimated.attack_tpr * 100).toFixed(2)}%`} />
+              <StatCard
+                label={`${COPY.verified} — attack`}
+                value={`${(verification.verified.attack_tpr * 100).toFixed(2)}%`}
+                tone={optimistic ? "amber" : undefined}
+              />
+              <StatCard label={`${COPY.estimate} — quality`} value={`${(verification.estimated.utility * 100).toFixed(2)}%`} />
+              <StatCard label={`${COPY.verified} — quality`} value={`${(verification.verified.utility * 100).toFixed(2)}%`} />
+            </div>
+
+            {adopted ? (
+              <p className="text-sm font-semibold text-green-600 dark:text-green-400 flex items-center gap-2">
+                <span className="material-symbols-outlined text-base">check_circle</span>
+                {COPY.adopted}
+              </p>
+            ) : (
+              <button
+                onClick={onAdopt}
+                className="px-6 py-2.5 rounded-lg bg-primary text-white font-bold hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+              >
+                <span className="material-symbols-outlined text-base">check</span>
+                {COPY.adopt}
+              </button>
+            )}
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/leakpro/webapp/frontend/src/components/results/Optimization.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Optimization.tsx
@@ -3,7 +3,7 @@ import Plot from "react-plotly.js";
 import { api, ModelResult, OptimizationRun, Setting, Verification } from "../../api";
 import { COPY, tagsFor } from "./optimizationCopy";
 
-const ACCENT = "#193ce6";
+const ACCENT = "#f5a623";
 const TESTED = "#94a3b8";
 const POLL_MS = 2000;
 
@@ -218,7 +218,7 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
         </div>
         <button
           onClick={onBack}
-          className="flex items-center gap-2 px-4 py-2 rounded-lg border border-slate-300 dark:border-slate-700 text-sm font-bold hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors shrink-0"
+          className="flex items-center gap-2 px-4 py-2 rounded-lg border border-slate-300 dark:border-surface-border text-sm font-bold hover:bg-slate-100 dark:hover:bg-surface-2 transition-colors shrink-0"
         >
           <span className="material-symbols-outlined text-base">arrow_back</span>
           {COPY.back}
@@ -232,7 +232,7 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
       )}
 
       {/* Constraint — one control, everything else behind Advanced */}
-      <div className="rounded-xl border border-slate-200 dark:border-slate-800 p-5 flex flex-col gap-4">
+      <div className="rounded-xl border border-slate-200 dark:border-surface-border p-5 flex flex-col gap-4">
         <div className="flex items-center gap-6 flex-wrap">
           <div className="flex-1 min-w-[280px]">
             <label className="text-sm font-bold block mb-2">
@@ -285,7 +285,7 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
                       else next[k] = Number(e.target.value);
                       return next;
                     })}
-                    className="w-full rounded border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-xs px-2 py-1.5 font-mono"
+                    className="w-full rounded border-slate-300 dark:border-surface-border bg-white dark:bg-surface text-xs px-2 py-1.5 font-mono"
                   />
                 </div>
               ))}
@@ -297,7 +297,7 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
           <button
             onClick={start}
             disabled={starting}
-            className="self-start px-8 py-2.5 rounded-lg bg-primary text-white font-bold hover:opacity-90 transition-opacity flex items-center gap-2 disabled:opacity-50"
+            className="self-start px-8 py-2.5 rounded-lg bg-slate-700 text-cream border border-primary font-bold hover:bg-slate-600 transition-colors flex items-center gap-2 disabled:opacity-50"
           >
             <span className="material-symbols-outlined text-base">rocket_launch</span>
             {starting ? "…" : COPY.start}
@@ -404,7 +404,7 @@ function StatCard({ label, value, tone }: { label: string; value: string; tone?:
     <div className={`rounded-lg px-4 py-3 border ${
       tone === "amber"
         ? "border-amber-500/40 bg-amber-500/10"
-        : "border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900"
+        : "border-slate-200 dark:border-surface-border bg-slate-50 dark:bg-surface"
     }`}>
       <p className="text-xs text-slate-400">{label}</p>
       <p className="font-mono font-bold text-lg">{value}</p>
@@ -441,7 +441,7 @@ function SettingPanel({
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
       <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
-      <aside className="relative w-full max-w-md h-full overflow-y-auto bg-white dark:bg-slate-900 border-l border-slate-200 dark:border-slate-800 p-6 flex flex-col gap-6">
+      <aside className="relative w-full max-w-md h-full overflow-y-auto bg-white dark:bg-surface border-l border-slate-200 dark:border-surface-border p-6 flex flex-col gap-6">
         <div className="flex items-start justify-between">
           <h3 className="text-xl font-black">{COPY.panelTitle}</h3>
           <button onClick={onClose} className="material-symbols-outlined text-slate-400 hover:text-slate-600">close</button>
@@ -452,7 +452,7 @@ function SettingPanel({
           <StatCard label={COPY.estimatedQuality} value={`${(setting.utility * 100).toFixed(2)}%`} />
         </div>
 
-        <div className="rounded-lg border border-slate-200 dark:border-slate-800 divide-y divide-slate-200 dark:divide-slate-800">
+        <div className="rounded-lg border border-slate-200 dark:border-surface-border divide-y divide-slate-200 dark:divide-surface-border">
           {rows.map(([label, value]) => (
             <div key={label} className="flex items-center justify-between px-4 py-2.5 text-sm">
               <span className="text-slate-500">{label}</span>
@@ -464,7 +464,7 @@ function SettingPanel({
         {verification == null && (
           <button
             onClick={onConfirm}
-            className="px-6 py-2.5 rounded-lg bg-primary text-white font-bold hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+            className="px-6 py-2.5 rounded-lg bg-slate-700 text-cream border border-primary font-bold hover:bg-slate-600 transition-colors flex items-center justify-center gap-2"
           >
             <span className="material-symbols-outlined text-base">verified</span>
             {COPY.confirm}
@@ -472,7 +472,7 @@ function SettingPanel({
         )}
 
         {verification?.status === "running" && (
-          <div className="rounded-xl border border-slate-200 dark:border-slate-800 px-4 py-4 flex flex-col gap-2">
+          <div className="rounded-xl border border-slate-200 dark:border-surface-border px-4 py-4 flex flex-col gap-2">
             <div className="flex items-center gap-3">
               <span className="material-symbols-outlined text-primary animate-spin">sync</span>
               <span className="font-semibold text-sm">{COPY.verifying}</span>
@@ -514,7 +514,7 @@ function SettingPanel({
             ) : (
               <button
                 onClick={onAdopt}
-                className="px-6 py-2.5 rounded-lg bg-primary text-white font-bold hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+                className="px-6 py-2.5 rounded-lg bg-slate-700 text-cream border border-primary font-bold hover:bg-slate-600 transition-colors flex items-center justify-center gap-2"
               >
                 <span className="material-symbols-outlined text-base">check</span>
                 {COPY.adopt}

--- a/leakpro/webapp/frontend/src/components/results/Optimization.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Optimization.tsx
@@ -34,6 +34,13 @@ function pickHighlights(best: Setting[], max = 5): Setting[] {
 }
 
 export default function Optimization({ jobId, model, onBack, onAdopted }: Props) {
+  // A model loaded from a previous session belongs to its own job, which owns
+  // the dataset and architecture the campaign retrains from. Optimize against
+  // that job under the model's original name, not the current session's job or
+  // the display name the compare view may have renamed it to.
+  const targetJob = model.job_id ?? jobId;
+  const targetName = model.orig_model_name ?? model.model_name;
+
   const [run, setRun] = useState<OptimizationRun | null>(null);
   const [maxQualityLoss, setMaxQualityLoss] = useState(0.05);
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -53,11 +60,11 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
   // no run to fetch, which is the normal starting state, not a failure.
   const poll = useCallback(async (silent = false) => {
     try {
-      setRun(await api.getOptimization(jobId, model.model_name));
+      setRun(await api.getOptimization(targetJob, targetName));
     } catch (e) {
       if (!silent) setError(e instanceof Error ? e.message : String(e));
     }
-  }, [jobId, model.model_name]);
+  }, [targetJob, targetName]);
 
   useEffect(() => { poll(true); }, [poll]);
 
@@ -73,7 +80,7 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
     setStarting(true);
     setError(null);
     try {
-      await api.startOptimization(jobId, model.model_name, { max_quality_loss: maxQualityLoss, advanced });
+      await api.startOptimization(targetJob, targetName, { max_quality_loss: maxQualityLoss, advanced });
       await poll();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -110,7 +117,7 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
     setAdopted(false);
     setError(null);
     try {
-      setVerification(await api.verifySetting(jobId, model.model_name, setting.index));
+      setVerification(await api.verifySetting(targetJob, targetName, setting.index));
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -120,16 +127,16 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
     if (verification?.status !== "running" || !selected) return;
     const id = setInterval(async () => {
       try {
-        setVerification(await api.getVerification(jobId, model.model_name, selected.index));
+        setVerification(await api.getVerification(targetJob, targetName, selected.index));
       } catch { /* keep the last state; the next tick retries */ }
     }, POLL_MS);
     return () => clearInterval(id);
-  }, [verification?.status, selected, jobId, model.model_name]);
+  }, [verification?.status, selected, targetJob, targetName]);
 
   const adopt = async () => {
     if (!selected || !verification) return;
     try {
-      await api.adoptSetting(jobId, model.model_name, selected.index);
+      await api.adoptSetting(targetJob, targetName, selected.index);
       setAdopted(true);
       onAdopted(selected, verification);
     } catch (e) {

--- a/leakpro/webapp/frontend/src/components/results/Optimization.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Optimization.tsx
@@ -300,14 +300,16 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
           )}
         </div>
 
-        {phase === "setup" && (
+        {/* A failed run must stay startable: hiding the button here once locked
+            the view permanently on a stale error read back from disk. */}
+        {(phase === "setup" || run?.status === "failed") && (
           <button
             onClick={start}
             disabled={starting}
             className="self-start px-8 py-2.5 rounded-lg bg-slate-700 text-cream border border-primary font-bold hover:bg-slate-600 transition-colors flex items-center gap-2 disabled:opacity-50"
           >
-            <span className="material-symbols-outlined text-base">rocket_launch</span>
-            {starting ? "…" : COPY.start}
+            <span className="material-symbols-outlined text-base">{run?.status === "failed" ? "refresh" : "rocket_launch"}</span>
+            {starting ? "…" : run?.status === "failed" ? COPY.retry : COPY.start}
           </button>
         )}
       </div>
@@ -343,8 +345,9 @@ export default function Optimization({ jobId, model, onBack, onAdopted }: Props)
           )}
 
           {run?.status === "failed" ? (
-            <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-500">
-              {run.error ?? COPY.failed}
+            <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-500 flex flex-col gap-1">
+              <span className="font-bold">{COPY.failed} {COPY.retryHint}</span>
+              <span className="text-xs opacity-80 break-words">{run.error ?? ""}</span>
             </div>
           ) : tested.length === 0 && phase === "done" ? (
             <p className="text-sm text-slate-400 italic">{COPY.noResults}</p>

--- a/leakpro/webapp/frontend/src/components/results/RiskDiagram.tsx
+++ b/leakpro/webapp/frontend/src/components/results/RiskDiagram.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+
+/**
+ * Schematic of the risk assessment model.
+ *
+ * The one thing the picture has to convey is the split: the left column is measured by this audit and
+ * reproducible, the right column is declared by you and is a value judgement. Everything below is a
+ * product of the two, which is why no single number can stand on its own.
+ *
+ * Structure follows Sion et al., "Privacy Risk Assessment for Data Subject-aware Threat Modeling"
+ * (IWPE 2019). Precision follows Jayaraman et al. (PoPETs 2021), Theorem 4.2.
+ *
+ * Two visual encodings, spelled out in the legend at the foot of the diagram:
+ *   role       dashed border = given value, solid border = computed value
+ *   provenance amber = measured by the audit, grey = declared by the user
+ *
+ * Layout rows (viewBox 720x400), kept disjoint so nothing overlaps at any width:
+ *   52..158  inputs   196..264  intermediate products   318..380  risk   400..411  legend
+ *
+ * Expected exposed subjects and attacker precision are deliberately NOT drawn here: neither is
+ * derived from Risk. Both come off the measured vulnerability directly (with NDS, or with alpha and
+ * pi), so putting them under Risk would assert a dependency the code does not have.
+ */
+export default function RiskDiagram({ className = "" }: { className?: string }) {
+  // Two independent visual encodings, explained by the legend at the foot of the diagram:
+  //   role       dashed border = a value that is given, solid border = a value that is computed
+  //   provenance amber = measured by the audit, grey = declared by the user
+  // Risk is the terminal calculation, so it is solid with a heavier accent stroke.
+  const measuredInput = "fill-amber-50 dark:fill-[#2d5867] stroke-primary";
+  const declaredInput = "fill-slate-50 dark:fill-[#1d3e4a] stroke-slate-400 dark:stroke-[#365d6c]";
+  const computed = "fill-white dark:fill-[#254c5b] stroke-slate-400 dark:stroke-[#365d6c]";
+  const computedFinal = "fill-white dark:fill-[#254c5b] stroke-primary";
+  const DASH = "5 4";
+
+  const heading = "fill-slate-500 dark:fill-slate-300";
+  const body = "fill-slate-700 dark:fill-slate-100";
+  const faint = "fill-slate-400 dark:fill-slate-400";
+  const line = "stroke-slate-400 dark:stroke-slate-500";
+  const tag = "fill-slate-400 dark:fill-slate-400";
+
+  const factors: Array<[string, string, number]> = [
+    ["DTS", "data type sensitivity", 88],
+    ["NR", "records per subject", 106],
+    ["DST", "subject type weight", 124],
+    ["NDS", "number of data subjects", 142],
+  ];
+
+  return (
+    <div className={`w-full overflow-x-auto ${className}`}>
+      <svg
+        viewBox="0 0 720 430"
+        role="img"
+        aria-label="Risk equals loss magnitude times loss event frequency. Loss event frequency comes from the attack success rate measured by this audit; loss magnitude comes from four factors you declare."
+        className="w-full min-w-[560px] h-auto font-display"
+      >
+        <defs>
+          <marker id="rd-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" className="fill-slate-400 dark:fill-slate-500" />
+          </marker>
+        </defs>
+
+        {/* Column headings */}
+        <text x="170" y="20" textAnchor="middle" className={heading} fontSize="12" fontWeight="700" letterSpacing="1.2">
+          MEASURED BY THIS AUDIT
+        </text>
+        <text x="170" y="36" textAnchor="middle" className={faint} fontSize="10.5">
+          re-run it and get the same number
+        </text>
+        <text x="550" y="20" textAnchor="middle" className={heading} fontSize="12" fontWeight="700" letterSpacing="1.2">
+          DECLARED BY YOU
+        </text>
+        <text x="550" y="36" textAnchor="middle" className={faint} fontSize="10.5">
+          your use case, which LeakPro cannot observe
+        </text>
+
+        <line x1="360" y1="46" x2="360" y2="300" className={line} strokeDasharray="4 5" strokeWidth="1" />
+
+        {/* INPUT, measured: vulnerability */}
+        <rect x="55" y="52" width="230" height="106" rx="10" className={measuredInput} strokeWidth="1.5" strokeDasharray={DASH} />
+        <text x="170" y="70" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">INPUT</text>
+        <text x="170" y="99" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Vulnerability (V)</text>
+        <text x="170" y="119" textAnchor="middle" className={body} fontSize="12" fontFamily="monospace">TPR at your chosen α</text>
+        <text x="170" y="137" textAnchor="middle" className={faint} fontSize="10">how often the best attack is right</text>
+
+        {/* INPUTS, declared: the four harm factors */}
+        <rect x="435" y="52" width="230" height="106" rx="10" className={declaredInput} strokeWidth="1.5" strokeDasharray={DASH} />
+        <text x="550" y="68" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">INPUTS</text>
+        {factors.map(([abbr, desc, y]) => (
+          <g key={abbr}>
+            <text x="455" y={y} className={body} fontSize="11.5" fontWeight="700" fontFamily="monospace">{abbr}</text>
+            <text x="497" y={y} className={faint} fontSize="10.5">{desc}</text>
+          </g>
+        ))}
+
+        {/* Down into the two products */}
+        <line x1="170" y1="158" x2="170" y2="194" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
+        <line x1="550" y1="158" x2="550" y2="194" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
+
+        {/* CALCULATED: Loss Event Frequency */}
+        <rect x="55" y="196" width="230" height="68" rx="10" className={computed} strokeWidth="1.5" />
+        <text x="170" y="212" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
+        <text x="170" y="230" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Event Frequency</text>
+        <text x="170" y="247" textAnchor="middle" className={body} fontSize="11.5" fontFamily="monospace">LEF = V × (RP × TEF)</text>
+        <text x="170" y="259" textAnchor="middle" className={faint} fontSize="9.5">RP × TEF assumed 1: a single attempt</text>
+
+        {/* CALCULATED: Loss Magnitude */}
+        <rect x="435" y="196" width="230" height="68" rx="10" className={computed} strokeWidth="1.5" />
+        <text x="550" y="212" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
+        <text x="550" y="230" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Magnitude</text>
+        <text x="550" y="247" textAnchor="middle" className={body} fontSize="11.5" fontFamily="monospace">LM = DTS × NR × DST × NDS</text>
+        <text x="550" y="259" textAnchor="middle" className={faint} fontSize="9.5">factors assumed independent</text>
+
+        {/* Join into risk */}
+        <path d="M 170 264 L 170 292 L 360 292" fill="none" className={line} strokeWidth="1.5" />
+        <path d="M 550 264 L 550 292 L 360 292" fill="none" className={line} strokeWidth="1.5" />
+        <line x1="360" y1="292" x2="360" y2="316" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
+
+        <rect x="245" y="318" width="230" height="62" rx="10" className={computedFinal} strokeWidth="2.5" />
+        <text x="360" y="334" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
+        <text x="360" y="353" textAnchor="middle" className={body} fontSize="14" fontWeight="700">Risk</text>
+        <text x="360" y="371" textAnchor="middle" className={body} fontSize="12" fontFamily="monospace">Risk = LEF × LM</text>
+
+        {/* Legend: the two encodings, role by border and provenance by colour */}
+        <rect x="118" y="400" width="16" height="11" rx="3" className={measuredInput} strokeWidth="1.5" strokeDasharray={DASH} />
+        <text x="140" y="409" className={faint} fontSize="10.5">measured input</text>
+        <rect x="252" y="400" width="16" height="11" rx="3" className={declaredInput} strokeWidth="1.5" strokeDasharray={DASH} />
+        <text x="274" y="409" className={faint} fontSize="10.5">your input</text>
+        <rect x="360" y="400" width="16" height="11" rx="3" className={computed} strokeWidth="1.5" />
+        <text x="382" y="409" className={faint} fontSize="10.5">calculated</text>
+        <rect x="470" y="400" width="16" height="11" rx="3" className={computedFinal} strokeWidth="2.5" />
+        <text x="492" y="409" className={faint} fontSize="10.5">final result</text>
+      </svg>
+    </div>
+  );
+}

--- a/leakpro/webapp/frontend/src/components/results/RiskDiagram.tsx
+++ b/leakpro/webapp/frontend/src/components/results/RiskDiagram.tsx
@@ -1,56 +1,38 @@
 import React from "react";
 
 /**
- * Schematic of the risk assessment model.
+ * Schematic of the risk assessment model, in three boxes.
  *
- * The one thing the picture has to convey is the split: the left column is measured by this audit and
- * reproducible, the right column is declared by you and is a value judgement. Everything below is a
- * product of the two, which is why no single number can stand on its own.
+ * The point the picture has to make is the split: the left branch is measured by this audit and
+ * reproducible, the right branch is declared by the user and is a value judgement, and Risk is their
+ * product.
+ *
+ * Factor names are spelled out in full. The abbreviations (LEF, LM, V, DTS, NR, DST, NDS) that the JSON
+ * output, the summary table and the papers use are defined in the info modals instead, to keep the
+ * picture to one line of text per idea.
  *
  * Structure follows Sion et al., "Privacy Risk Assessment for Data Subject-aware Threat Modeling"
- * (IWPE 2019). Precision follows Jayaraman et al. (PoPETs 2021), Theorem 4.2.
+ * (IWPE 2019).
  *
- * Two visual encodings, spelled out in the legend at the foot of the diagram:
- *   role       dashed border = given value, solid border = computed value
- *   provenance amber = measured by the audit, grey = declared by the user
- *
- * Layout rows (viewBox 720x400), kept disjoint so nothing overlaps at any width:
- *   52..158  inputs   196..264  intermediate products   318..380  risk   400..411  legend
- *
- * Expected exposed subjects and attacker precision are deliberately NOT drawn here: neither is
- * derived from Risk. Both come off the measured vulnerability directly (with NDS, or with alpha and
- * pi), so putting them under Risk would assert a dependency the code does not have.
+ * Layout rows (viewBox 720x260), kept disjoint so nothing overlaps at any width:
+ *   52..114  the two products    170..228  risk
  */
 export default function RiskDiagram({ className = "" }: { className?: string }) {
-  // Two independent visual encodings, explained by the legend at the foot of the diagram:
-  //   role       dashed border = a value that is given, solid border = a value that is computed
-  //   provenance amber = measured by the audit, grey = declared by the user
-  // Risk is the terminal calculation, so it is solid with a heavier accent stroke.
-  const measuredInput = "fill-amber-50 dark:fill-[#2d5867] stroke-primary";
-  const declaredInput = "fill-slate-50 dark:fill-[#1d3e4a] stroke-slate-400 dark:stroke-[#365d6c]";
-  const computed = "fill-white dark:fill-[#254c5b] stroke-slate-400 dark:stroke-[#365d6c]";
-  const computedFinal = "fill-white dark:fill-[#254c5b] stroke-primary";
-  const DASH = "5 4";
+  const measured = "fill-amber-50 dark:fill-[#2d5867] stroke-primary";
+  const declared = "fill-slate-50 dark:fill-[#1d3e4a] stroke-slate-400 dark:stroke-[#365d6c]";
+  const result = "fill-white dark:fill-[#254c5b] stroke-primary";
 
-  const heading = "fill-slate-500 dark:fill-slate-300";
+  const headingCls = "fill-slate-500 dark:fill-slate-300";
   const body = "fill-slate-700 dark:fill-slate-100";
   const faint = "fill-slate-400 dark:fill-slate-400";
   const line = "stroke-slate-400 dark:stroke-slate-500";
-  const tag = "fill-slate-400 dark:fill-slate-400";
-
-  const factors: Array<[string, string, number]> = [
-    ["DTS", "data type sensitivity", 88],
-    ["NR", "records per subject", 106],
-    ["DST", "subject type weight", 124],
-    ["NDS", "number of data subjects", 142],
-  ];
 
   return (
     <div className={`w-full overflow-x-auto ${className}`}>
       <svg
-        viewBox="0 0 720 430"
+        viewBox="0 0 720 246"
         role="img"
-        aria-label="Risk equals loss magnitude times loss event frequency. Loss event frequency comes from the attack success rate measured by this audit; loss magnitude comes from four factors you declare."
+        aria-label="Risk is loss event frequency times loss magnitude. Loss event frequency is vulnerability times retention period times threat event frequency, measured by this audit. Loss magnitude is data type sensitivity times records per subject times data subject type times number of data subjects, declared by you."
         className="w-full min-w-[560px] h-auto font-display"
       >
         <defs>
@@ -59,76 +41,40 @@ export default function RiskDiagram({ className = "" }: { className?: string }) 
           </marker>
         </defs>
 
-        {/* Column headings */}
-        <text x="170" y="20" textAnchor="middle" className={heading} fontSize="12" fontWeight="700" letterSpacing="1.2">
+        {/* Column headings carry the measured / declared distinction */}
+        <text x="180" y="20" textAnchor="middle" className={headingCls} fontSize="12" fontWeight="700" letterSpacing="1.2">
           MEASURED BY THIS AUDIT
         </text>
-        <text x="170" y="36" textAnchor="middle" className={faint} fontSize="10.5">
+        <text x="180" y="36" textAnchor="middle" className={faint} fontSize="10.5">
           re-run it and get the same number
         </text>
-        <text x="550" y="20" textAnchor="middle" className={heading} fontSize="12" fontWeight="700" letterSpacing="1.2">
+        <text x="540" y="20" textAnchor="middle" className={headingCls} fontSize="12" fontWeight="700" letterSpacing="1.2">
           DECLARED BY YOU
         </text>
-        <text x="550" y="36" textAnchor="middle" className={faint} fontSize="10.5">
+        <text x="540" y="36" textAnchor="middle" className={faint} fontSize="10.5">
           your use case, which LeakPro cannot observe
         </text>
 
-        <line x1="360" y1="46" x2="360" y2="300" className={line} strokeDasharray="4 5" strokeWidth="1" />
+        {/* Loss Event Frequency */}
+        <rect x="30" y="52" width="300" height="62" rx="10" className={measured} strokeWidth="1.5" />
+        <text x="180" y="74" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Event Frequency</text>
+        <text x="180" y="93" textAnchor="middle" className={body} fontSize="10.5">Vulnerability × Retention Period</text>
+        <text x="180" y="107" textAnchor="middle" className={body} fontSize="10.5">× Threat Event Frequency</text>
 
-        {/* INPUT, measured: vulnerability */}
-        <rect x="55" y="52" width="230" height="106" rx="10" className={measuredInput} strokeWidth="1.5" strokeDasharray={DASH} />
-        <text x="170" y="70" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">INPUT</text>
-        <text x="170" y="99" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Vulnerability (V)</text>
-        <text x="170" y="119" textAnchor="middle" className={body} fontSize="12" fontFamily="monospace">TPR at your chosen α</text>
-        <text x="170" y="137" textAnchor="middle" className={faint} fontSize="10">how often the best attack is right</text>
-
-        {/* INPUTS, declared: the four harm factors */}
-        <rect x="435" y="52" width="230" height="106" rx="10" className={declaredInput} strokeWidth="1.5" strokeDasharray={DASH} />
-        <text x="550" y="68" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">INPUTS</text>
-        {factors.map(([abbr, desc, y]) => (
-          <g key={abbr}>
-            <text x="455" y={y} className={body} fontSize="11.5" fontWeight="700" fontFamily="monospace">{abbr}</text>
-            <text x="497" y={y} className={faint} fontSize="10.5">{desc}</text>
-          </g>
-        ))}
-
-        {/* Down into the two products */}
-        <line x1="170" y1="158" x2="170" y2="194" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
-        <line x1="550" y1="158" x2="550" y2="194" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
-
-        {/* CALCULATED: Loss Event Frequency */}
-        <rect x="55" y="196" width="230" height="68" rx="10" className={computed} strokeWidth="1.5" />
-        <text x="170" y="212" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
-        <text x="170" y="230" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Event Frequency</text>
-        <text x="170" y="247" textAnchor="middle" className={body} fontSize="11.5" fontFamily="monospace">LEF = V × (RP × TEF)</text>
-        <text x="170" y="259" textAnchor="middle" className={faint} fontSize="9.5">RP × TEF assumed 1: a single attempt</text>
-
-        {/* CALCULATED: Loss Magnitude */}
-        <rect x="435" y="196" width="230" height="68" rx="10" className={computed} strokeWidth="1.5" />
-        <text x="550" y="212" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
-        <text x="550" y="230" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Magnitude</text>
-        <text x="550" y="247" textAnchor="middle" className={body} fontSize="11.5" fontFamily="monospace">LM = DTS × NR × DST × NDS</text>
-        <text x="550" y="259" textAnchor="middle" className={faint} fontSize="9.5">factors assumed independent</text>
+        {/* Loss Magnitude */}
+        <rect x="390" y="52" width="300" height="62" rx="10" className={declared} strokeWidth="1.5" />
+        <text x="540" y="74" textAnchor="middle" className={body} fontSize="13" fontWeight="700">Loss Magnitude</text>
+        <text x="540" y="93" textAnchor="middle" className={body} fontSize="10.5">Data Type Sensitivity × Records per Subject</text>
+        <text x="540" y="107" textAnchor="middle" className={body} fontSize="10.5">× Data Subject Type × Number of Data Subjects</text>
 
         {/* Join into risk */}
-        <path d="M 170 264 L 170 292 L 360 292" fill="none" className={line} strokeWidth="1.5" />
-        <path d="M 550 264 L 550 292 L 360 292" fill="none" className={line} strokeWidth="1.5" />
-        <line x1="360" y1="292" x2="360" y2="316" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
+        <path d="M 180 114 L 180 142 L 360 142" fill="none" className={line} strokeWidth="1.5" />
+        <path d="M 540 114 L 540 142 L 360 142" fill="none" className={line} strokeWidth="1.5" />
+        <line x1="360" y1="142" x2="360" y2="168" className={line} strokeWidth="1.5" markerEnd="url(#rd-arrow)" />
 
-        <rect x="245" y="318" width="230" height="62" rx="10" className={computedFinal} strokeWidth="2.5" />
-        <text x="360" y="334" textAnchor="middle" className={tag} fontSize="9" fontWeight="700" letterSpacing="1.1">CALCULATED</text>
-        <text x="360" y="353" textAnchor="middle" className={body} fontSize="14" fontWeight="700">Risk</text>
-        <text x="360" y="371" textAnchor="middle" className={body} fontSize="12" fontFamily="monospace">Risk = LEF × LM</text>
-
-        {/* Legend: the two encodings, role by border and provenance by colour */}
-        <rect x="118" y="400" width="16" height="11" rx="3" className={measuredInput} strokeWidth="1.5" strokeDasharray={DASH} />
-        <text x="140" y="409" className={faint} fontSize="10.5">measured input</text>
-        <rect x="252" y="400" width="16" height="11" rx="3" className={declaredInput} strokeWidth="1.5" strokeDasharray={DASH} />
-        <text x="274" y="409" className={faint} fontSize="10.5">your input</text>
-        <rect x="360" y="400" width="16" height="11" rx="3" className={computed} strokeWidth="1.5" />
-        <text x="382" y="409" className={faint} fontSize="10.5">calculated</text>
-        <rect x="470" y="400" width="16" height="11" rx="3" className={computedFinal} strokeWidth="2.5" />
-        <text x="492" y="409" className={faint} fontSize="10.5">final result</text>
+        <rect x="200" y="170" width="320" height="58" rx="10" className={result} strokeWidth="2.5" />
+        <text x="360" y="192" textAnchor="middle" className={body} fontSize="14" fontWeight="700">Risk</text>
+        <text x="360" y="212" textAnchor="middle" className={body} fontSize="11.5">Loss Event Frequency × Loss Magnitude</text>
       </svg>
     </div>
   );

--- a/leakpro/webapp/frontend/src/components/results/Summary.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Summary.tsx
@@ -1,77 +1,378 @@
 import React, { useState } from "react";
-import { ModelResult } from "../../api";
+import { api, ModelResult, RiskAssessment, RiskRequest } from "../../api";
+import InfoButton from "../InfoButton";
 import MetaPanel from "./MetaPanel";
+import RiskDiagram from "./RiskDiagram";
 
-interface Props { results: ModelResult[] }
+/**
+ * Risk is never scored here. The measured half (TPR at the chosen operating point) comes straight from
+ * the audit, and the harm half is declared by the user and combined by leakpro/risk on the backend.
+ * This file only displays what it is given, which is why there is no threshold table in it.
+ *
+ * Presentation rule: the first view shows numbers, not prose. Every explanation lives behind an
+ * InfoButton. The one exception is warnings — those stay visible as a chip, because a caveat like
+ * "this operating point was not measurable" must not be something the reader has to go looking for.
+ *
+ * Risk state lives in the parent (Step7Results), not here. The tab bar unmounts this component when
+ * the user switches tabs, so local state would silently discard a completed assessment.
+ */
 
-function riskLevel(auc: number | undefined): { label: string; color: string; bg: string } {
-  if (auc === undefined) return { label: "N/A", color: "text-slate-400", bg: "bg-slate-100 dark:bg-surface-2" };
-  if (auc >= 0.75)        return { label: "HIGH",   color: "text-red-500",    bg: "bg-red-500/10 border border-red-500/30" };
-  if (auc >= 0.60)        return { label: "MEDIUM", color: "text-orange-500", bg: "bg-orange-500/10 border border-orange-500/30" };
-  return                         { label: "LOW",    color: "text-green-500",  bg: "bg-green-500/10 border border-green-500/30" };
+export interface RiskState {
+  draft: RiskRequest;
+  applied: RiskRequest | null;
+  /** Keyed by `${job_id}/${model_name}` — model names are not unique across jobs in compare mode. */
+  assessments: Record<string, RiskAssessment>;
+  unassessable: Record<string, string>;
+  error: string | null;
 }
 
-function bestAuc(model: ModelResult): number | undefined {
-  const vals = model.attacks.map((a) => a.roc_auc).filter((v): v is number => v !== null && v !== undefined);
-  return vals.length ? Math.max(...vals) : undefined;
+export const initialRiskState: RiskState = {
+  draft: {
+    tolerated_fpr: 0.01,
+    attacker_prior: 0.5,
+    records_per_subject: 1,
+    data_type_sensitivity: 1,
+    subject_type_weight: 1,
+    extrapolate_to_population: false,
+    notes: "",
+  },
+  applied: null,
+  assessments: {},
+  unassessable: {},
+  error: null,
+};
+
+interface Props {
+  results: ModelResult[];
+  risk: RiskState;
+  onRiskChange: (next: RiskState) => void;
 }
 
-function bestTpr(model: ModelResult): { value: number; attack: string } | undefined {
+function modelKey(m: ModelResult) {
+  return `${m.job_id ?? ""}/${m.model_name}`;
+}
+
+const ALPHAS = [
+  { value: 0.01, label: "1%" },
+  { value: 0.001, label: "0.1%" },
+  { value: 0.0001, label: "0.01%" },
+];
+
+const PRIORS = [
+  { value: 0.5, label: "0.5 — balanced" },
+  { value: 0.1, label: "0.1" },
+  { value: 0.01, label: "0.01" },
+  { value: 0.001, label: "0.001" },
+];
+
+// CNIL PIA-3 severity levels, offered as a starting scale. See leakpro/risk/policy.py.
+const SENSITIVITY = [
+  { value: 1, label: "1 — Negligible" },
+  { value: 2, label: "2 — Limited" },
+  { value: 3, label: "3 — Significant" },
+  { value: 4, label: "4 — Maximum" },
+];
+
+const BAND_STYLE: Record<string, { color: string; bg: string }> = {
+  SEVERE: { color: "text-red-500", bg: "bg-red-500/10 border border-red-500/30" },
+  HIGH: { color: "text-orange-500", bg: "bg-orange-500/10 border border-orange-500/30" },
+  MODERATE: { color: "text-amber-500", bg: "bg-amber-500/10 border border-amber-500/30" },
+  LOW: { color: "text-green-500", bg: "bg-green-500/10 border border-green-500/30" },
+  NONE: { color: "text-slate-400", bg: "bg-slate-100 dark:bg-surface-2" },
+};
+
+function bandStyle(band?: string) {
+  return (band && BAND_STYLE[band]) || BAND_STYLE.NONE;
+}
+
+function pct(v: number | undefined | null) {
+  return v != null ? (v * 100).toFixed(1) + "%" : "—";
+}
+
+function num(v: number | undefined | null, digits = 0) {
+  return v != null ? v.toLocaleString(undefined, { maximumFractionDigits: digits }) : "—";
+}
+
+/** Best TPR at a given operating point across a model's attacks, for the pre-assessment view. */
+function bestTpr(model: ModelResult, alpha: number): { value: number; attack: string } | undefined {
+  const key = alpha === 0.01 ? "TPR@1%FPR" : alpha === 0.001 ? "TPR@0.1%FPR" : "TPR@0.01%FPR";
   let best: { value: number; attack: string } | undefined;
   model.attacks.forEach((a) => {
-    const v = a.tpr_at_fpr?.["TPR@0.1%FPR"];
-    if (v != null && (best === undefined || v > best.value))
-      best = { value: v, attack: a.attack_name };
+    // Attacks with an inverted ROC are excluded, matching the backend's guard: an AUC below 0.5 means
+    // a real leak would read as no leak.
+    if (a.roc_auc != null && a.roc_auc < 0.5) return;
+    const v = a.tpr_at_fpr?.[key];
+    if (v != null && (best === undefined || v > best.value)) best = { value: v, attack: a.attack_name };
   });
   return best;
 }
 
-function pct(v: number | undefined) {
-  return v !== undefined ? (v * 100).toFixed(1) + "%" : "—";
-}
+// ---------------------------------------------------------------------------
+// Explanation content. Kept here, out of the layout, so the panels stay readable.
+// ---------------------------------------------------------------------------
 
-export default function Summary({ results }: Props) {
+const HOW_IT_WORKS = (
+  <>
+    <p>
+      The audit measures how often an attack correctly identifies a training member. Whether that
+      matters depends on your deployment, which LeakPro cannot observe. So the assessment keeps the two
+      halves apart and combines them without inventing any weights.
+    </p>
+    <RiskDiagram className="my-1" />
+    <p>
+      <b>Nothing is hidden in a coefficient.</b> Every number is either measured by this audit or
+      declared by you, and the result lists the assumption behind each derived figure.
+    </p>
+    <p>
+      <b>Why Loss Event Frequency is just the measured success rate.</b> In the published model,
+      <code> LEF = V × (RP × TEF)</code>, where <b>RP</b> is the <i>retention period</i> — how long the
+      data stays available to be attacked — and <b>TEF</b> is the <i>threat event frequency</i>, how
+      often an adversary tries. LeakPro can observe neither, so both are set to 1: a single attack
+      attempt against a model that is retained. If repeated attempts are plausible in your setting,
+      the real frequency is higher than this assessment assumes, and you should scale it up yourself.
+    </p>
+    <p className="text-xs text-slate-400">
+      Structure: Sion, Van Landuyt, Wuyts &amp; Joosen, “Privacy Risk Assessment for Data
+      Subject-aware Threat Modeling”, IWPE 2019. Precision: Jayaraman, Wang, Knipmeyer, Gu &amp; Evans,
+      “Revisiting Membership Inference Under Realistic Assumptions”, PoPETs 2021, Theorem 4.2.
+      Sensitivity scale: CNIL PIA-3 knowledge bases, 2018.
+    </p>
+  </>
+);
+
+const ABOUT_ALPHA = (
+  <>
+    <p>
+      α is the false-positive rate the attacker is assumed to tolerate. It sets the operating point the
+      whole assessment is read at, so there is no default: the choice is yours.
+    </p>
+    <ul className="list-disc ml-5 flex flex-col gap-1">
+      <li><b>1%</b> — resolvable on the audit set sizes most targets have. Start here.</li>
+      <li><b>0.1%</b> — stricter. Needs at least 1000 non-members to be measurable at all.</li>
+      <li><b>0.01%</b> — very strict. Needs at least 10000 non-members.</li>
+    </ul>
+    <p>
+      Below the resolution of your audit set, a true positive rate of zero means “not measurable”, not
+      “no leakage”. The backend refuses to report derived figures there rather than let you read a zero
+      as safety.
+    </p>
+  </>
+);
+
+const ABOUT_PRIOR = (
+  <>
+    <p>
+      π is the share of the attacker’s candidate pool that really are members. It does not change the
+      measurement; it changes what the measurement means.
+    </p>
+    <p>
+      The audit runs on a balanced split, so every TPR and AUC it reports implicitly assumes π = 0.5.
+      Real pools are usually far more skewed, and precision falls steeply as they are. At a 1%
+      false-positive rate and a measured TPR of 10%, an attacker is right 91% of the time at π = 0.5 —
+      and about 1% of the time at π = 0.001.
+    </p>
+    <p>Both values are always reported, so a balanced-prior figure can never be quoted by accident.</p>
+  </>
+);
+
+const ABOUT_FACTORS = (
+  <>
+    <p>
+      These four are the Loss Magnitude factors from Sion et al.: <code>LM = DTS × NR × DST × NDS</code>.
+      The paper deliberately supplies no numeric values for them, so they are yours to set. All default
+      to a neutral 1.0, which reduces the loss magnitude to a plain count of subjects.
+    </p>
+    <ul className="list-disc ml-5 flex flex-col gap-1">
+      <li><b>DTS</b> — sensitivity of the leaked data type. The CNIL PIA severity levels are a defensible starting scale.</li>
+      <li><b>NR</b> — records of this data type per subject. Fractions are fine when only some subjects contribute it.</li>
+      <li><b>DST</b> — weight for the subject type. Raise it for vulnerable subjects such as minors or patients.</li>
+      <li><b>NDS</b> — number of data subjects. Left blank, the target’s training-set size is used.</li>
+    </ul>
+    <p className="text-xs text-slate-400">
+      Sion et al. note the model assumes these factors are independent, which they flag as a
+      simplification of reality. That assumption is recorded in every assessment.
+    </p>
+  </>
+);
+
+const ABOUT_TPR = (
+  <p>
+    Of all the training members in the audit set, the share the strongest attack correctly identifies
+    while keeping its false-positive rate at or below α. Attacks whose ROC is inverted (AUC below 0.5)
+    are excluded rather than counted as weak evidence.
+  </p>
+);
+
+const ABOUT_LIFT = (
+  <p>
+    How many times better than random guessing the attack is at this operating point: TPR divided by α.
+    A lift of 1× is no better than chance. The band label is derived from this figure alone, and it is
+    an unsourced convenience — no published thresholds exist for it.
+  </p>
+);
+
+const ABOUT_PPV = (
+  <>
+    <p>
+      If the attacker claims a record was in the training set, how often are they right? This is the
+      number that decides whether a leak is actionable, and it depends on your declared prior π as much
+      as on the attack.
+    </p>
+    <p className="font-mono text-xs">PPV = TPR / (TPR + γ·α), γ = (1 − π) / π</p>
+    <p>
+      <b>γ is how outnumbered the members are:</b> for every genuine member in the attacker’s candidate
+      pool there are γ non-members. It is derived from your π, not a separate input — π = 0.5 gives
+      γ = 1, π = 0.01 gives γ = 99, π = 0.001 gives γ = 999.
+    </p>
+    <p>
+      That is why it multiplies the false-positive rate. At π = 0.001 with a measured TPR of 10% and
+      α = 1%, each member yields 0.10 expected true positives while the 999 non-members yield
+      999 × 0.01 = 9.99 false ones — about ten false alarms per correct hit, so precision is roughly
+      1%. The identical measurement reads 91% at π = 0.5.
+    </p>
+    <p className="text-xs text-slate-400">
+      A tenfold more skewed pool costs as much precision as a tenfold looser threshold, which is the
+      same reason strict operating points matter.
+    </p>
+  </>
+);
+
+const ABOUT_EXPOSED = (
+  <>
+    <p>
+      The measured success rate applied to your declared population: how many subjects an attacker would
+      be expected to identify. Sensitivity weights are deliberately left out of this figure so it stays
+      a plain count you can reason about.
+    </p>
+    <p>
+      <b>This count does not depend on π, and should not.</b> The true positive rate is conditional on a
+      record actually being a member, so it is unaffected by how the attacker’s pool is composed —
+      which means this figure already counts true positives only. Multiplying it by precision would be
+      circular, since precision times the flagged set <i>is</i> the true-positive count.
+    </p>
+    <p>
+      A skewed prior does not reduce how many members are genuinely identified; it increases the false
+      accusations sitting alongside them. So read the two columns as different questions: this one is
+      how many people the attack really exposes, precision is how far an attacker can trust any single
+      claim. “1000 exposed at 1% precision” and “40 exposed at 99% precision” are both real findings,
+      and they call for different responses.
+    </p>
+  </>
+);
+
+const ABOUT_BAND = (
+  <p>
+    An advisory label over the measured lift only, never over the combination of measurement and
+    judgement. The thresholds are round numbers chosen so that NONE means no better than chance and
+    SEVERE means two orders of magnitude better than chance. They are not calibrated against anything
+    published, which is why the policy version travels with every assessment.
+  </p>
+);
+
+export default function Summary({ results, risk, onRiskChange }: Props) {
+  // Ephemeral view state only. Anything the user would be annoyed to lose lives in `risk`.
   const [openKey, setOpenKey] = useState<string | null>(null);
+  const [wizard, setWizard] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [details, setDetails] = useState<string | null>(null);
 
+  const { draft, applied, assessments, unassessable, error } = risk;
+  const setDraft = (next: RiskRequest) => onRiskChange({ ...risk, draft: next });
+
+  const alpha = applied?.tolerated_fpr ?? draft.tolerated_fpr;
   const toggleInfo = (key: string) => setOpenKey((prev) => (prev === key ? null : key));
 
+  const submit = async () => {
+    // Compare mode can show models from several jobs, and the endpoint is per job, so assess each job
+    // the visible models come from and merge under composite keys.
+    const jobIds = Array.from(new Set(results.map((m) => m.job_id).filter((v): v is string => !!v)));
+    if (!jobIds.length) {
+      onRiskChange({ ...risk, error: "No job id on these results." });
+      return;
+    }
+    setBusy(true);
+    onRiskChange({ ...risk, error: null });
+    try {
+      const responses = await Promise.all(jobIds.map((id) => api.assessRisk(id, draft)));
+      const assessed: Record<string, RiskAssessment> = {};
+      const failed: Record<string, string> = {};
+      responses.forEach((res, i) => {
+        Object.entries(res.assessments).forEach(([name, a]) => { assessed[`${jobIds[i]}/${name}`] = a; });
+        Object.entries(res.unassessable).forEach(([name, why]) => { failed[`${jobIds[i]}/${name}`] = why; });
+      });
+      onRiskChange({ ...risk, assessments: assessed, unassessable: failed, applied: draft, error: null });
+      setWizard(false);
+    } catch (e) {
+      onRiskChange({ ...risk, error: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const downloadCSV = () => {
-    const rows = ["model,model_class,tpr_at_0.1pct_fpr,train_accuracy,test_accuracy,dpsgd,risk"];
+    const header = [
+      "model", "model_class", "alpha", "tpr_at_alpha", "advantage", "lift", "roc_auc",
+      "train_accuracy", "test_accuracy", "dpsgd", "attacker_prior", "ppv", "ppv_at_balanced_prior",
+      "n_subjects", "loss_magnitude", "risk_lm_x_lef", "expected_exposed_subjects", "expected_cost",
+      "vulnerability_band", "policy_version",
+    ];
+    const rows = [header.join(",")];
     results.forEach((m) => {
-      const auc = bestAuc(m);
-      const tpr = bestTpr(m);
-      const { label } = riskLevel(auc);
+      const a = assessments[modelKey(m)];
+      const tpr = bestTpr(m, alpha);
       rows.push([
         m.model_name,
         m.model_class ?? "",
-        tpr?.value.toFixed(6) ?? "",
+        alpha,
+        a?.measured.success_rate?.toFixed(6) ?? tpr?.value.toFixed(6) ?? "",
+        a?.measured.advantage?.toFixed(6) ?? "",
+        a?.measured.lift?.toFixed(3) ?? "",
+        a?.measured.roc_auc?.toFixed(6) ?? "",
         m.train_accuracy?.toFixed(6) ?? "",
         m.test_accuracy?.toFixed(6) ?? "",
         m.dpsgd ? `eps=${m.target_epsilon}` : "No",
-        label,
+        a?.declared.attacker_prior ?? "",
+        a?.combined.ppv?.toFixed(6) ?? "",
+        a?.combined.ppv_balanced?.toFixed(6) ?? "",
+        a?.declared.n_subjects ?? "",
+        a?.combined.loss_magnitude?.toFixed(2) ?? "",
+        a?.combined.risk?.toFixed(2) ?? "",
+        a?.combined.expected_exposed_subjects?.toFixed(2) ?? "",
+        a?.combined.expected_cost?.toFixed(2) ?? "",
+        a?.combined.vulnerability_band ?? "",
+        a?.policy_version ?? "",
       ].join(","));
     });
     const blob = new Blob([rows.join("\n")], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement("a"); a.href = url;
-    a.download = "leakpro_summary.csv"; a.click();
+    const el = document.createElement("a"); el.href = url;
+    el.download = "leakpro_summary.csv"; el.click();
     URL.revokeObjectURL(url);
   };
 
+  const alphaLabel = ALPHAS.find((a) => a.value === alpha)?.label ?? `${alpha * 100}%`;
+  const shown = details ? assessments[details] : undefined;
+
   return (
     <div className="flex flex-col gap-8">
-      {/* Risk cards */}
+      {/* Cards: measured lift until a use case is declared, band afterwards */}
       {results.length > 1 && (
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           {results.map((m) => {
-            const auc = bestAuc(m);
-            const { label, color, bg } = riskLevel(auc);
+            const a = assessments[modelKey(m)];
+            const tpr = bestTpr(m, alpha);
+            const style = bandStyle(a?.combined.vulnerability_band);
             return (
-              <div key={`${m.job_id}/${m.model_name}`} className={`rounded-xl p-4 ${bg}`}>
-                <p className={`text-2xl font-black ${color}`}>{label}</p>
-                <p className="font-bold text-sm mt-1">{m.model_name}</p>
+              <div key={modelKey(m)}
+                   className={a ? `rounded-xl p-4 ${style.bg}` : "rounded-xl p-4 bg-slate-50 dark:bg-surface border border-slate-200 dark:border-surface-border"}>
+                <p className={`text-2xl font-black ${a ? style.color : "text-primary"}`}>
+                  {a ? a.combined.vulnerability_band : `${num(tpr ? tpr.value / alpha : undefined, 1)}×`}
+                </p>
+                <p className="text-[11px] uppercase tracking-wider text-slate-400 -mt-0.5">
+                  {a ? "vulnerability" : "vs random"}
+                </p>
+                <p className="font-bold text-sm mt-2">{m.model_name}</p>
                 {m.model_class && <p className="text-xs font-mono text-slate-400 mt-0.5">{m.model_class}</p>}
-                <p className="text-xs text-slate-500 mt-1">AUC {auc?.toFixed(3) ?? "—"}</p>
                 {m.dpsgd && <p className="text-xs text-blue-500 mt-1">DP-SGD{m.target_epsilon != null ? ` ε=${m.target_epsilon}` : ""}</p>}
               </div>
             );
@@ -79,8 +380,44 @@ export default function Summary({ results }: Props) {
         </div>
       )}
 
+      {/* Risk bar. One line of text, everything else behind the info button. */}
+      <div className="flex items-center justify-between gap-3 flex-wrap rounded-xl border border-slate-200 dark:border-surface-border bg-slate-50 dark:bg-surface px-4 py-3">
+        <div>
+          <p className="font-bold text-sm flex items-center gap-1">
+            Risk assessment
+            <InfoButton label="How risk is computed" title="How risk is computed">{HOW_IT_WORKS}</InfoButton>
+          </p>
+          <p className="text-xs text-slate-400">
+            {applied
+              ? `α = ${alphaLabel} FPR · π = ${applied.attacker_prior} · policy ${Object.values(assessments)[0]?.policy_version ?? "—"}`
+              : "Measured leakage is above. Add your use case to turn it into risk."}
+          </p>
+        </div>
+        <button
+          onClick={() => setWizard(true)}
+          className="px-3 py-1.5 rounded-lg bg-primary text-white text-xs font-bold hover:opacity-90 transition-opacity"
+        >
+          {applied ? "Change inputs" : "Declare your use case"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-500">{error}</div>
+      )}
+
+      {Object.entries(unassessable).length > 0 && (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm">
+          <p className="font-bold text-amber-500 mb-1">Not assessable</p>
+          <ul className="list-disc ml-5 text-slate-600 dark:text-slate-300">
+            {Object.entries(unassessable).map(([key, reason]) => (
+              <li key={key}><b>{key.slice(key.indexOf("/") + 1)}</b>: {reason}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {/* Comparison table */}
-      <div className="rounded-xl border border-slate-200 dark:border-surface-border overflow-hidden">
+      <div className="rounded-xl border border-slate-200 dark:border-surface-border overflow-hidden overflow-x-auto">
         <div className="flex items-center justify-between px-3 py-2 bg-slate-50 dark:bg-surface border-b border-slate-200 dark:border-surface-border">
           <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Summary</span>
           <button
@@ -95,19 +432,30 @@ export default function Summary({ results }: Props) {
           <thead className="bg-slate-50 dark:bg-surface border-b border-slate-200 dark:border-surface-border">
             <tr>
               <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Model</th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">TPR@0.1%FPR</th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Train Acc</th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Test Acc</th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                TPR@{alphaLabel} <InfoButton label={`TPR at ${alphaLabel} FPR`}>{ABOUT_TPR}</InfoButton>
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                Lift <InfoButton label="Lift over random guessing">{ABOUT_LIFT}</InfoButton>
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                Precision <InfoButton label="Attacker precision (PPV)">{ABOUT_PPV}</InfoButton>
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                Exposed <InfoButton label="Expected exposed subjects">{ABOUT_EXPOSED}</InfoButton>
+              </th>
               <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">DP-SGD</th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Risk</th>
+              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
+                Band <InfoButton label="Vulnerability band">{ABOUT_BAND}</InfoButton>
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200 dark:divide-surface-border">
             {results.map((m) => {
-              const key = `${m.job_id}/${m.model_name}`;
-              const auc = bestAuc(m);
-              const tpr = bestTpr(m);
-              const { label, color } = riskLevel(auc);
+              const key = modelKey(m);
+              const a = assessments[key];
+              const tpr = bestTpr(m, alpha);
+              const style = bandStyle(a?.combined.vulnerability_band);
               const isOpen = openKey === key;
               return (
                 <React.Fragment key={key}>
@@ -127,23 +475,54 @@ export default function Summary({ results }: Props) {
                         >
                           info
                         </button>
+                        {a && (
+                          <button
+                            onClick={() => setDetails(key)}
+                            title="How this was computed"
+                            className="material-symbols-outlined text-base text-slate-400 hover:text-primary transition-colors"
+                          >
+                            calculate
+                          </button>
+                        )}
+                        {a && a.warnings.length > 0 && (
+                          <button
+                            onClick={() => setDetails(key)}
+                            title="Show caveats"
+                            className="px-1.5 py-0.5 rounded text-[11px] font-bold bg-amber-500/15 text-amber-600 dark:text-amber-400 border border-amber-500/30 hover:bg-amber-500/25 transition-colors"
+                          >
+                            {a.warnings.length} caveat{a.warnings.length > 1 ? "s" : ""}
+                          </button>
+                        )}
                       </div>
                     </td>
                     <td className="px-4 py-3 font-mono">
                       {tpr !== undefined
-                        ? <>{(tpr.value * 100).toFixed(2)}% <span className="text-slate-400 font-sans text-xs">({tpr.attack})</span></>
+                        ? <>{pct(tpr.value)} <span className="text-slate-400 font-sans text-xs">({tpr.attack})</span></>
                         : "—"}
                     </td>
-                    <td className="px-4 py-3 font-mono">{pct(m.train_accuracy)}</td>
-                    <td className="px-4 py-3 font-mono">{pct(m.test_accuracy)}</td>
-                    <td className="px-4 py-3">{m.dpsgd ? <span className="text-blue-500 font-semibold">{m.target_epsilon != null ? `ε=${m.target_epsilon}` : "Yes"}</span> : <span className="text-slate-400">No</span>}</td>
-                    <td className="px-4 py-3"><span className={`font-bold ${color}`}>{label}</span></td>
+                    <td className="px-4 py-3 font-mono">{tpr ? `${num(tpr.value / alpha, 1)}×` : "—"}</td>
+                    <td className="px-4 py-3 font-mono">
+                      {a?.combined.ppv != null
+                        ? <>{pct(a.combined.ppv)} <span className="text-slate-400 font-sans text-xs">(π={a.declared.attacker_prior})</span></>
+                        : <span className="text-slate-400 font-sans text-xs">—</span>}
+                    </td>
+                    <td className="px-4 py-3 font-mono">
+                      {a?.combined.expected_exposed_subjects != null ? num(a.combined.expected_exposed_subjects, 1) : "—"}
+                    </td>
+                    <td className="px-4 py-3">
+                      {m.dpsgd
+                        ? <span className="text-blue-500 font-semibold">{m.target_epsilon != null ? `ε=${m.target_epsilon}` : "Yes"}</span>
+                        : <span className="text-slate-400">No</span>}
+                    </td>
+                    <td className="px-4 py-3">
+                      {a?.combined.vulnerability_band
+                        ? <span className={`font-bold ${style.color}`}>{a.combined.vulnerability_band}</span>
+                        : <span className="text-slate-400">—</span>}
+                    </td>
                   </tr>
                   {isOpen && (
                     <tr className="bg-slate-50 dark:bg-surface/60">
-                      <td colSpan={6} className="px-6 py-4">
-                        <MetaPanel r={m} />
-                      </td>
+                      <td colSpan={7} className="px-6 py-4"><MetaPanel r={m} /></td>
                     </tr>
                   )}
                 </React.Fragment>
@@ -153,33 +532,229 @@ export default function Summary({ results }: Props) {
         </table>
       </div>
 
-      {/* Plain-English verdicts */}
+      {/* One sentence per model. Detail is a click away, not on the page. */}
       <div className="flex flex-col gap-3">
         {results.map((m) => {
-          const auc = bestAuc(m);
-          const { label, color, bg } = riskLevel(auc);
+          const key = modelKey(m);
+          const a = assessments[key];
+          const tpr = bestTpr(m, alpha);
+          const style = bandStyle(a?.combined.vulnerability_band);
           return (
-            <div key={`${m.job_id}/${m.model_name}`} className={`rounded-xl p-5 ${bg}`}>
-              <p className={`font-bold mb-1 ${color}`}>
+            <div key={key}
+                 className={a ? `rounded-xl p-5 ${style.bg}` : "rounded-xl p-5 bg-slate-50 dark:bg-surface border border-slate-200 dark:border-surface-border"}>
+              <p className={`font-bold mb-1 ${a ? style.color : ""}`}>
                 {m.model_name}
                 {m.model_class && <span className="ml-2 text-xs font-mono text-slate-400">{m.model_class}</span>}
-                {" "}— {label} risk
+                {a?.combined.vulnerability_band ? ` — ${a.combined.vulnerability_band} vulnerability` : ""}
               </p>
               <p className="text-sm text-slate-600 dark:text-slate-300">
-                {auc !== undefined
-                  ? label === "HIGH"
-                    ? `AUC = ${auc.toFixed(3)}. An attacker can reliably distinguish training members from non-members.`
-                    : label === "MEDIUM"
-                      ? `AUC = ${auc.toFixed(3)}. Moderate privacy leakage — some membership signal is detectable.`
-                      : `AUC = ${auc.toFixed(3)}. Low privacy leakage — model is reasonably well protected.`
-                  : "No attack results available for this model."
-                }
-                {m.dpsgd && ` Trained with DP-SGD${m.target_epsilon != null ? ` (ε=${m.target_epsilon})` : ""}.`}
+                {tpr
+                  ? `At a ${alphaLabel} false-positive rate, ${tpr.attack} identifies ${pct(tpr.value)} of training members, ${num(tpr.value / alpha, 1)}× better than chance.`
+                  : "No usable attack results at this operating point."}
+                {a?.combined.ppv != null && ` An attacker claiming membership would be right ${pct(a.combined.ppv)} of the time.`}
               </p>
+              {a && (
+                <button
+                  onClick={() => setDetails(key)}
+                  className="mt-2 text-xs font-bold text-primary hover:underline"
+                >
+                  Show the numbers behind this
+                </button>
+              )}
             </div>
           );
         })}
       </div>
+
+      {/* Wizard: labels and inputs only, explanations behind info buttons */}
+      {wizard && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4" onClick={() => setWizard(false)}>
+          <div className="max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-2xl bg-white dark:bg-surface-deep p-6 shadow-2xl"
+               onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-black mb-1 flex items-center gap-1">
+              Your use case
+              <InfoButton label="How risk is computed" title="How risk is computed">{HOW_IT_WORKS}</InfoButton>
+            </h3>
+            <p className="text-xs text-slate-500 mb-5">Only you can supply these. Defaults are neutral.</p>
+
+            <div className="flex flex-col gap-4 text-sm">
+              <label className="flex flex-col gap-1">
+                <span className="font-bold flex items-center gap-1">
+                  Tolerated false-positive rate (α)
+                  <InfoButton label="Operating point (α)">{ABOUT_ALPHA}</InfoButton>
+                </span>
+                <select
+                  className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                  value={draft.tolerated_fpr}
+                  onChange={(e) => setDraft({ ...draft, tolerated_fpr: Number(e.target.value) })}
+                >
+                  {ALPHAS.map((a) => <option key={a.value} value={a.value}>{a.label}</option>)}
+                </select>
+              </label>
+
+              <label className="flex flex-col gap-1">
+                <span className="font-bold flex items-center gap-1">
+                  Attacker prior (π)
+                  <InfoButton label="Attacker prior (π)">{ABOUT_PRIOR}</InfoButton>
+                </span>
+                <select
+                  className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                  value={draft.attacker_prior}
+                  onChange={(e) => setDraft({ ...draft, attacker_prior: Number(e.target.value) })}
+                >
+                  {PRIORS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+                </select>
+              </label>
+
+              <div className="flex items-center gap-1">
+                <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Harm factors</span>
+                <InfoButton label="Harm factors" title="Harm factors (Loss Magnitude)">{ABOUT_FACTORS}</InfoButton>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <label className="flex flex-col gap-1">
+                  <span className="font-bold">Data subjects (NDS)</span>
+                  <input
+                    type="number" min={1} placeholder="training-set size"
+                    className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                    value={draft.n_subjects ?? ""}
+                    onChange={(e) => setDraft({ ...draft, n_subjects: e.target.value ? Number(e.target.value) : undefined })}
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="font-bold">Records per subject (NR)</span>
+                  <input
+                    type="number" min={0.01} step={0.01}
+                    className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                    value={draft.records_per_subject}
+                    onChange={(e) => setDraft({ ...draft, records_per_subject: Number(e.target.value) })}
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="font-bold">Sensitivity (DTS)</span>
+                  <select
+                    className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                    value={draft.data_type_sensitivity}
+                    onChange={(e) => setDraft({ ...draft, data_type_sensitivity: Number(e.target.value) })}
+                  >
+                    {SENSITIVITY.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="font-bold">Subject weight (DST)</span>
+                  <input
+                    type="number" min={0.01} step={0.5}
+                    className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                    value={draft.subject_type_weight}
+                    onChange={(e) => setDraft({ ...draft, subject_type_weight: Number(e.target.value) })}
+                  />
+                </label>
+              </div>
+
+              <label className="flex flex-col gap-1">
+                <span className="font-bold flex items-center gap-1">
+                  Cost per exposed subject
+                  <InfoButton label="Cost per exposed subject">
+                    <p>
+                      Optional, in any unit you choose. Left blank, no monetary figure is reported at
+                      all — a default cost would be fabricated, and a fabricated cost is worse than
+                      none.
+                    </p>
+                  </InfoButton>
+                </span>
+                <input
+                  type="number" min={0} step={1} placeholder="optional"
+                  className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                  value={draft.cost_per_exposed_subject ?? ""}
+                  onChange={(e) => setDraft({ ...draft, cost_per_exposed_subject: e.target.value ? Number(e.target.value) : undefined })}
+                />
+              </label>
+
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={draft.extrapolate_to_population ?? false}
+                  onChange={(e) => setDraft({ ...draft, extrapolate_to_population: e.target.checked })}
+                />
+                <span className="flex items-center gap-1">
+                  Extrapolate exposed records to the full training set
+                  <InfoButton label="Extrapolation">
+                    <p>
+                      Scales the exposed-record count from the audit set up to the training population.
+                      Off by default: per-record vulnerability is strongly non-uniform, so this is an
+                      estimate under an assumption, not a measurement.
+                    </p>
+                  </InfoButton>
+                </span>
+              </label>
+
+              <label className="flex flex-col gap-1">
+                <span className="font-bold">Notes</span>
+                <textarea
+                  rows={2} placeholder="kept in the audit trail"
+                  className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
+                  value={draft.notes ?? ""}
+                  onChange={(e) => setDraft({ ...draft, notes: e.target.value })}
+                />
+              </label>
+            </div>
+
+            <div className="mt-6 flex justify-end gap-2">
+              <button onClick={() => setWizard(false)}
+                      className="px-4 py-2 rounded-lg border border-slate-300 dark:border-surface-border text-sm font-bold">
+                Cancel
+              </button>
+              <button onClick={submit} disabled={busy}
+                      className="px-4 py-2 rounded-lg bg-primary text-white text-sm font-bold disabled:opacity-50">
+                {busy ? "Assessing…" : "Assess risk"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Details: formula, assumptions, caveats */}
+      {details && shown && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4" onClick={() => setDetails(null)}>
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-white dark:bg-surface-deep p-6 shadow-2xl"
+               onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-black mb-1">
+              {details.slice(details.indexOf("/") + 1)}
+            </h3>
+            <p className="text-xs text-slate-500 mb-4">
+              Policy {shown.policy_version} · LeakPro {shown.leakpro_version}
+            </p>
+
+            <RiskDiagram className="mb-4" />
+
+            <pre className="text-xs bg-slate-100 dark:bg-surface-2 rounded-lg p-3 overflow-x-auto mb-4">
+{`LEF  = measured TPR at α    = ${shown.combined.loss_event_frequency}
+LM   = DTS × NR × DST × NDS = ${shown.combined.loss_magnitude ?? "—"}
+Risk = LEF × LM             = ${shown.combined.risk ?? "—"}
+PPV  = TPR / (TPR + γ·α)    = ${shown.combined.ppv ?? "—"}   γ = ${shown.combined.gamma}`}
+            </pre>
+
+            {shown.warnings.length > 0 && (
+              <>
+                <p className="font-bold text-sm mb-1 text-amber-500">Caveats</p>
+                <ul className="list-disc ml-5 text-xs text-amber-600 dark:text-amber-400 flex flex-col gap-1 mb-4">
+                  {shown.warnings.map((w, i) => <li key={i}>{w}</li>)}
+                </ul>
+              </>
+            )}
+
+            <p className="font-bold text-sm mb-1">Assumptions</p>
+            <ol className="list-decimal ml-5 text-xs text-slate-600 dark:text-slate-300 flex flex-col gap-1">
+              {shown.assumptions.map((a, i) => <li key={i}>{a}</li>)}
+            </ol>
+
+            <div className="mt-6 flex justify-end">
+              <button onClick={() => setDetails(null)}
+                      className="px-4 py-2 rounded-lg bg-primary text-white text-sm font-bold">Close</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/leakpro/webapp/frontend/src/components/results/Summary.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Summary.tsx
@@ -148,6 +148,37 @@ const HOW_IT_WORKS = (
   </>
 );
 
+const HOW_PROTECTION = (
+  <>
+    <p>
+      Your model is retrained many times, each with a different strength of protection. Every version is
+      attacked the same way the audit attacked the original and scored for quality, so you can see the
+      trade-off and pick a setting.
+    </p>
+    <Detail>
+      <p>
+        The protection is noise added during training (differentially private training). Four settings are
+        varied together — how much noise, how strongly individual examples are capped, the learning rate,
+        and the batch size — because tuning them separately misses the best combinations.
+      </p>
+      <p>
+        Attack success means the share of training records an attacker identifies at a 1% false-alarm
+        rate, the same measure as this table. The attacker is given the same advantage as in the audit:
+        reference models trained exactly like the tested one.
+      </p>
+      <p>
+        The search uses a faster, approximate version of the attack. The setting you confirm is re-checked
+        with a stronger attack before it can be adopted, and the estimate and the verified number are
+        shown side by side — if the estimate was optimistic, that is flagged rather than hidden.
+      </p>
+      <p className="text-xs text-slate-400">
+        The formal privacy budget (ε) is recorded next to every measured result, so the empirical and the
+        mathematical guarantee can be compared.
+      </p>
+    </Detail>
+  </>
+);
+
 const ABOUT_ALPHA = (
   <>
     <p>How many false alarms the attacker puts up with. Lower is stricter. Use 1% unless you have a reason not to.</p>
@@ -435,6 +466,19 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
         </div>
       </div>
 
+      {/* Protection bar, same shape as the risk bar: title, info, one line. */}
+      {onOptimize && (
+        <div className="flex items-center justify-between gap-3 flex-wrap rounded-xl border border-slate-200 dark:border-surface-border bg-slate-50 dark:bg-surface px-4 py-3">
+          <div>
+            <p className="font-bold text-sm flex items-center gap-1">
+              Optimize protection
+              <InfoButton label="How protection is optimized" title="How protection is optimized">{HOW_PROTECTION}</InfoButton>
+            </p>
+            <p className="text-xs text-slate-400">{COPY.sectionBlurb}</p>
+          </div>
+        </div>
+      )}
+
       {error && (
         <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-500">{error}</div>
       )}
@@ -561,21 +605,27 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
                         : <span className="text-slate-400">—</span>}
                     </td>
                     <td className="px-4 py-3">
-                      <div className="flex items-center justify-end gap-1">
+                      <div className="flex items-center justify-end gap-1.5 flex-wrap">
                         <button
                           onClick={() => setWizard(key)}
                           title={a ? "Change this model's use case" : "Declare this model's use case"}
-                          className={`material-symbols-outlined text-base transition-colors ${a ? "text-primary" : "text-slate-400 hover:text-primary"}`}
+                          className={`flex items-center gap-1 px-2 py-1 rounded-lg border text-xs font-bold whitespace-nowrap transition-colors ${
+                            a
+                              ? "border-primary/50 text-primary hover:bg-primary/5"
+                              : "border-slate-300 dark:border-surface-border text-slate-500 hover:text-primary hover:border-primary/50"
+                          }`}
                         >
-                          balance
+                          <span className="material-symbols-outlined text-sm">balance</span>
+                          Risk assessment
                         </button>
                         {onOptimize && (
                           <button
                             onClick={() => onOptimize(m)}
                             title={COPY.entry}
-                            className="material-symbols-outlined text-base text-slate-400 hover:text-primary transition-colors"
+                            className="flex items-center gap-1 px-2 py-1 rounded-lg border border-slate-300 dark:border-surface-border text-xs font-bold text-slate-500 hover:text-primary hover:border-primary/50 whitespace-nowrap transition-colors"
                           >
-                            shield
+                            <span className="material-symbols-outlined text-sm">shield</span>
+                            {COPY.entry}
                           </button>
                         )}
                       </div>

--- a/leakpro/webapp/frontend/src/components/results/Summary.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Summary.tsx
@@ -19,25 +19,31 @@ import RiskDiagram from "./RiskDiagram";
  */
 
 export interface RiskState {
-  draft: RiskRequest;
-  applied: RiskRequest | null;
+  /** Per-model declarations, keyed like `assessments`. Declaring is per model because the
+   *  population at risk is a property of the training split (f_train), not the dataset.
+   *  PARKED: nothing stops two models on identical data being declared with different
+   *  sensitivities; a copy-from-model affordance is the known fix, deferred for now. */
+  drafts: Record<string, RiskRequest>;
+  applied: Record<string, RiskRequest>;
   /** Keyed by `${job_id}/${model_name}` — model names are not unique across jobs in compare mode. */
   assessments: Record<string, RiskAssessment>;
   unassessable: Record<string, string>;
   error: string | null;
 }
 
+export const DEFAULT_PROFILE: RiskRequest = {
+  tolerated_fpr: 0.01,
+  attacker_prior: 0.5,
+  records_per_subject: 1,
+  data_type_sensitivity: 1,
+  subject_type_weight: 1,
+  extrapolate_to_population: false,
+  notes: "",
+};
+
 export const initialRiskState: RiskState = {
-  draft: {
-    tolerated_fpr: 0.01,
-    attacker_prior: 0.5,
-    records_per_subject: 1,
-    data_type_sensitivity: 1,
-    subject_type_weight: 1,
-    extrapolate_to_population: false,
-    notes: "",
-  },
-  applied: null,
+  drafts: {},
+  applied: {},
   assessments: {},
   unassessable: {},
   error: null,
@@ -276,36 +282,65 @@ const ABOUT_BAND = (
 export default function Summary({ results, onOptimize, risk, onRiskChange }: Props) {
   // Ephemeral view state only. Anything the user would be annoyed to lose lives in `risk`.
   const [openKey, setOpenKey] = useState<string | null>(null);
-  const [wizard, setWizard] = useState(false);
+  // The model key being declared, or null when the wizard is closed.
+  const [wizard, setWizard] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [details, setDetails] = useState<string | null>(null);
 
-  const { draft, applied, assessments, unassessable, error } = risk;
-  const setDraft = (next: RiskRequest) => onRiskChange({ ...risk, draft: next });
+  const { drafts, applied, assessments, unassessable, error } = risk;
 
-  const alpha = applied?.tolerated_fpr ?? draft.tolerated_fpr;
+  // A model declared for the first time is seeded from the last profile the user
+  // submitted anywhere: judgement fields rarely differ across models of one
+  // comparison, so carrying them over is the cheap consistency default.
+  const appliedProfiles = Object.values(applied);
+  const lastApplied = appliedProfiles[appliedProfiles.length - 1];
+  const draft = (wizard ? drafts[wizard] : undefined) ?? lastApplied ?? DEFAULT_PROFILE;
+  const setDraft = (next: RiskRequest) => {
+    if (wizard) onRiskChange({ ...risk, drafts: { ...drafts, [wizard]: next } });
+  };
+
+  // Display fallback for rows not yet assessed; assessed rows use their own alpha.
+  const alpha = lastApplied?.tolerated_fpr ?? DEFAULT_PROFILE.tolerated_fpr;
+  const alphaFor = (key: string) => applied[key]?.tolerated_fpr ?? alpha;
   const toggleInfo = (key: string) => setOpenKey((prev) => (prev === key ? null : key));
 
+  const wizardModel = wizard ? results.find((m) => modelKey(m) === wizard) : undefined;
+  // Left blank, the backend fills NDS with the model's exact num_train from its
+  // metadata; this estimate only makes that visible in the placeholder.
+  const derivedSubjects =
+    wizardModel?.train_meta?.n_samples != null && wizardModel?.train_meta?.f_train != null
+      ? Math.round(wizardModel.train_meta.n_samples * wizardModel.train_meta.f_train)
+      : undefined;
+
   const submit = async () => {
-    // Compare mode can show models from several jobs, and the endpoint is per job, so assess each job
-    // the visible models come from and merge under composite keys.
-    const jobIds = Array.from(new Set(results.map((m) => m.job_id).filter((v): v is string => !!v)));
-    if (!jobIds.length) {
-      onRiskChange({ ...risk, error: "No job id on these results." });
+    // One model per request: the population at risk follows the training split,
+    // so each model carries its own declaration.
+    const m = wizardModel;
+    if (!wizard || !m) return;
+    if (!m.job_id) {
+      onRiskChange({ ...risk, error: "No job id on this model." });
       return;
     }
     setBusy(true);
     onRiskChange({ ...risk, error: null });
     try {
-      const responses = await Promise.all(jobIds.map((id) => api.assessRisk(id, draft)));
-      const assessed: Record<string, RiskAssessment> = {};
-      const failed: Record<string, string> = {};
-      responses.forEach((res, i) => {
-        Object.entries(res.assessments).forEach(([name, a]) => { assessed[`${jobIds[i]}/${name}`] = a; });
-        Object.entries(res.unassessable).forEach(([name, why]) => { failed[`${jobIds[i]}/${name}`] = why; });
+      const res = await api.assessRisk(m.job_id, { ...draft, model_name: m.orig_model_name ?? m.model_name });
+      const assessed = { ...assessments };
+      const failed = { ...unassessable };
+      delete assessed[wizard];
+      delete failed[wizard];
+      // The response is keyed by the backend name; re-key to the display name.
+      Object.values(res.assessments).forEach((a) => { assessed[wizard] = a; });
+      Object.values(res.unassessable).forEach((why) => { failed[wizard] = why; });
+      onRiskChange({
+        ...risk,
+        assessments: assessed,
+        unassessable: failed,
+        applied: { ...applied, [wizard]: draft },
+        drafts: { ...drafts, [wizard]: draft },
+        error: null,
       });
-      onRiskChange({ ...risk, assessments: assessed, unassessable: failed, applied: draft, error: null });
-      setWizard(false);
+      setWizard(null);
     } catch (e) {
       onRiskChange({ ...risk, error: e instanceof Error ? e.message : String(e) });
     } finally {
@@ -323,11 +358,12 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
     const rows = [header.join(",")];
     results.forEach((m) => {
       const a = assessments[modelKey(m)];
-      const tpr = bestTpr(m, alpha);
+      const rowAlpha = alphaFor(modelKey(m));
+      const tpr = bestTpr(m, rowAlpha);
       rows.push([
         m.model_name,
         m.model_class ?? "",
-        alpha,
+        rowAlpha,
         a?.measured.success_rate?.toFixed(6) ?? tpr?.value.toFixed(6) ?? "",
         a?.measured.advantage?.toFixed(6) ?? "",
         a?.measured.lift?.toFixed(3) ?? "",
@@ -354,7 +390,6 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
     URL.revokeObjectURL(url);
   };
 
-  const alphaLabel = ALPHAS.find((a) => a.value === alpha)?.label ?? `${alpha * 100}%`;
   const shown = details ? assessments[details] : undefined;
 
   return (
@@ -364,13 +399,14 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           {results.map((m) => {
             const a = assessments[modelKey(m)];
-            const tpr = bestTpr(m, alpha);
+            const cardAlpha = alphaFor(modelKey(m));
+            const tpr = bestTpr(m, cardAlpha);
             const style = bandStyle(a?.combined.vulnerability_band);
             return (
               <div key={modelKey(m)}
                    className={a ? `rounded-xl p-4 ${style.bg}` : "rounded-xl p-4 bg-slate-50 dark:bg-surface border border-slate-200 dark:border-surface-border"}>
                 <p className={`text-2xl font-black ${a ? style.color : "text-primary"}`}>
-                  {a ? a.combined.vulnerability_band : `${num(tpr ? tpr.value / alpha : undefined, 1)}×`}
+                  {a ? a.combined.vulnerability_band : `${num(tpr ? tpr.value / cardAlpha : undefined, 1)}×`}
                 </p>
                 <p className="text-[11px] uppercase tracking-wider text-slate-400 -mt-0.5">
                   {a ? "vulnerability" : "vs random"}
@@ -392,17 +428,11 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
             <InfoButton label="How risk is computed" title="How risk is computed">{HOW_IT_WORKS}</InfoButton>
           </p>
           <p className="text-xs text-slate-400">
-            {applied
-              ? `α = ${alphaLabel} FPR · π = ${applied.attacker_prior} · policy ${Object.values(assessments)[0]?.policy_version ?? "—"}`
-              : "Measured leakage is above. Add your use case to turn it into risk."}
+            {appliedProfiles.length > 0
+              ? `${appliedProfiles.length} of ${results.length} model${results.length !== 1 ? "s" : ""} assessed · policy ${Object.values(assessments)[0]?.policy_version ?? "—"}`
+              : "Measured leakage is above. Declare each model's use case with the buttons in the table."}
           </p>
         </div>
-        <button
-          onClick={() => setWizard(true)}
-          className="px-3 py-1.5 rounded-lg bg-primary text-white text-xs font-bold hover:opacity-90 transition-opacity"
-        >
-          {applied ? "Change inputs" : "Declare your use case"}
-        </button>
       </div>
 
       {error && (
@@ -417,33 +447,6 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
               <li key={key}><b>{key.slice(key.indexOf("/") + 1)}</b>: {reason}</li>
             ))}
           </ul>
-        </div>
-      )}
-
-      {/* Protection — one entry per model, since each is optimized on its own */}
-      {onOptimize && results.length > 0 && (
-        <div className="rounded-xl border border-slate-200 dark:border-surface-border p-4 flex flex-col gap-3">
-          <div>
-            <p className="font-bold text-sm">Reduce the risk</p>
-            <p className="text-xs text-slate-500 mt-0.5">
-              Test protection settings automatically and see the best trade-offs between privacy and quality.
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {results.map((m) => (
-              <button
-                key={`${m.job_id}/${m.model_name}`}
-                onClick={() => onOptimize(m)}
-                className="flex items-center gap-2 px-4 py-2 rounded-lg border border-primary/50 text-primary text-sm font-bold hover:bg-primary/5 transition-colors"
-              >
-                <span className="material-symbols-outlined text-base">shield</span>
-                {COPY.entry}
-                {results.length > 1 && (
-                  <span className="font-normal text-slate-400">· {m.model_name}</span>
-                )}
-              </button>
-            ))}
-          </div>
         </div>
       )}
 
@@ -464,7 +467,7 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
             <tr>
               <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Model</th>
               <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
-                TPR@{alphaLabel} <InfoButton label={`TPR at ${alphaLabel} FPR`}>{ABOUT_TPR}</InfoButton>
+                TPR@α <InfoButton label="TPR at the tolerated FPR (α)">{ABOUT_TPR}</InfoButton>
               </th>
               <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
                 Lift <InfoButton label="Lift over random guessing">{ABOUT_LIFT}</InfoButton>
@@ -479,13 +482,15 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
               <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">
                 Band <InfoButton label="Vulnerability band">{ABOUT_BAND}</InfoButton>
               </th>
+              <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200 dark:divide-surface-border">
             {results.map((m) => {
               const key = modelKey(m);
               const a = assessments[key];
-              const tpr = bestTpr(m, alpha);
+              const rowAlpha = alphaFor(key);
+              const tpr = bestTpr(m, rowAlpha);
               const style = bandStyle(a?.combined.vulnerability_band);
               const isOpen = openKey === key;
               return (
@@ -536,7 +541,7 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
                         ? <>{pct(tpr.value)} <span className="text-slate-400 font-sans text-xs">({tpr.attack})</span></>
                         : "—"}
                     </td>
-                    <td className="px-4 py-3 font-mono">{tpr ? `${num(tpr.value / alpha, 1)}×` : "—"}</td>
+                    <td className="px-4 py-3 font-mono">{tpr ? `${num(tpr.value / rowAlpha, 1)}×` : "—"}</td>
                     <td className="px-4 py-3 font-mono">
                       {a?.combined.ppv != null
                         ? <>{pct(a.combined.ppv)} <span className="text-slate-400 font-sans text-xs">(π={a.declared.attacker_prior})</span></>
@@ -555,10 +560,30 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
                         ? <span className={`font-bold ${style.color}`}>{a.combined.vulnerability_band}</span>
                         : <span className="text-slate-400">—</span>}
                     </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          onClick={() => setWizard(key)}
+                          title={a ? "Change this model's use case" : "Declare this model's use case"}
+                          className={`material-symbols-outlined text-base transition-colors ${a ? "text-primary" : "text-slate-400 hover:text-primary"}`}
+                        >
+                          balance
+                        </button>
+                        {onOptimize && (
+                          <button
+                            onClick={() => onOptimize(m)}
+                            title={COPY.entry}
+                            className="material-symbols-outlined text-base text-slate-400 hover:text-primary transition-colors"
+                          >
+                            shield
+                          </button>
+                        )}
+                      </div>
+                    </td>
                   </tr>
                   {isOpen && (
                     <tr className="bg-slate-50 dark:bg-surface/60">
-                      <td colSpan={7} className="px-6 py-4"><MetaPanel r={m} /></td>
+                      <td colSpan={8} className="px-6 py-4"><MetaPanel r={m} /></td>
                     </tr>
                   )}
                 </React.Fragment>
@@ -573,7 +598,8 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
         {results.map((m) => {
           const key = modelKey(m);
           const a = assessments[key];
-          const tpr = bestTpr(m, alpha);
+          const proseAlpha = alphaFor(modelKey(m));
+          const tpr = bestTpr(m, proseAlpha);
           const style = bandStyle(a?.combined.vulnerability_band);
           return (
             <div key={key}
@@ -585,7 +611,7 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
               </p>
               <p className="text-sm text-slate-600 dark:text-slate-300">
                 {tpr
-                  ? `At a ${alphaLabel} false-positive rate, ${tpr.attack} identifies ${pct(tpr.value)} of training members, ${num(tpr.value / alpha, 1)}× better than chance.`
+                  ? `At a ${ALPHAS.find((x) => x.value === proseAlpha)?.label ?? pct(proseAlpha)} false-positive rate, ${tpr.attack} identifies ${pct(tpr.value)} of training members, ${num(tpr.value / proseAlpha, 1)}× better than chance.`
                   : "No usable attack results at this operating point."}
                 {a?.combined.ppv != null && ` An attacker claiming membership would be right ${pct(a.combined.ppv)} of the time.`}
               </p>
@@ -604,11 +630,11 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
 
       {/* Wizard: labels and inputs only, explanations behind info buttons */}
       {wizard && (
-        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4" onClick={() => setWizard(false)}>
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4" onClick={() => setWizard(null)}>
           <div className="max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-2xl bg-white dark:bg-surface-deep p-6 shadow-2xl"
                onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-black mb-1 flex items-center gap-1">
-              Your use case
+              Use case — {wizardModel?.model_name ?? ""}
               <InfoButton label="How risk is computed" title="How risk is computed">{HOW_IT_WORKS}</InfoButton>
             </h3>
             <p className="text-xs text-slate-500 mb-5">Only you can supply these. Defaults are neutral.</p>
@@ -651,7 +677,8 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
                 <label className="flex flex-col gap-1">
                   <span className="font-bold">Data subjects (NDS)</span>
                   <input
-                    type="number" min={1} placeholder="training-set size"
+                    type="number" min={1}
+                    placeholder={derivedSubjects != null ? `from metadata (~${derivedSubjects.toLocaleString()})` : "training-set size"}
                     className="rounded-lg border border-slate-300 dark:border-surface-border bg-transparent px-3 py-2"
                     value={draft.n_subjects ?? ""}
                     onChange={(e) => setDraft({ ...draft, n_subjects: e.target.value ? Number(e.target.value) : undefined })}
@@ -740,7 +767,7 @@ export default function Summary({ results, onOptimize, risk, onRiskChange }: Pro
             </div>
 
             <div className="mt-6 flex justify-end gap-2">
-              <button onClick={() => setWizard(false)}
+              <button onClick={() => setWizard(null)}
                       className="px-4 py-2 rounded-lg border border-slate-300 dark:border-surface-border text-sm font-bold">
                 Cancel
               </button>

--- a/leakpro/webapp/frontend/src/components/results/Summary.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Summary.tsx
@@ -1,8 +1,13 @@
 import React, { useState } from "react";
 import { ModelResult } from "../../api";
 import MetaPanel from "./MetaPanel";
+import { COPY } from "./optimizationCopy";
 
-interface Props { results: ModelResult[] }
+interface Props {
+  results: ModelResult[];
+  /** Opens the optimization view for one model. Omitted when unavailable. */
+  onOptimize?: (model: ModelResult) => void;
+}
 
 function riskLevel(auc: number | undefined): { label: string; color: string; bg: string } {
   if (auc === undefined) return { label: "N/A", color: "text-slate-400", bg: "bg-slate-100 dark:bg-surface-2" };
@@ -30,7 +35,7 @@ function pct(v: number | undefined) {
   return v !== undefined ? (v * 100).toFixed(1) + "%" : "—";
 }
 
-export default function Summary({ results }: Props) {
+export default function Summary({ results, onOptimize }: Props) {
   const [openKey, setOpenKey] = useState<string | null>(null);
 
   const toggleInfo = (key: string) => setOpenKey((prev) => (prev === key ? null : key));
@@ -79,6 +84,33 @@ export default function Summary({ results }: Props) {
         </div>
       )}
 
+      {/* Protection — one entry per model, since each is optimized on its own */}
+      {onOptimize && results.length > 0 && (
+        <div className="rounded-xl border border-slate-200 dark:border-slate-800 p-4 flex flex-col gap-3">
+          <div>
+            <p className="font-bold text-sm">Reduce the risk</p>
+            <p className="text-xs text-slate-500 mt-0.5">
+              Test protection settings automatically and see the best trade-offs between privacy and quality.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {results.map((m) => (
+              <button
+                key={`${m.job_id}/${m.model_name}`}
+                onClick={() => onOptimize(m)}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg border border-primary/50 text-primary text-sm font-bold hover:bg-primary/5 transition-colors"
+              >
+                <span className="material-symbols-outlined text-base">shield</span>
+                {COPY.entry}
+                {results.length > 1 && (
+                  <span className="font-normal text-slate-400">· {m.model_name}</span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Comparison table */}
       <div className="rounded-xl border border-slate-200 dark:border-surface-border overflow-hidden">
         <div className="flex items-center justify-between px-3 py-2 bg-slate-50 dark:bg-surface border-b border-slate-200 dark:border-surface-border">
@@ -115,6 +147,11 @@ export default function Summary({ results }: Props) {
                     <td className="px-4 py-3 font-semibold">
                       <div className="flex items-center gap-2 flex-wrap">
                         {m.model_name}
+                        {m.optimized && (
+                          <span className="text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary font-bold uppercase tracking-wider">
+                            optimized
+                          </span>
+                        )}
                         {m.model_class && (
                           <span className="text-xs px-1.5 py-0.5 rounded bg-slate-100 dark:bg-surface-2 text-slate-500 font-mono">
                             {m.model_class}

--- a/leakpro/webapp/frontend/src/components/results/Summary.tsx
+++ b/leakpro/webapp/frontend/src/components/results/Summary.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { api, ModelResult, RiskAssessment, RiskRequest } from "../../api";
-import InfoButton from "../InfoButton";
+import InfoButton, { Detail } from "../InfoButton";
 import MetaPanel from "./MetaPanel";
 import RiskDiagram from "./RiskDiagram";
 
@@ -108,165 +108,166 @@ function bestTpr(model: ModelResult, alpha: number): { value: number; attack: st
 }
 
 // ---------------------------------------------------------------------------
-// Explanation content. Kept here, out of the layout, so the panels stay readable.
+// Explanation content. Each one opens with a plain-language lead; the depth sits behind a nested
+// Detail disclosure so the first thing a reader sees is never a wall of text.
 // ---------------------------------------------------------------------------
 
 const HOW_IT_WORKS = (
   <>
     <p>
-      The audit measures how often an attack correctly identifies a training member. Whether that
-      matters depends on your deployment, which LeakPro cannot observe. So the assessment keeps the two
-      halves apart and combines them without inventing any weights.
+      The audit measures how often an attack succeeds. You say how much a success would cost. Risk is
+      those two multiplied.
     </p>
     <RiskDiagram className="my-1" />
-    <p>
-      <b>Nothing is hidden in a coefficient.</b> Every number is either measured by this audit or
-      declared by you, and the result lists the assumption behind each derived figure.
-    </p>
-    <p>
-      <b>Why Loss Event Frequency is just the measured success rate.</b> In the published model,
-      <code> LEF = V × (RP × TEF)</code>, where <b>RP</b> is the <i>retention period</i> — how long the
-      data stays available to be attacked — and <b>TEF</b> is the <i>threat event frequency</i>, how
-      often an adversary tries. LeakPro can observe neither, so both are set to 1: a single attack
-      attempt against a model that is retained. If repeated attempts are plausible in your setting,
-      the real frequency is higher than this assessment assumes, and you should scale it up yourself.
-    </p>
-    <p className="text-xs text-slate-400">
-      Structure: Sion, Van Landuyt, Wuyts &amp; Joosen, “Privacy Risk Assessment for Data
-      Subject-aware Threat Modeling”, IWPE 2019. Precision: Jayaraman, Wang, Knipmeyer, Gu &amp; Evans,
-      “Revisiting Membership Inference Under Realistic Assumptions”, PoPETs 2021, Theorem 4.2.
-      Sensitivity scale: CNIL PIA-3 knowledge bases, 2018.
-    </p>
+    <Detail>
+      <p>
+        Nothing is hidden in a coefficient: every number is either measured here or declared by you, and
+        the result lists the assumption behind each derived figure.
+      </p>
+      <p>
+        Loss Event Frequency is the measured success rate on its own because the published model puts two
+        more factors in it — retention period (how long the data stays attackable) and threat event
+        frequency (how often an adversary tries). LeakPro can observe neither, so both are set to 1: one
+        attempt on a model that is kept. If repeated attempts are plausible for you, real frequency is
+        higher than this assumes.
+      </p>
+      <p className="text-xs text-slate-400">
+        Structure: Sion, Van Landuyt, Wuyts &amp; Joosen, IWPE 2019. Precision: Jayaraman, Wang,
+        Knipmeyer, Gu &amp; Evans, PoPETs 2021, Theorem 4.2. Sensitivity scale: CNIL PIA-3, 2018.
+      </p>
+    </Detail>
   </>
 );
 
 const ABOUT_ALPHA = (
   <>
-    <p>
-      α is the false-positive rate the attacker is assumed to tolerate. It sets the operating point the
-      whole assessment is read at, so there is no default: the choice is yours.
-    </p>
-    <ul className="list-disc ml-5 flex flex-col gap-1">
-      <li><b>1%</b> — resolvable on the audit set sizes most targets have. Start here.</li>
-      <li><b>0.1%</b> — stricter. Needs at least 1000 non-members to be measurable at all.</li>
-      <li><b>0.01%</b> — very strict. Needs at least 10000 non-members.</li>
-    </ul>
-    <p>
-      Below the resolution of your audit set, a true positive rate of zero means “not measurable”, not
-      “no leakage”. The backend refuses to report derived figures there rather than let you read a zero
-      as safety.
-    </p>
+    <p>How many false alarms the attacker puts up with. Lower is stricter. Use 1% unless you have a reason not to.</p>
+    <Detail>
+      <p>
+        A stricter rate needs a bigger audit set to be measurable at all: you need at least 1/α
+        non-members, so 1000 for 0.1% and 10000 for 0.01%.
+      </p>
+      <p>
+        Below that, a true positive rate of zero means “not measurable”, not “no leakage”, so the
+        derived figures are withheld rather than letting a zero read as safety.
+      </p>
+    </Detail>
   </>
 );
 
 const ABOUT_PRIOR = (
   <>
     <p>
-      π is the share of the attacker’s candidate pool that really are members. It does not change the
-      measurement; it changes what the measurement means.
+      How common members are in the pool the attacker is guessing from. The audit assumes half of them
+      are, which makes any attack look better than it would in practice.
     </p>
-    <p>
-      The audit runs on a balanced split, so every TPR and AUC it reports implicitly assumes π = 0.5.
-      Real pools are usually far more skewed, and precision falls steeply as they are. At a 1%
-      false-positive rate and a measured TPR of 10%, an attacker is right 91% of the time at π = 0.5 —
-      and about 1% of the time at π = 0.001.
-    </p>
-    <p>Both values are always reported, so a balanced-prior figure can never be quoted by accident.</p>
+    <Detail>
+      <p>
+        It changes what the measurement means, not the measurement. With a 10% true positive rate at a 1%
+        false-alarm rate, an attacker is right 91% of the time if half the pool are members, and about 1%
+        of the time if one in a thousand are.
+      </p>
+      <p>Both values are always reported, so the flattering one can never be quoted by accident.</p>
+    </Detail>
   </>
 );
 
 const ABOUT_FACTORS = (
   <>
     <p>
-      These four are the Loss Magnitude factors from Sion et al.: <code>LM = DTS × NR × DST × NDS</code>.
-      The paper deliberately supplies no numeric values for them, so they are yours to set. All default
-      to a neutral 1.0, which reduces the loss magnitude to a plain count of subjects.
+      Four numbers describing how bad a leak would be for the people in your data. All default to 1,
+      meaning no weighting.
     </p>
-    <ul className="list-disc ml-5 flex flex-col gap-1">
-      <li><b>DTS</b> — sensitivity of the leaked data type. The CNIL PIA severity levels are a defensible starting scale.</li>
-      <li><b>NR</b> — records of this data type per subject. Fractions are fine when only some subjects contribute it.</li>
-      <li><b>DST</b> — weight for the subject type. Raise it for vulnerable subjects such as minors or patients.</li>
-      <li><b>NDS</b> — number of data subjects. Left blank, the target’s training-set size is used.</li>
-    </ul>
-    <p className="text-xs text-slate-400">
-      Sion et al. note the model assumes these factors are independent, which they flag as a
-      simplification of reality. That assumption is recorded in every assessment.
-    </p>
+    <Detail>
+      <ul className="list-disc ml-5 flex flex-col gap-1">
+        <li><b>Sensitivity</b> — how revealing the leaked data type is. The CNIL PIA severity levels are a defensible scale.</li>
+        <li><b>Records per subject</b> — fractions are fine when only some subjects contribute the data.</li>
+        <li><b>Subject weight</b> — raise it for vulnerable subjects such as minors or patients.</li>
+        <li><b>Data subjects</b> — left blank, the target’s training-set size is used.</li>
+      </ul>
+      <p>
+        These are the Loss Magnitude factors of Sion et al., who supply the structure but deliberately no
+        values, and who note the model treats the factors as independent — a simplification recorded in
+        every assessment.
+      </p>
+    </Detail>
   </>
 );
 
 const ABOUT_TPR = (
-  <p>
-    Of all the training members in the audit set, the share the strongest attack correctly identifies
-    while keeping its false-positive rate at or below α. Attacks whose ROC is inverted (AUC below 0.5)
-    are excluded rather than counted as weak evidence.
-  </p>
+  <>
+    <p>Share of training members the best attack finds, at your false-alarm rate.</p>
+    <Detail>
+      <p>
+        Attacks whose ROC is inverted (AUC below 0.5) are excluded rather than counted as weak evidence,
+        because an inverted result makes a real leak read as no leak.
+      </p>
+    </Detail>
+  </>
 );
 
 const ABOUT_LIFT = (
-  <p>
-    How many times better than random guessing the attack is at this operating point: TPR divided by α.
-    A lift of 1× is no better than chance. The band label is derived from this figure alone, and it is
-    an unsourced convenience — no published thresholds exist for it.
-  </p>
+  <>
+    <p>How many times better than guessing the attack is. 1× is chance.</p>
+    <Detail>
+      <p>
+        True positive rate divided by the false-alarm rate. The band label comes from this figure alone,
+        and its thresholds are round numbers rather than anything published.
+      </p>
+    </Detail>
+  </>
 );
 
 const ABOUT_PPV = (
   <>
-    <p>
-      If the attacker claims a record was in the training set, how often are they right? This is the
-      number that decides whether a leak is actionable, and it depends on your declared prior π as much
-      as on the attack.
-    </p>
-    <p className="font-mono text-xs">PPV = TPR / (TPR + γ·α), γ = (1 − π) / π</p>
-    <p>
-      <b>γ is how outnumbered the members are:</b> for every genuine member in the attacker’s candidate
-      pool there are γ non-members. It is derived from your π, not a separate input — π = 0.5 gives
-      γ = 1, π = 0.01 gives γ = 99, π = 0.001 gives γ = 999.
-    </p>
-    <p>
-      That is why it multiplies the false-positive rate. At π = 0.001 with a measured TPR of 10% and
-      α = 1%, each member yields 0.10 expected true positives while the 999 non-members yield
-      999 × 0.01 = 9.99 false ones — about ten false alarms per correct hit, so precision is roughly
-      1%. The identical measurement reads 91% at π = 0.5.
-    </p>
-    <p className="text-xs text-slate-400">
-      A tenfold more skewed pool costs as much precision as a tenfold looser threshold, which is the
-      same reason strict operating points matter.
-    </p>
+    <p>When the attacker says “this record was used in training”, how often they are right.</p>
+    <Detail>
+      <p className="font-mono text-xs">PPV = TPR / (TPR + γ·α), γ = (1 − π) / π</p>
+      <p>
+        γ is how outnumbered the members are: for every real member in the pool there are γ others. It
+        comes from your prior, so π = 0.5 gives γ = 1 and π = 0.001 gives γ = 999.
+      </p>
+      <p>
+        That is why it multiplies the false-alarm rate. At π = 0.001 with a 10% true positive rate and a
+        1% false-alarm rate, one member yields 0.10 correct flags while the other 999 yield about 10
+        wrong ones — so roughly ten false alarms per hit.
+      </p>
+    </Detail>
   </>
 );
 
 const ABOUT_EXPOSED = (
   <>
-    <p>
-      The measured success rate applied to your declared population: how many subjects an attacker would
-      be expected to identify. Sensitivity weights are deliberately left out of this figure so it stays
-      a plain count you can reason about.
-    </p>
-    <p>
-      <b>This count does not depend on π, and should not.</b> The true positive rate is conditional on a
-      record actually being a member, so it is unaffected by how the attacker’s pool is composed —
-      which means this figure already counts true positives only. Multiplying it by precision would be
-      circular, since precision times the flagged set <i>is</i> the true-positive count.
-    </p>
-    <p>
-      A skewed prior does not reduce how many members are genuinely identified; it increases the false
-      accusations sitting alongside them. So read the two columns as different questions: this one is
-      how many people the attack really exposes, precision is how far an attacker can trust any single
-      claim. “1000 exposed at 1% precision” and “40 exposed at 99% precision” are both real findings,
-      and they call for different responses.
-    </p>
+    <p>Roughly how many of your subjects an attacker would actually identify.</p>
+    <Detail>
+      <p>
+        This count does not depend on the prior, and should not. The true positive rate is conditional on
+        a record really being a member, so the figure already counts correct identifications only.
+        Multiplying it by precision would be circular, since precision times the flagged set is that same
+        count.
+      </p>
+      <p>
+        A skewed prior does not reduce how many members are identified; it adds false accusations beside
+        them. So read the two columns as different questions: this one is how many people are exposed,
+        precision is how far a single claim can be trusted.
+      </p>
+      <p>Sensitivity weights are left out on purpose, so this stays a plain count.</p>
+    </Detail>
   </>
 );
 
 const ABOUT_BAND = (
-  <p>
-    An advisory label over the measured lift only, never over the combination of measurement and
-    judgement. The thresholds are round numbers chosen so that NONE means no better than chance and
-    SEVERE means two orders of magnitude better than chance. They are not calibrated against anything
-    published, which is why the policy version travels with every assessment.
-  </p>
+  <>
+    <p>A rough label for the measured lift. Advisory only.</p>
+    <Detail>
+      <p>
+        It labels the measurement, never the combination of measurement and judgement. NONE means no
+        better than chance and SEVERE means two orders of magnitude better, but the thresholds are not
+        calibrated against anything published — which is why the policy version travels with every
+        assessment.
+      </p>
+    </Detail>
+  </>
 );
 
 export default function Summary({ results, risk, onRiskChange }: Props) {
@@ -655,11 +656,13 @@ export default function Summary({ results, risk, onRiskChange }: Props) {
                 <span className="font-bold flex items-center gap-1">
                   Cost per exposed subject
                   <InfoButton label="Cost per exposed subject">
-                    <p>
-                      Optional, in any unit you choose. Left blank, no monetary figure is reported at
-                      all — a default cost would be fabricated, and a fabricated cost is worse than
-                      none.
-                    </p>
+                    <p>Optional, in any unit you like.</p>
+                    <Detail>
+                      <p>
+                        Left blank, no monetary figure is reported at all. A default cost would be made
+                        up, and a made-up cost is worse than none.
+                      </p>
+                    </Detail>
                   </InfoButton>
                 </span>
                 <input
@@ -679,11 +682,13 @@ export default function Summary({ results, risk, onRiskChange }: Props) {
                 <span className="flex items-center gap-1">
                   Extrapolate exposed records to the full training set
                   <InfoButton label="Extrapolation">
-                    <p>
-                      Scales the exposed-record count from the audit set up to the training population.
-                      Off by default: per-record vulnerability is strongly non-uniform, so this is an
-                      estimate under an assumption, not a measurement.
-                    </p>
+                    <p>Scales the exposed count from the audit set up to the whole training set.</p>
+                    <Detail>
+                      <p>
+                        Off by default, because some records are far more exposed than others. The
+                        scaled number is an estimate under that assumption, not a measurement.
+                      </p>
+                    </Detail>
                   </InfoButton>
                 </span>
               </label>

--- a/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
+++ b/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
@@ -1,0 +1,74 @@
+/**
+ * Plain-language labels for the optimization view.
+ *
+ * The audience includes non-technical public-sector users, so the search
+ * method is never named: no "Bayesian", no "Pareto", no "acquisition". Keep
+ * every visible string in this file so the vocabulary stays reviewable in one
+ * place rather than scattered through JSX.
+ */
+
+export const COPY = {
+  entry: "Find the best protection",
+  title: "Find the best protection",
+  intro:
+    "We train your model many times with different protection settings and test each one, " +
+    "then show you the best trade-offs between privacy and quality.",
+
+  constraintLabel: "Maximum acceptable quality loss",
+  constraintHelp: "How much accuracy you are willing to give up in exchange for protection.",
+  baselineLabel: "Current quality, without protection",
+  floorLabel: "Quality floor",
+
+  advanced: "Advanced",
+  advancedHelp: "Defaults come from the optimization run. Change these only if you know why.",
+
+  start: "Start",
+  running: "Testing protection settings…",
+  testedOf: (done: number, total?: number) =>
+    total ? `Tested ${done} of ${total} settings` : `Tested ${done} settings`,
+
+  axisAttack: "Attack success (%) — lower is safer",
+  axisQuality: "Model quality (%) — higher is better",
+  fprNote:
+    "Attack success is the share of training records an attacker correctly identifies, " +
+    "measured at a 1% false-alarm rate.",
+
+  resultsTitle: "Best trade-offs",
+  resultsBlurb:
+    "Each highlighted setting is the best available at its level of protection. " +
+    "Everything tested is shown in grey behind them.",
+  exceedsLimit: "Exceeds your quality limit",
+  qualityLimitLine: "Your quality limit",
+
+  panelTitle: "Protection setting",
+  estimatedAttack: "Estimated attack success",
+  estimatedQuality: "Estimated quality",
+  confirm: "Confirm this setting",
+
+  verifying: "Verifying with full audit…",
+  verifyingHelp:
+    "The search uses a faster, approximate test. This runs the full audit on the setting you picked " +
+    "so the numbers can be trusted.",
+  estimate: "Estimate",
+  verified: "Verified",
+  optimistic: "Estimate was optimistic — verified numbers shown",
+  adopt: "Adopt this configuration",
+  adopted: "Added to your results as an optimized setting.",
+
+  noResults: "No settings were tested successfully.",
+  failed: "The optimization run failed.",
+  back: "Back to results",
+} as const;
+
+/** Tags for the highlighted settings, ordered from most protective to highest quality. */
+const TAGS: Record<number, readonly string[]> = {
+  1: ["Balanced"],
+  2: ["Safest", "Best quality"],
+  3: ["Safest", "Balanced", "Best quality"],
+  4: ["Safest", "Safer", "Better quality", "Best quality"],
+  5: ["Safest", "Safer", "Balanced", "Better quality", "Best quality"],
+};
+
+export function tagsFor(count: number): readonly string[] {
+  return TAGS[count] ?? TAGS[5];
+}

--- a/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
+++ b/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
@@ -56,6 +56,10 @@ export const COPY = {
   adopted: "Added to your results as an optimized setting.",
 
   lowResolution: "These numbers rest on very few records.",
+  notMeasurable: "This result could not be measured directly.",
+  notMeasurableHelp:
+    "Too few records separated the protected model's answers, so this attack figure is estimated " +
+    "rather than observed. Treat it as unknown, not as proof of protection.",
   noResults: "No settings were tested successfully.",
   failed: "The optimization run failed.",
   retry: "Try again",

--- a/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
+++ b/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
@@ -58,6 +58,8 @@ export const COPY = {
   lowResolution: "These numbers rest on very few records.",
   noResults: "No settings were tested successfully.",
   failed: "The optimization run failed.",
+  retry: "Try again",
+  retryHint: "You can start it again — finished settings are kept.",
   back: "Back to results",
 } as const;
 

--- a/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
+++ b/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
@@ -55,6 +55,7 @@ export const COPY = {
   adopt: "Adopt this configuration",
   adopted: "Added to your results as an optimized setting.",
 
+  lowResolution: "These numbers rest on very few records.",
   noResults: "No settings were tested successfully.",
   failed: "The optimization run failed.",
   back: "Back to results",

--- a/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
+++ b/leakpro/webapp/frontend/src/components/results/optimizationCopy.ts
@@ -8,7 +8,8 @@
  */
 
 export const COPY = {
-  entry: "Find the best protection",
+  entry: "Optimize protection",
+  sectionBlurb: "Test protection settings per model with the buttons in the table.",
   title: "Find the best protection",
   intro:
     "We train your model many times with different protection settings and test each one, " +

--- a/leakpro/webapp/frontend/src/components/steps/Step7Results.tsx
+++ b/leakpro/webapp/frontend/src/components/steps/Step7Results.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { api, ModelResult, JobListItem } from "../../api";
+import { api, ModelResult, JobListItem, Setting, Verification } from "../../api";
 import Summary from "../results/Summary";
+import Optimization from "../results/Optimization";
 import RocChart from "../results/RocChart";
 import Histograms from "../results/Histograms";
 import Records from "../results/Records";
@@ -28,6 +29,7 @@ interface PendingRename {
 
 export default function Step7Results({ jobId, onRestart, autoOpenCompare }: Props) {
   const [allResults, setAllResults] = useState<ModelResult[] | null>(null);
+  const [optimizing, setOptimizing] = useState<ModelResult | null>(null);
   const [noResults, setNoResults] = useState(false);
   const [tab, setTab] = useState("summary");
 
@@ -123,12 +125,44 @@ export default function Step7Results({ jobId, onRestart, autoOpenCompare }: Prop
     });
   };
 
+  // An adopted setting becomes a normal summary row, tagged so it reads as
+  // the outcome of optimization rather than another audited model.
+  const addOptimizedRow = (base: ModelResult, setting: Setting, verification: Verification) => {
+    const verified = verification.verified;
+    if (!verified) return;
+    setAllResults((prev) => [
+      ...(prev ?? []),
+      {
+        ...base,
+        model_name: `${base.model_name} (optimized)`,
+        source: "optimized",
+        optimized: true,
+        dpsgd: true,
+        target_epsilon: setting.epsilon,
+        test_accuracy: verified.utility,
+        train_accuracy: undefined,
+        attacks: [],
+      },
+    ]);
+  };
+
   if (allResults === null) {
     return (
       <div className="flex flex-col items-center gap-4 py-16">
         <span className="material-symbols-outlined text-4xl text-primary animate-spin">sync</span>
         <p className="text-slate-500">Loading results…</p>
       </div>
+    );
+  }
+
+  if (optimizing) {
+    return (
+      <Optimization
+        jobId={jobId}
+        model={optimizing}
+        onBack={() => setOptimizing(null)}
+        onAdopted={(setting, verification) => addOptimizedRow(optimizing, setting, verification)}
+      />
     );
   }
 
@@ -303,7 +337,7 @@ export default function Step7Results({ jobId, onRestart, autoOpenCompare }: Prop
           </div>
 
           <div>
-            {tab === "summary"    && <Summary    results={allResults} />}
+            {tab === "summary"    && <Summary    results={allResults} onOptimize={setOptimizing} />}
             {tab === "roc"        && <RocChart   results={allResults} />}
             {tab === "histograms" && <Histograms results={allResults} />}
             {tab === "records"    && <Records    results={allResults} jobId={jobId} />}

--- a/leakpro/webapp/frontend/src/components/steps/Step7Results.tsx
+++ b/leakpro/webapp/frontend/src/components/steps/Step7Results.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { api, ModelResult, JobListItem } from "../../api";
-import Summary from "../results/Summary";
+import Summary, { RiskState, initialRiskState } from "../results/Summary";
 import RocChart from "../results/RocChart";
 import Histograms from "../results/Histograms";
 import Records from "../results/Records";
@@ -39,6 +39,10 @@ export default function Step7Results({ jobId, onRestart, autoOpenCompare }: Prop
 
   // Rename dialog state
   const [pendingRename, setPendingRename] = useState<PendingRename | null>(null);
+
+  // Risk assessment state. Held here rather than in Summary because the tab bar unmounts the tab
+  // components, which would throw away a completed assessment when the user looks at the ROC curves.
+  const [risk, setRisk] = useState<RiskState>(initialRiskState);
 
   useEffect(() => {
     api.getResults(jobId)
@@ -303,7 +307,7 @@ export default function Step7Results({ jobId, onRestart, autoOpenCompare }: Prop
           </div>
 
           <div>
-            {tab === "summary"    && <Summary    results={allResults} />}
+            {tab === "summary"    && <Summary    results={allResults} risk={risk} onRiskChange={setRisk} />}
             {tab === "roc"        && <RocChart   results={allResults} />}
             {tab === "histograms" && <Histograms results={allResults} />}
             {tab === "records"    && <Records    results={allResults} jobId={jobId} />}

--- a/leakpro/webapp/frontend/src/components/steps/Step7Results.tsx
+++ b/leakpro/webapp/frontend/src/components/steps/Step7Results.tsx
@@ -77,7 +77,9 @@ export default function Step7Results({ jobId, onRestart, autoOpenCompare }: Prop
 
   const mergeResults = (pastJobId: string, newResults: ModelResult[], renames: Record<string, string>) => {
     const renamed = newResults.map((m) =>
-      renames[m.model_name] ? { ...m, model_name: renames[m.model_name] } : m
+      // Keep the backend name so optimization can still find the model in its
+      // own job after the display name changes.
+      renames[m.model_name] ? { ...m, model_name: renames[m.model_name], orig_model_name: m.model_name } : m
     );
     setAllResults((prev) => {
       const base = prev ?? [];


### PR DESCRIPTION
Top of the stack: #438 → #447 → this. Retarget to main as the rungs below merge (GitHub does it automatically).

Contains the merge of feature/leakage-risk-assessment (#445, @TheColdIce) with his original commits preserved — if #445 merges to main first, his commits drop out of this diff automatically; if this merges first, his work lands here with authorship intact and #445 closes as merged.

### PET optimization in the webapp

- **View** (Summary tab → "Optimize protection" per model): one slider (max acceptable quality loss, baseline and floor shown), live scatter filling in per tested setting (attack success TPR@1%FPR vs accuracy), finished state fades tested points and tags the best trade-offs "Safest"→"Best quality", side panel with the real hyperparameters, "Confirm this setting" runs a stronger verification attack, estimate vs verified side by side (amber badge if the estimate was >20% optimistic), "Adopt" writes an `optimized` row into the summary. No optimizer jargon anywhere; all copy in `optimizationCopy.ts`.
- **Backend**: `leakpro/optimization/adapters.py` (arch file + tensor dataset → PETRecipe + splits; binary vs multiclass decided by probing the model head), `pet_runner.py` as a detached subprocess (survives backend restarts; JSONL is the resume state; kill = resumable pause; OOM auto-backoff halves the physical batch), five `/jobs/{id}/pet/*` endpoints placed before the SPA mount. ε=inf is serialized as null — Python's bare `Infinity` is rejected by every browser's JSON.parse.

### Risk assessment made per model (on top of #445)

Declaring is per model because the population at risk follows the training split (f_train), not the dataset. Each summary row gets "Risk assessment" and "Optimize protection" buttons; submits go one model per request via `RiskRequest.model_name`; each row displays at its own declared α. Subjects left blank uses the model's exact `num_train` from metadata (provenance recorded); the wizard shows the derived count as placeholder. Known deferred gap (commented in code): two same-data models can be declared with different sensitivities; copy-from-model is the planned fix.

### Fixes along the way

- Records tab images for models loaded from previous sessions (sample endpoints now register the job's dataset_handler before unpickling).
- Cross-session optimization targets the model's own job under its original name.
- A failed optimization run is retryable instead of a dead end.

### Verification

142 tests pass (optimization + risk suites), ruff clean, tsc 0 errors, vite build clean, and a 20-check end-to-end run of the PET flow (start → poll → verify → adopt → rejection paths) against a live TestClient with a BatchNorm model, exercising the ModuleValidator path in situ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WotNsAFnfJsCerAiyoXLNM

## Shared Opacus-compat helper

The webapp's DP-SGD loop carried a near-verbatim copy of the BatchNorm fix, in-place-activation pass and residual-forward patch that now live in `leakpro.optimization.make_opacus_compatible` (#447). It is removed here in favour of the shared helper, so a model trained through the wizard and the same model trained by a PET campaign are the same architecture — and the subclass-safety fix from #447's review covers both paths. This was the one review finding on #447 whose fix belongs in this PR.

## Verification

- 155 tests pass (optimization + risk suites).
- `ruff check .` clean; `tsc --noEmit` 0 errors; `vite build` clean.
- Full 20-check end-to-end run of the PET flow against a live TestClient (start → poll → verify → adopt, plus the 404/409 rejection paths), using a BatchNorm fixture model so the ModuleValidator path is exercised in situ.
