### PR TITLE
fix: score offline LiRA with logpdf per the reference implementation

### DIFF
--- a/leakpro/attacks/mia_attacks/lira.py
+++ b/leakpro/attacks/mia_attacks/lira.py
@@ -244,8 +244,11 @@ class AttackLiRA(AbstractMIA):
                 pr_in = norm.logpdf(target_signal, in_mean, in_std + 1e-30)
                 pr_out = norm.logpdf(target_signal, out_mean, out_std + 1e-30)
             else:
+                # Offline attack scores by how unlikely the target signal is under the
+                # OUT distribution, matching the reference implementation
+                # (tensorflow/privacy mi_lira_2021: score = logpdf(out), negated at ROC time).
                 pr_in = 0
-                pr_out = -norm.logcdf(target_signal, out_mean, out_std + 1e-30)
+                pr_out = norm.logpdf(target_signal, out_mean, out_std + 1e-30)
 
             score[i] = (pr_in - pr_out)  # Append the calculated probability density value to the score list
             if np.isnan(score[i]):

--- a/leakpro/tests/mia_attacks/attacks/test_lira.py
+++ b/leakpro/tests/mia_attacks/attacks/test_lira.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from dotmap import DotMap
 from pydantic import ValidationError
+from scipy.stats import norm
 
 from leakpro.attacks.mia_attacks.lira import AttackLiRA
 from leakpro.reporting.mia_result import MIAResult
@@ -179,3 +180,33 @@ def test_lira_rejects_non_scalar_signal(image_handler:ImageInputHandler) -> None
 
     with pytest.raises(ValueError, match="one scalar per audit point"):
         lira_obj.prepare_attack()
+
+def test_lira_offline_score_matches_reference_implementation(image_handler:ImageInputHandler) -> None:
+    """Offline LiRA must score -logpdf under the OUT distribution, per tensorflow/privacy mi_lira_2021.
+
+    The reference implementation predicts logpdf(signal; mean_out, std_out) and negates
+    at ROC time; LeakPro folds the negation into the score so that higher means member,
+    consistent with the online attack. It must NOT use the logcdf (issue #378).
+    """
+    audit_config = get_audit_config()
+    lira_params = DotMap({k: v for k, v in audit_config.attack_list[0].items() if k != "attack"})
+    lira_params.online = False
+    image_handler.configs.shadow_model = get_shadow_model_config()
+    lira_obj = AttackLiRA(image_handler, lira_params)
+    if ShadowModelHandler.is_created() == False:
+        ShadowModelHandler(image_handler)
+    lira_obj.prepare_attack()
+    lira_obj.run_attack()
+
+    n_audit_samples = lira_obj.shadow_models_signals.shape[1]
+    actual = np.zeros(n_audit_samples)
+    actual[lira_obj.audit_dataset["in_members"]] = lira_obj.in_member_signals.flatten()
+    actual[lira_obj.audit_dataset["out_members"]] = lira_obj.out_member_signals.flatten()
+
+    for i in range(n_audit_samples):
+        out_mask = lira_obj.out_indices[:, i]
+        sm_signals = lira_obj.shadow_models_signals[:, i]
+        out_mean = np.mean(sm_signals[out_mask])
+        out_std = lira_obj.get_std(sm_signals, out_mask, False, lira_obj.var_calculation)
+        expected = -norm.logpdf(lira_obj.target_signals[i], out_mean, out_std + 1e-30)
+        assert np.isclose(actual[i], expected), f"sample {i}: got {actual[i]}, reference gives {expected}"


### PR DESCRIPTION
Closes #378.

## Validation of the issue

Checked against the reference before fixing: `tensorflow/privacy research/mi_lira_2021/plot.py` `generate_ours_offline` scores `scipy.stats.norm.logpdf(sc, mean_out, std_out + 1e-30)` and its `sweep` negates predictions at ROC time (`roc_curve(x, -score)`), so the effective membership score is **−logpdf under the OUT distribution**. LeakPro's offline branch instead used `logcdf` — ranking purely by how high the signal sits in the OUT distribution, a different statistic with a different ROC. LeakPro's own `multi_signal_lira.py` already used logpdf for the identical case, so the two LiRA implementations disagreed with each other. Issue confirmed valid.

One nuance for the record: the LiRA *paper* (§ offline attack) describes a one-sided test, which is CDF-shaped; the *reference code* — which the issue cites and our multi-signal LiRA follows — uses the density. This PR follows the reference code.

## Fix

`pr_out = -norm.logcdf(...)` → `pr_out = norm.logpdf(...)`, so `score = pr_in − pr_out = −logpdf(out)` with the reference's ROC-time negation folded in (higher = member, consistent with the online branch).

⚠️ Offline LiRA scores produced before this change are not comparable with scores produced after it.

## Tests

New `test_lira_offline_score_matches_reference_implementation` recomputes every audit sample's score against the reference formula; it fails on the logcdf code. Full `test_lira.py` (8) and the LiRA end-to-end tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4j7ifPMD8R2Mgd7om97F2