### PR TITLE
fix(webapp): require authentication and validate paths on the backend API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# The webapp image is built from the repo root (see leakpro/webapp/Dockerfile.backend).
+# Without this file, `COPY . .` bakes real audit data and git history into every
+# image layer — including anything pushed to a registry.
+
+# Version control
+.git
+.gitignore
+
+# Real job data, uploaded datasets and trained models
+webapp_jobs/
+webapp_*_files/
+leakpro_output/
+leakpro_outpu*/
+
+# Local environments and caches
+.venv/
+venv/
+**/__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+*.egg-info/
+
+# Node
+**/node_modules/
+**/dist/
+**/.vite/
+
+# Notebooks and scratch files
+.ipynb_checkpoints/
+*.swp
+*.swo
+*~
+
+# Local configuration
+.env
+.env.*
+CLAUDE.local.md

--- a/examples/mia/celebA_HQ/webapp/README.md
+++ b/examples/mia/celebA_HQ/webapp/README.md
@@ -16,10 +16,15 @@ cd leakpro/webapp/frontend && npm install
 
 **Backend** (from repo root):
 ```bash
-uvicorn leakpro.webapp.backend.main:app --reload --port 8000
+uvicorn leakpro.webapp.backend.main:app --reload --host 127.0.0.1 --port 8000
 # To use a different port:
-uvicorn leakpro.webapp.backend.main:app --reload --port 8001
+uvicorn leakpro.webapp.backend.main:app --reload --host 127.0.0.1 --port 8001
 ```
+
+The backend prints an API token at startup; paste it into the UI when prompted.
+Set `LEAKPRO_WEBAPP_TOKEN` to pin your own instead. Keep the bind address on
+`127.0.0.1`: this backend loads user model files and runs user-supplied Python
+by design. See [`leakpro/webapp/SECURITY.md`](../../../../leakpro/webapp/SECURITY.md).
 
 **Frontend** (from `leakpro/webapp/frontend/`):
 ```bash

--- a/leakpro/tests/test_webapp_security.py
+++ b/leakpro/tests/test_webapp_security.py
@@ -10,6 +10,7 @@ unauthenticated access, cross-site requests, path traversal through
 metadata deserialization.
 """
 
+import contextlib
 import os
 import pickle
 import tempfile
@@ -17,8 +18,8 @@ from pathlib import Path
 
 import pytest
 
-# The webapp is optional tooling with its own dependencies (see the webapp
-# READMEs); skip these tests entirely where fastapi is not installed, e.g. CI.
+# Webapp tests: run wherever the webapp extras are installed
+# (pip install -e ".[webapp]"); skipped elsewhere.
 pytest.importorskip("fastapi", reason="webapp extras (fastapi) not installed")
 
 from fastapi import HTTPException  # noqa: E402
@@ -67,6 +68,20 @@ class TestPathValidation:
         assert safe_suffix("../../evil") == ""
         assert safe_suffix(None) == ""
 
+    def test_trailing_newline_rejected(self: Self) -> None:
+        """`$` under match() accepts a trailing newline; fullmatch must not."""
+        from leakpro.webapp.backend.security import safe_name, safe_suffix
+
+        with pytest.raises(HTTPException):
+            safe_name("model1\n")
+        assert safe_suffix("x.pkl\n") == ""
+
+    def test_non_ascii_token_is_invalid_not_error(self: Self) -> None:
+        """compare_digest raises TypeError on non-ASCII str; must return False."""
+        from leakpro.webapp.backend.security import token_is_valid
+
+        assert token_is_valid("\u00fc") is False
+
 
 class _Canary:
     """Pickle payload that would run a command on a vulnerable loader."""
@@ -77,6 +92,15 @@ class _Canary:
     def __reduce__(self: Self) -> tuple:
         """Return the os.system call a vulnerable unpickler would execute."""
         return (os.system, (f"touch {self.marker}",))
+
+
+class _FakeMetadata:
+    """Stand-in for a real metadata object of a non-allowlisted class."""
+
+    def __init__(self: Self) -> None:
+        self.train_indices = [1, 2]
+        self.optimizer = "adam"
+        self.epochs = 5
 
 
 class TestRestrictedUnpickler:
@@ -97,11 +121,9 @@ class TestRestrictedUnpickler:
             assert marker.exists(), "payload should execute under plain pickle.load"
             marker.unlink()
 
-            with open(payload, "rb") as handle:
-                try:
-                    RestrictedUnpickler(handle).load()
-                except Exception:  # noqa: BLE001, S110 - refusing to load is fine
-                    pass
+            # Refusing to load (raising) is an acceptable outcome; executing is not.
+            with open(payload, "rb") as handle, contextlib.suppress(Exception):
+                RestrictedUnpickler(handle).load()
             assert not marker.exists(), "RestrictedUnpickler must not execute the payload"
 
     def test_preserves_field_names(self: Self) -> None:
@@ -115,9 +137,34 @@ class TestRestrictedUnpickler:
                 loaded = RestrictedUnpickler(handle).load()
             assert set(loaded) == {"epochs", "train_indices"}
 
+    def test_preserves_field_names_of_custom_class(self: Self) -> None:
+        """A non-allowlisted class becomes a stub whose __dict__ keeps the fields.
+
+        This is the case validate_model_metadata actually depends on: real
+        metadata is a ModelMetadata *object*, and its field names survive only
+        through the stub's __setstate__.
+        """
+        from leakpro.webapp.backend.security import RestrictedUnpickler
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "meta.pkl"
+            path.write_bytes(pickle.dumps(_FakeMetadata()))
+            with open(path, "rb") as handle:
+                loaded = RestrictedUnpickler(handle).load()
+            assert type(loaded).__name__ == "Stub__FakeMetadata"
+            assert set(loaded.__dict__) == {"train_indices", "optimizer", "epochs"}
+
 
 class TestApiBoundary:
-    """Every /jobs route requires a valid token and an allowlisted origin."""
+    """Every route except the static SPA requires a valid token and origin."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_jobs_root(self: Self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Keep test jobs out of the real webapp_jobs/ (and out of _load_jobs)."""
+        from leakpro.webapp.backend import main as backend_main
+
+        monkeypatch.setattr(backend_main, "JOBS_ROOT", tmp_path)
+        self.jobs_root = tmp_path
 
     def _client(self: Self) -> tuple:
         from fastapi.testclient import TestClient
@@ -145,7 +192,8 @@ class TestApiBoundary:
         client, auth = self._client()
         job_id = client.post("/jobs", headers=auth).json()["job_id"]
 
-        for hostile in ["../../../../tmp/pwned", "/tmp/pwned_abs"]:
+        escape_target = self.jobs_root.parent / "pwned_abs"
+        for hostile in ["../../../../escaped/pwned", str(escape_target)]:
             res = client.post(
                 f"/jobs/{job_id}/upload/weights",
                 params={"model_name": hostile},
@@ -153,7 +201,27 @@ class TestApiBoundary:
                 headers=auth,
             )
             assert res.status_code == 400
-        assert not Path("/tmp/pwned_abs").exists()
+        assert not escape_target.exists()
+
+    def test_query_token_not_accepted_on_http(self: Self) -> None:
+        """?token= must not authenticate HTTP routes — it lands in access logs."""
+        from leakpro.webapp.backend import security
+
+        client, _ = self._client()
+        assert client.get("/jobs", params={"token": security.API_TOKEN}).status_code == 401
+
+    def test_non_ascii_credentials_get_401_not_500(self: Self) -> None:
+        """Garbage credentials must be rejected, not crash the auth path."""
+        client, _ = self._client()
+        assert client.get("/jobs", params={"token": "\u00fc"}).status_code == 401
+
+    def test_static_spa_paths_stay_public(self: Self) -> None:
+        """Fail-closed auth must still leave the SPA shell reachable."""
+        client, _ = self._client()
+        for path in ["/", "/index.html", "/assets/anything.js"]:
+            assert client.get(path).status_code not in (401, 403), path
+        # Anything else is protected by default
+        assert client.get("/some/future/route").status_code == 401
 
     def test_server_side_path_confined(self: Self) -> None:
         """An arbitrary absolute path cannot be read through data-path."""

--- a/leakpro/tests/test_webapp_security.py
+++ b/leakpro/tests/test_webapp_security.py
@@ -16,7 +16,12 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from fastapi import HTTPException
+
+# The webapp is optional tooling with its own dependencies (see the webapp
+# READMEs); skip these tests entirely where fastapi is not installed, e.g. CI.
+pytest.importorskip("fastapi", reason="webapp extras (fastapi) not installed")
+
+from fastapi import HTTPException  # noqa: E402
 
 from leakpro.utils.import_helper import Self
 

--- a/leakpro/tests/test_webapp_security.py
+++ b/leakpro/tests/test_webapp_security.py
@@ -1,0 +1,170 @@
+#
+# Copyright 2023-2026 Lindholmen Science Park AB
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Regression tests for the webapp backend security controls.
+
+These cover the vulnerabilities fixed in the webapp hardening pass:
+unauthenticated access, cross-site requests, path traversal through
+``model_name``, unconfined server-side paths, and code execution during
+metadata deserialization.
+"""
+
+import os
+import pickle
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from leakpro.utils.import_helper import Self
+
+
+class TestPathValidation:
+    """safe_name and confine must reject traversal and absolute-path escapes."""
+
+    def test_safe_name_rejects_escapes(self: Self) -> None:
+        """Names that would escape the job directory are refused."""
+        from leakpro.webapp.backend.security import safe_name
+
+        # `Path("/a/b") / "/etc"` is `/etc`, so an absolute value is an escape.
+        for bad in ["../../etc", "/etc/cron.d", "..", ".", "a/b", "a\\b", "", ".hidden", "x" * 65]:
+            with pytest.raises(HTTPException):
+                safe_name(bad, "model_name")
+
+    def test_safe_name_accepts_ordinary_names(self: Self) -> None:
+        """Names the UI actually produces are unaffected."""
+        from leakpro.webapp.backend.security import safe_name
+
+        for good in ["model1", "my_model", "resnet-18", "a.b", "uploaded_model"]:
+            assert safe_name(good, "model_name") == good
+
+    def test_confine_blocks_paths_outside_roots(self: Self) -> None:
+        """A server-side path outside the permitted roots is refused."""
+        from leakpro.webapp.backend.security import confine
+
+        with tempfile.TemporaryDirectory() as root:
+            inside = Path(root) / "data.pkl"
+            inside.write_bytes(b"x")
+            assert confine(str(inside), [Path(root)]) == inside.resolve()
+
+            with pytest.raises(HTTPException):
+                confine("/etc/passwd", [Path(root)])
+            with pytest.raises(HTTPException):
+                confine(f"{root}/../../etc/passwd", [Path(root)])
+
+    def test_safe_suffix_ignores_hostile_filenames(self: Self) -> None:
+        """Only a plain extension is ever taken from a client filename."""
+        from leakpro.webapp.backend.security import safe_suffix
+
+        assert safe_suffix("data.pkl") == ".pkl"
+        assert safe_suffix("../../evil") == ""
+        assert safe_suffix(None) == ""
+
+
+class _Canary:
+    """Pickle payload that would run a command on a vulnerable loader."""
+
+    def __init__(self: Self, marker: str) -> None:
+        self.marker = marker
+
+    def __reduce__(self: Self) -> tuple:
+        """Return the os.system call a vulnerable unpickler would execute."""
+        return (os.system, (f"touch {self.marker}",))
+
+
+class TestRestrictedUnpickler:
+    """The restricted unpickler must never resolve an attacker-chosen callable."""
+
+    def test_does_not_execute_payload(self: Self) -> None:
+        """A malicious pickle is inert under RestrictedUnpickler."""
+        from leakpro.webapp.backend.security import RestrictedUnpickler
+
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "EXECUTED"
+            payload = Path(tmp) / "payload.pkl"
+            payload.write_bytes(pickle.dumps(_Canary(str(marker))))
+
+            # Sanity check: the payload really is dangerous to a plain loader.
+            with open(payload, "rb") as handle:
+                pickle.load(handle)  # noqa: S301
+            assert marker.exists(), "payload should execute under plain pickle.load"
+            marker.unlink()
+
+            with open(payload, "rb") as handle:
+                try:
+                    RestrictedUnpickler(handle).load()
+                except Exception:  # noqa: BLE001, S110 - refusing to load is fine
+                    pass
+            assert not marker.exists(), "RestrictedUnpickler must not execute the payload"
+
+    def test_preserves_field_names(self: Self) -> None:
+        """Metadata validation still sees which fields a pickle contains."""
+        from leakpro.webapp.backend.security import RestrictedUnpickler
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "meta.pkl"
+            path.write_bytes(pickle.dumps({"epochs": 5, "train_indices": [1, 2]}))
+            with open(path, "rb") as handle:
+                loaded = RestrictedUnpickler(handle).load()
+            assert set(loaded) == {"epochs", "train_indices"}
+
+
+class TestApiBoundary:
+    """Every /jobs route requires a valid token and an allowlisted origin."""
+
+    def _client(self: Self) -> tuple:
+        from fastapi.testclient import TestClient
+
+        from leakpro.webapp.backend import security
+        from leakpro.webapp.backend.main import app
+
+        return TestClient(app), {"Authorization": f"Bearer {security.API_TOKEN}"}
+
+    def test_unauthenticated_requests_rejected(self: Self) -> None:
+        """No token means no access to the API surface."""
+        client, _ = self._client()
+        assert client.get("/jobs").status_code == 401
+        assert client.post("/jobs").status_code == 401
+        assert client.post("/jobs", headers={"Authorization": "Bearer nope"}).status_code == 401
+
+    def test_cross_site_origin_rejected(self: Self) -> None:
+        """A valid token from a foreign origin is still refused."""
+        client, auth = self._client()
+        res = client.post("/jobs", headers={**auth, "Origin": "https://evil.example"})
+        assert res.status_code == 403
+
+    def test_traversal_in_model_name_rejected(self: Self) -> None:
+        """model_name cannot redirect an upload outside the job directory."""
+        client, auth = self._client()
+        job_id = client.post("/jobs", headers=auth).json()["job_id"]
+
+        for hostile in ["../../../../tmp/pwned", "/tmp/pwned_abs"]:
+            res = client.post(
+                f"/jobs/{job_id}/upload/weights",
+                params={"model_name": hostile},
+                files={"file": ("w.pkl", b"data", "application/octet-stream")},
+                headers=auth,
+            )
+            assert res.status_code == 400
+        assert not Path("/tmp/pwned_abs").exists()
+
+    def test_server_side_path_confined(self: Self) -> None:
+        """An arbitrary absolute path cannot be read through data-path."""
+        client, auth = self._client()
+        job_id = client.post("/jobs", headers=auth).json()["job_id"]
+        res = client.post(f"/jobs/{job_id}/data-path", json={"path": "/etc/passwd"}, headers=auth)
+        assert res.status_code == 400
+
+    def test_legitimate_upload_still_works(self: Self) -> None:
+        """The hardening does not break the normal flow."""
+        client, auth = self._client()
+        job_id = client.post("/jobs", headers=auth).json()["job_id"]
+        res = client.post(
+            f"/jobs/{job_id}/upload/weights",
+            params={"model_name": "good_model"},
+            files={"file": ("w.pkl", b"data", "application/octet-stream")},
+            headers=auth,
+        )
+        assert res.status_code == 200

--- a/leakpro/webapp/Dockerfile.backend
+++ b/leakpro/webapp/Dockerfile.backend
@@ -14,4 +14,9 @@ RUN pip install --no-cache-dir -e ".[dev]" \
 
 EXPOSE 8000
 
+# The container binds 0.0.0.0 because it has its own network namespace; the
+# host-side exposure is controlled by docker-compose, which publishes this port
+# on 127.0.0.1 only. Do not publish it on a public interface: this backend
+# deserializes user models and executes user-supplied Python by design.
+# See leakpro/webapp/SECURITY.md.
 CMD ["uvicorn", "leakpro.webapp.backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/leakpro/webapp/SECURITY.md
+++ b/leakpro/webapp/SECURITY.md
@@ -59,10 +59,18 @@ server process. That is the tool working as intended. It also means:
 - Treat the job directory as trusted-input storage.
 
 `security.RestrictedUnpickler` is used where only field names are needed
-(metadata validation) and never resolves an attacker-chosen callable. The
-`_LenientUnpickler` in `inspector.py` and `checker.py` is a **compatibility
-shim, not a security boundary** — it resolves real classes whenever the import
-succeeds, and is safe only because it now sits behind authentication.
+(metadata validation) and never resolves an attacker-chosen callable. Its scope
+is that one endpoint: the compatibility check, the audit worker and the sample
+endpoints load the same files with full (code-executing) deserialization, behind
+authentication. The `_LenientUnpickler` in `inspector.py` and `checker.py` is a
+**compatibility shim, not a security boundary** — it resolves real classes
+whenever the import succeeds, and is safe only because it now sits behind
+authentication.
+
+The WebSocket log stream authenticates via a `?token=` query parameter (browsers
+cannot set headers on a WebSocket), so the token can appear in server access
+logs for that one route. HTTP routes accept the token only in the
+`Authorization` header for exactly this reason.
 
 ## Reporting a vulnerability
 

--- a/leakpro/webapp/SECURITY.md
+++ b/leakpro/webapp/SECURITY.md
@@ -1,0 +1,70 @@
+# LeakPro webapp — security model
+
+## What this backend is
+
+The webapp is **demo tooling for a trusted operator auditing their own model.**
+It is not a multi-tenant service and must not be deployed as one.
+
+To audit a model, the backend has to do two things that are arbitrary code
+execution by design:
+
+1. **Deserialize user model files** (`pickle`, `torch.load`, `joblib`) — you
+   cannot reconstruct a PyTorch checkpoint without it.
+2. **Execute user-supplied Python** (`arch.py`, `handler.py`,
+   `dataset_handler.py`) — the compatibility check and the audit run the
+   operator's own model code.
+
+Neither can be removed without removing the product. So the security boundary
+is **who can reach them**, not the operations themselves. Everything below
+exists to keep them reachable only by an authenticated local operator.
+
+## Controls
+
+| Control | Default | Override |
+|---|---|---|
+| Bearer token on every `/jobs` route | generated per run, printed at startup | `LEAKPRO_WEBAPP_TOKEN` |
+| CORS + WebSocket origin allowlist | `localhost:5173`, `localhost:8000` | `LEAKPRO_WEBAPP_ORIGINS` |
+| Server-side path endpoints confined | the LeakPro repo root | `LEAKPRO_WEBAPP_DATA_ROOTS` |
+| Upload size cap | 2048 MB | `LEAKPRO_WEBAPP_MAX_UPLOAD_MB` |
+| Docker port binding | `127.0.0.1` only | `docker-compose.yml` |
+
+`model_name` and `TrainParams.name` are validated as single path components
+(`security.safe_name`) because they are joined into filesystem paths that create
+directories and write files. `Path("/a/b") / "/etc"` is `/etc`, so an
+unvalidated name is an arbitrary-write primitive, not just a traversal.
+
+The WebSocket log stream takes its token as a query parameter, because browsers
+cannot set an `Authorization` header on a WebSocket. WebSockets are exempt from
+CORS, so the origin is checked explicitly before `accept()`.
+
+## Running it safely
+
+```bash
+# Pin a token (otherwise one is generated and printed to the log)
+export LEAKPRO_WEBAPP_TOKEN="$(python -c 'import secrets;print(secrets.token_urlsafe(32))')"
+
+# Bind to loopback. Do NOT use --host 0.0.0.0 on a shared or public machine.
+uvicorn leakpro.webapp.backend.main:app --host 127.0.0.1 --port 8000
+```
+
+The UI prompts for the token once and stores it in `localStorage`.
+
+## What is deliberately still possible
+
+An **authenticated** operator can upload a pickle and Python that run as the
+server process. That is the tool working as intended. It also means:
+
+- Do not hand the token to anyone you would not give a shell to.
+- Do not run this on a shared machine, a jump host, or anything internet-facing.
+- Treat the job directory as trusted-input storage.
+
+`security.RestrictedUnpickler` is used where only field names are needed
+(metadata validation) and never resolves an attacker-chosen callable. The
+`_LenientUnpickler` in `inspector.py` and `checker.py` is a **compatibility
+shim, not a security boundary** — it resolves real classes whenever the import
+succeeds, and is safe only because it now sits behind authentication.
+
+## Reporting a vulnerability
+
+Open a GitHub Security Advisory on `aidotse/LeakPro`, or contact the
+maintainers directly. Please allow time to patch before public disclosure.

--- a/leakpro/webapp/backend/checker.py
+++ b/leakpro/webapp/backend/checker.py
@@ -137,7 +137,10 @@ try:
         try:
             import numpy as np
 
-            class _SafeUnpickler(pickle.Unpickler):
+            # Compatibility shim, not a security boundary: it resolves real
+            # classes whenever the import succeeds. Safe here only because this
+            # runs in a subprocess on a file the authenticated operator supplied.
+            class _LenientUnpickler(pickle.Unpickler):
                 def find_class(self, module, name):
                     try:
                         return super().find_class(module, name)
@@ -145,7 +148,7 @@ try:
                         return type(name, (), {})
 
             with open(data_path, "rb") as fh:
-                raw = _SafeUnpickler(fh).load()
+                raw = _LenientUnpickler(fh).load()
 
             # Extract data array and targets — try common attribute names
             data_arr = targets_arr = None

--- a/leakpro/webapp/backend/inspector.py
+++ b/leakpro/webapp/backend/inspector.py
@@ -12,8 +12,15 @@ import numpy as np
 from .models import DataMeta
 
 
-class _SafeUnpickler(pickle.Unpickler):
-    """Unpickler that returns a placeholder for unknown classes instead of raising."""
+class _LenientUnpickler(pickle.Unpickler):
+    """Unpickler that substitutes a placeholder for classes that fail to import.
+
+    NOTE: this is a *compatibility* shim, not a security boundary. It resolves
+    real classes whenever the import succeeds, so it offers no protection
+    against a malicious pickle. Reaching it requires an authenticated request;
+    see ``security.RestrictedUnpickler`` for the hardened variant used where
+    only field names are needed.
+    """
     def find_class(self, module: str, name: str):
         try:
             return super().find_class(module, name)
@@ -25,7 +32,11 @@ class _SafeUnpickler(pickle.Unpickler):
 def _try_load(path: Path) -> Any:
     suffix = path.suffix.lower()
     if suffix == ".npy":
-        return np.load(path, allow_pickle=True)
+        # Plain arrays load without pickle; only object arrays need the fallback.
+        try:
+            return np.load(path, allow_pickle=False)
+        except ValueError:
+            return np.load(path, allow_pickle=True)
     if suffix in {".pkl", ".pickle"}:
         # Add common LeakPro handler directories to sys.path so custom
         # classes (e.g. cifar_handler.UserDataset) can be unpickled.
@@ -43,12 +54,16 @@ def _try_load(path: Path) -> Any:
             with open(path, "rb") as f:
                 return pickle.load(f)  # noqa: S301
         except Exception:
-            # Fall back to safe unpickler if import still fails
+            # Fall back to the lenient unpickler if a custom class won't import
             with open(path, "rb") as f:
-                return _SafeUnpickler(f).load()  # noqa: S301
+                return _LenientUnpickler(f).load()  # noqa: S301
     if suffix == ".pt":
         import torch
-        return torch.load(path, map_location="cpu", weights_only=False)
+        # Tensors and state dicts load without executing pickled code.
+        try:
+            return torch.load(path, map_location="cpu", weights_only=True)
+        except Exception:
+            return torch.load(path, map_location="cpu", weights_only=False)
     if suffix == ".csv":
         import pandas as pd
         return pd.read_csv(path)

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -388,7 +388,8 @@ async def _require_auth(request, call_next):
 
     The backend deserializes user pickles and executes user-supplied Python by
     design, so every route that can reach those sinks must be authenticated.
-    The static SPA is left open so the UI can load and prompt for the token.
+    Fail closed: only the static SPA paths are exempt, so the UI can load and
+    prompt for the token; any route added later is protected by default.
     """
     if request.method == "OPTIONS" or not path_is_protected(request.url.path):
         return await call_next(request)
@@ -398,9 +399,10 @@ async def _require_auth(request, call_next):
     if not origin_is_allowed(request.headers.get("origin")):
         return JSONResponse({"detail": "Origin not allowed"}, status_code=403)
 
+    # Header only: a ?token= fallback here would land the secret in the access
+    # log on every request, and HTTP middleware never sees WebSocket scopes —
+    # the WS route does its own query-parameter check.
     presented = bearer_from_header(request.headers.get("authorization"))
-    if presented is None:
-        presented = request.query_params.get("token")
     if not token_is_valid(presented):
         return JSONResponse({"detail": "Unauthorized"}, status_code=401)
 

--- a/leakpro/webapp/backend/main.py
+++ b/leakpro/webapp/backend/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import queue
 import shutil
 import threading
@@ -16,6 +17,7 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from leakpro.schemas import EvalOutput, TrainingOutput
@@ -260,6 +262,21 @@ _PRESET_ARCHS: dict[str, str] = {
 
 from .checker import run_check
 from .inspector import inspect
+from .security import (
+    ALLOWED_ORIGINS,
+    bearer_from_header,
+    confine,
+    load_metadata_fields,
+    origin_is_allowed,
+    path_is_protected,
+    safe_copy,
+    safe_detail,
+    safe_name,
+    safe_suffix,
+    save_upload,
+    startup_banner,
+    token_is_valid,
+)
 from .models import (
     ArchConfig,
     AttackParams,
@@ -277,6 +294,8 @@ from .worker import run_audit_job
 # ---------------------------------------------------------------------------
 # App setup
 # ---------------------------------------------------------------------------
+
+_logger = logging.getLogger("leakpro.webapp")
 
 JOBS_ROOT = Path(__file__).parents[3] / "webapp_jobs"
 JOBS_ROOT.mkdir(parents=True, exist_ok=True)
@@ -356,16 +375,43 @@ def _load_jobs() -> None:
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     _load_jobs()
+    _logger.info("\n%s", startup_banner())
     yield
 
 
 app = FastAPI(title="LeakPro Webapp API", version="0.1.0", lifespan=lifespan)
 
+
+@app.middleware("http")
+async def _require_auth(request, call_next):
+    """Gate the API surface behind a bearer token and an origin allowlist.
+
+    The backend deserializes user pickles and executes user-supplied Python by
+    design, so every route that can reach those sinks must be authenticated.
+    The static SPA is left open so the UI can load and prompt for the token.
+    """
+    if request.method == "OPTIONS" or not path_is_protected(request.url.path):
+        return await call_next(request)
+
+    # A browser attaches Origin on cross-site requests; the token alone already
+    # blocks them, this rejects them earlier and covers DNS-rebinding attempts.
+    if not origin_is_allowed(request.headers.get("origin")):
+        return JSONResponse({"detail": "Origin not allowed"}, status_code=403)
+
+    presented = bearer_from_header(request.headers.get("authorization"))
+    if presented is None:
+        presented = request.query_params.get("token")
+    if not token_is_valid(presented):
+        return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+
+    return await call_next(request)
+
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=ALLOWED_ORIGINS,
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 
@@ -423,9 +469,8 @@ async def get_status(job_id: str) -> dict:
 @app.post("/jobs/{job_id}/upload/data", response_model=DataMeta)
 async def upload_data(job_id: str, file: UploadFile) -> DataMeta:
     job = _get_job(job_id)
-    dest = _job_dir(job_id) / f"data{Path(file.filename).suffix}"
-    with open(dest, "wb") as f:
-        shutil.copyfileobj(file.file, f)
+    dest = _job_dir(job_id) / f"data{safe_suffix(file.filename)}"
+    save_upload(file.file, dest)
     meta = inspect(dest)
     job["data_path"] = str(dest)
     job["data_meta"] = meta.model_dump()
@@ -437,16 +482,16 @@ async def upload_data(job_id: str, file: UploadFile) -> DataMeta:
 async def set_data_path(job_id: str, body: dict) -> DataMeta:
     """Use a dataset already on the server by absolute path."""
     job = _get_job(job_id)
-    path = Path(body.get("path", ""))
+    path = confine(body.get("path", ""))
     if not path.exists():
-        raise HTTPException(status_code=400, detail=f"Path does not exist: {path}")
+        raise HTTPException(status_code=400, detail="Path does not exist")
     if not path.is_file():
-        raise HTTPException(status_code=400, detail=f"Path is not a file: {path}")
+        raise HTTPException(status_code=400, detail="Path is not a file")
     try:
         meta = inspect(path)
     except Exception as e:
-        import traceback
-        raise HTTPException(status_code=400, detail=f"Failed to inspect file: {e}\n{traceback.format_exc()}") from e
+        _logger.exception("inspect failed for job %s", job_id)
+        raise HTTPException(status_code=400, detail=safe_detail(e, "Failed to inspect file")) from e
     job["data_path"] = str(path)
     job["data_meta"] = meta.model_dump()
     _save_job(job_id)
@@ -458,8 +503,7 @@ async def upload_dataset_handler(job_id: str, file: UploadFile) -> dict:
     """Upload a custom dataset_handler.py defining UserDataset."""
     _get_job(job_id)
     dest = _job_dir(job_id) / "dataset_handler.py"
-    with open(dest, "wb") as f:
-        shutil.copyfileobj(file.file, f)
+    save_upload(file.file, dest)
     return {"ok": True, "filename": file.filename}
 
 
@@ -467,13 +511,13 @@ async def upload_dataset_handler(job_id: str, file: UploadFile) -> dict:
 async def set_dataset_handler_path(job_id: str, body: dict) -> dict:
     """Use a dataset_handler.py already on the server by absolute path."""
     _get_job(job_id)
-    path = Path(body.get("path", ""))
+    path = confine(body.get("path", ""))
     if not path.exists():
-        raise HTTPException(status_code=400, detail=f"Path does not exist: {path}")
+        raise HTTPException(status_code=400, detail="Path does not exist")
     if not path.suffix == ".py":
         raise HTTPException(status_code=400, detail="Path must point to a .py file")
     dest = _job_dir(job_id) / "dataset_handler.py"
-    shutil.copy2(path, dest)
+    safe_copy(path, dest)
     return {"ok": True, "filename": path.name}
 
 
@@ -497,20 +541,19 @@ async def set_handler_config(job_id: str, config: HandlerConfig) -> dict:
 async def upload_arch(job_id: str, file: UploadFile) -> dict:
     _get_job(job_id)
     dest = _job_dir(job_id) / "arch.py"
-    with open(dest, "wb") as f:
-        shutil.copyfileobj(file.file, f)
+    save_upload(file.file, dest)
     return {"ok": True, "filename": file.filename}
 
 
 @app.post("/jobs/{job_id}/arch-path")
 async def set_arch_path(job_id: str, body: dict) -> dict:
     _get_job(job_id)
-    path = Path(body.get("path", ""))
+    path = confine(body.get("path", ""))
     if not path.exists():
-        raise HTTPException(status_code=400, detail=f"Path does not exist: {path}")
-    # Symlink or copy into job dir
+        raise HTTPException(status_code=400, detail="Path does not exist")
+    # Copy into job dir
     dest = _job_dir(job_id) / "arch.py"
-    shutil.copy2(path, dest)
+    safe_copy(path, dest)
     return {"ok": True, "filename": path.name}
 
 
@@ -518,19 +561,18 @@ async def set_arch_path(job_id: str, body: dict) -> dict:
 async def upload_handler(job_id: str, file: UploadFile) -> dict:
     _get_job(job_id)
     dest = _job_dir(job_id) / "handler.py"
-    with open(dest, "wb") as f:
-        shutil.copyfileobj(file.file, f)
+    save_upload(file.file, dest)
     return {"ok": True, "filename": file.filename}
 
 
 @app.post("/jobs/{job_id}/handler-path")
 async def set_handler_path(job_id: str, body: dict) -> dict:
     _get_job(job_id)
-    path = Path(body.get("path", ""))
+    path = confine(body.get("path", ""))
     if not path.exists():
-        raise HTTPException(status_code=400, detail=f"Path does not exist: {path}")
+        raise HTTPException(status_code=400, detail="Path does not exist")
     dest = _job_dir(job_id) / "handler.py"
-    shutil.copy2(path, dest)
+    safe_copy(path, dest)
     return {"ok": True, "filename": path.name}
 
 
@@ -553,22 +595,20 @@ async def set_arch_config(job_id: str, config: ArchConfig) -> dict:
 @app.post("/jobs/{job_id}/upload/weights")
 async def upload_weights(job_id: str, model_name: str, file: UploadFile) -> dict:
     _get_job(job_id)
-    model_dir = _job_dir(job_id) / "models" / model_name
+    model_dir = _job_dir(job_id) / "models" / safe_name(model_name, "model_name")
     model_dir.mkdir(exist_ok=True)
     dest = model_dir / "target_model.pkl"
-    with open(dest, "wb") as f:
-        shutil.copyfileobj(file.file, f)
+    save_upload(file.file, dest)
     return {"ok": True, "path": str(dest)}
 
 
 @app.post("/jobs/{job_id}/upload/model-metadata")
 async def upload_model_metadata(job_id: str, model_name: str, file: UploadFile) -> dict:
     _get_job(job_id)
-    model_dir = _job_dir(job_id) / "models" / model_name
+    model_dir = _job_dir(job_id) / "models" / safe_name(model_name, "model_name")
     model_dir.mkdir(exist_ok=True)
     dest = model_dir / "model_metadata.pkl"
-    with open(dest, "wb") as f:
-        shutil.copyfileobj(file.file, f)
+    save_upload(file.file, dest)
     return {"ok": True, "path": str(dest)}
 
 
@@ -576,14 +616,14 @@ async def upload_model_metadata(job_id: str, model_name: str, file: UploadFile) 
 async def set_model_metadata_path(job_id: str, body: dict) -> dict:
     """Copy a metadata file already on the server into the job directory."""
     _get_job(job_id)
-    path = Path(body.get("path", ""))
-    model_name = body.get("model_name", "uploaded_model")
+    path = confine(body.get("path", ""))
+    model_name = safe_name(body.get("model_name", "uploaded_model"), "model_name")
     if not path.exists():
-        raise HTTPException(status_code=400, detail=f"Path does not exist: {path}")
+        raise HTTPException(status_code=400, detail="Path does not exist")
     model_dir = _job_dir(job_id) / "models" / model_name
     model_dir.mkdir(exist_ok=True)
     dest = model_dir / "model_metadata.pkl"
-    shutil.copy2(path, dest)
+    safe_copy(path, dest)
     return {"ok": True, "path": str(dest)}
 
 
@@ -591,51 +631,43 @@ async def set_model_metadata_path(job_id: str, body: dict) -> dict:
 async def validate_model_metadata(job_id: str, model_name: str) -> dict:
     """Check that an uploaded model_metadata.pkl has all required MIA fields."""
     _get_job(job_id)
+    model_name = safe_name(model_name, "model_name")
     meta_path = _job_dir(job_id) / "models" / model_name / "model_metadata.pkl"
     if not meta_path.exists():
         raise HTTPException(status_code=400, detail="No metadata file uploaded yet")
 
     required = ["train_indices", "test_indices", "optimizer", "criterion",
                 "data_loader", "epochs", "train_result", "test_result", "dataset"]
-    import pickle
-
-    class _SafeUnpickler(pickle.Unpickler):
-        def find_class(self, module, name):
-            try:
-                return super().find_class(module, name)
-            except (ImportError, AttributeError):
-                return type(name, (), {})
-
     try:
-        with open(meta_path, "rb") as f:
-            raw = _SafeUnpickler(f).load()
+        raw = load_metadata_fields(meta_path)
         attrs: dict = raw.__dict__ if hasattr(raw, "__dict__") else (raw if isinstance(raw, dict) else {})
         present = [k for k in required if k in attrs]
         missing = [k for k in required if k not in attrs]
         return {"ok": not missing, "present_fields": present, "missing_fields": missing}
     except Exception as e:
-        import traceback
+        _logger.exception("metadata validation failed for job %s", job_id)
         return {"ok": False, "present_fields": [], "missing_fields": required,
-                "error": f"{e}\n{traceback.format_exc()}"}
+                "error": safe_detail(e, "Failed to read metadata")}
 
 
 @app.post("/jobs/{job_id}/weights-path")
 async def set_weights_path(job_id: str, body: dict) -> dict:
     _get_job(job_id)
-    path = Path(body.get("path", ""))
-    model_name = body.get("model_name", "uploaded_model")
+    path = confine(body.get("path", ""))
+    model_name = safe_name(body.get("model_name", "uploaded_model"), "model_name")
     if not path.exists():
-        raise HTTPException(status_code=400, detail=f"Path does not exist: {path}")
+        raise HTTPException(status_code=400, detail="Path does not exist")
     model_dir = _job_dir(job_id) / "models" / model_name
     model_dir.mkdir(exist_ok=True)
     dest = model_dir / "target_model.pkl"
-    shutil.copy2(path, dest)
+    safe_copy(path, dest)
     return {"ok": True, "path": str(dest)}
 
 
 @app.post("/jobs/{job_id}/check", response_model=CompatResult)
 async def check_compat(job_id: str, model_name: str) -> CompatResult:
     job = _get_job(job_id)
+    model_name = safe_name(model_name, "model_name")
     job_dir = _job_dir(job_id)
     arch_path = job_dir / "arch.py"
     weights_path = job_dir / "models" / model_name / "target_model.pkl"
@@ -710,6 +742,8 @@ async def remove_model(job_id: str, model_name: str) -> dict:
 async def train_model(job_id: str, params: TrainParams) -> dict:
     """Enqueue a training job. Progress streams via WS /jobs/{id}/logs."""
     job = _get_job(job_id)
+    # params.name becomes a directory created with parents=True further down.
+    params.name = safe_name(params.name, "name")
     log_q = _log_queues[job_id]
 
     def _train() -> None:
@@ -793,15 +827,17 @@ async def train_model(job_id: str, params: TrainParams) -> dict:
                             return pickle.load(_f)
                     except Exception:
                         pass
-                    # Fall back: stub out missing classes, then reconstruct as TensorDataset
-                    class _SafeUnpickler(pickle.Unpickler):
+                    # Fall back: stub out missing classes, then reconstruct as TensorDataset.
+                    # NOTE: compatibility shim, not a security boundary — it resolves real
+                    # classes whenever the import succeeds (see security.RestrictedUnpickler).
+                    class _LenientUnpickler(pickle.Unpickler):
                         def find_class(self, module, name):
                             try:
                                 return super().find_class(module, name)
                             except (ImportError, AttributeError):
                                 return type(name, (), {})
                     with open(path, "rb") as _f:
-                        raw = _SafeUnpickler(_f).load()
+                        raw = _LenientUnpickler(_f).load()
                     import numpy as np
                     # Use __dict__ directly — bypasses any descriptor protocol on the stub class
                     attrs = getattr(raw, "__dict__", {})
@@ -1121,7 +1157,8 @@ async def train_model(job_id: str, params: TrainParams) -> dict:
 @app.post("/jobs/{job_id}/attack-config")
 async def set_attack_config(job_id: str, configs: list[ModelAttackConfig]) -> dict:
     job = _get_job(job_id)
-    cfg_map = {c.model_name: c.attacks for c in configs}
+    # model_name is persisted as target_folder and joined into paths by the worker.
+    cfg_map = {safe_name(c.model_name, "model_name"): c.attacks for c in configs}
     existing_names = {m["name"] for m in job.get("models", [])}
 
     # Upsert any model the frontend knows about that isn't in the backend state yet
@@ -1152,6 +1189,10 @@ async def start_audit(job_id: str) -> dict:
     job = _get_job(job_id)
     if job["status"] == JobStatus.running:
         raise HTTPException(status_code=409, detail="Audit already running")
+    # Claim the job synchronously: the worker only sets `running` once it starts,
+    # so without this, rapid repeat calls all pass the check and all get queued.
+    job["status"] = JobStatus.running
+    _save_job(job_id)
     log_q = _log_queues[job_id]
     _executor.submit(run_audit_job, job_id, _job_dir(job_id), job, log_q, _save_job)
     return {"ok": True}
@@ -1248,6 +1289,14 @@ async def get_sample_image(job_id: str, index: int):
 
 @app.websocket("/jobs/{job_id}/logs")
 async def log_stream(websocket: WebSocket, job_id: str) -> None:
+    # WebSockets bypass CORS entirely and browsers cannot set an Authorization
+    # header on them, so both checks have to happen here, before accept().
+    if not origin_is_allowed(websocket.headers.get("origin")):
+        await websocket.close(code=4403)
+        return
+    if not token_is_valid(websocket.query_params.get("token")):
+        await websocket.close(code=4401)
+        return
     if job_id not in _jobs:
         await websocket.close(code=4004)
         return

--- a/leakpro/webapp/backend/models.py
+++ b/leakpro/webapp/backend/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # ---------------------------------------------------------------------------
@@ -68,13 +68,15 @@ class ArchConfig(BaseModel):
 # ---------------------------------------------------------------------------
 
 class TrainParams(BaseModel):
-    name: str
-    epochs: int = 50
-    learning_rate: float = 0.001
-    batch_size: int = 128
+    # `name` becomes a directory name on disk; the pattern is enforced again
+    # server-side by security.safe_name.
+    name: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+    epochs: int = Field(default=50, ge=1, le=1000)
+    learning_rate: float = Field(default=0.001, gt=0, le=10)
+    batch_size: int = Field(default=128, ge=1, le=16384)
     optimizer: str = "adam"       # "adam" | "sgd"
-    f_train: float = 0.5          # fraction of dataset used for training
-    f_test: float = 0.5           # fraction of dataset used for testing
+    f_train: float = Field(default=0.5, gt=0, le=1)   # fraction used for training
+    f_test: float = Field(default=0.5, gt=0, le=1)    # fraction used for testing
     dpsgd: bool = False
     target_epsilon: float | None = None
     target_delta: float | None = None

--- a/leakpro/webapp/backend/models.py
+++ b/leakpro/webapp/backend/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +83,12 @@ class TrainParams(BaseModel):
     max_grad_norm: float | None = None
     virtual_batch_size: int | None = None
     accountant: str = "prv"          # "prv" | "rdp"
+
+    @model_validator(mode="after")
+    def _fractions_fit(self) -> "TrainParams":
+        if self.f_train + self.f_test > 1:
+            raise ValueError("f_train + f_test must not exceed 1")
+        return self
 
 
 class ModelInfo(BaseModel):

--- a/leakpro/webapp/backend/security.py
+++ b/leakpro/webapp/backend/security.py
@@ -1,0 +1,322 @@
+"""Security controls for the LeakPro webapp backend.
+
+The webapp is demo tooling: it deliberately deserializes user-supplied model
+files and executes user-supplied ``arch.py`` / ``handler.py`` so LeakPro can
+audit a real model. Those operations are arbitrary code execution *by design* —
+you cannot audit a PyTorch checkpoint without reconstructing it.
+
+The security boundary is therefore **who may reach those operations**, not the
+operations themselves. Everything in this module exists to keep them reachable
+only by an authenticated local operator, never by a remote or cross-site caller.
+
+Configuration (all optional, read from the environment at import time):
+
+``LEAKPRO_WEBAPP_TOKEN``
+    Bearer token required on every API request. If unset, a random token is
+    generated at startup and printed to the server log.
+``LEAKPRO_WEBAPP_ORIGINS``
+    Comma-separated CORS/WebSocket origin allowlist.
+    Default: ``http://localhost:5173,http://127.0.0.1:5173``.
+``LEAKPRO_WEBAPP_DATA_ROOTS``
+    Comma-separated directories the server-side ``*-path`` endpoints may read
+    from. Default: the job directory plus the LeakPro repo root (so the bundled
+    ``examples/`` datasets keep working).
+``LEAKPRO_WEBAPP_MAX_UPLOAD_MB``
+    Per-file upload cap in megabytes. Default 2048.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+from pathlib import Path
+from typing import Any, BinaryIO, Iterable
+
+from fastapi import HTTPException
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parents[3]
+
+#: True when no token was configured and we generated one for this process.
+TOKEN_WAS_GENERATED = not os.environ.get("LEAKPRO_WEBAPP_TOKEN")
+
+#: Bearer token required by every API request.
+API_TOKEN = os.environ.get("LEAKPRO_WEBAPP_TOKEN") or secrets.token_urlsafe(32)
+
+
+def _csv_env(name: str, default: Iterable[str]) -> list[str]:
+    raw = os.environ.get(name, "")
+    values = [item.strip() for item in raw.split(",") if item.strip()]
+    return values or list(default)
+
+
+ALLOWED_ORIGINS = _csv_env(
+    "LEAKPRO_WEBAPP_ORIGINS",
+    ("http://localhost:5173", "http://127.0.0.1:5173",
+     "http://localhost:8000", "http://127.0.0.1:8000"),
+)
+
+DATA_ROOTS = [Path(p).expanduser().resolve()
+              for p in _csv_env("LEAKPRO_WEBAPP_DATA_ROOTS", (str(_REPO_ROOT),))]
+
+MAX_UPLOAD_BYTES = int(float(os.environ.get("LEAKPRO_WEBAPP_MAX_UPLOAD_MB", "2048")) * 1024 * 1024)
+
+#: Only these URL prefixes require authentication — the rest is the static SPA.
+PROTECTED_PREFIXES = ("/jobs",)
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+def token_is_valid(presented: str | None) -> bool:
+    """Constant-time comparison of a presented token against the configured one."""
+    if not presented:
+        return False
+    return secrets.compare_digest(presented, API_TOKEN)
+
+
+def bearer_from_header(header: str | None) -> str | None:
+    """Extract the token from an ``Authorization: Bearer <token>`` header."""
+    if not header:
+        return None
+    scheme, _, value = header.partition(" ")
+    if scheme.lower() != "bearer":
+        return None
+    return value.strip() or None
+
+
+def path_is_protected(path: str) -> bool:
+    """True when the URL path belongs to the authenticated API surface."""
+    return any(path == p or path.startswith(p + "/") or path.startswith(p + "?")
+               for p in PROTECTED_PREFIXES)
+
+
+def origin_is_allowed(origin: str | None) -> bool:
+    """True when a browser-supplied Origin header is absent or allowlisted.
+
+    A missing Origin means a non-browser client (curl, tests), which the bearer
+    token already gates. A present-but-unlisted Origin is a cross-site caller.
+    """
+    if origin is None:
+        return True
+    return origin in ALLOWED_ORIGINS
+
+
+# ---------------------------------------------------------------------------
+# Path safety
+# ---------------------------------------------------------------------------
+
+#: A single filesystem path component: no separators, no traversal, no dotfiles.
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+def safe_name(value: str, field: str = "name") -> str:
+    """Validate a user-supplied string used as a single path component.
+
+    ``model_name`` reaches ``Path`` joins that create directories and write
+    files. Without this, ``model_name=/etc/cron.d`` overrides the join entirely
+    (``Path('/a/b') / '/etc'`` is ``/etc``) and ``../../`` escapes upward.
+    """
+    if not isinstance(value, str) or not _SAFE_NAME.match(value):
+        raise HTTPException(
+            status_code=400,
+            detail=(f"Invalid {field}: must be 1-64 characters of letters, digits, "
+                    "'.', '_' or '-', and start with a letter or digit."),
+        )
+    return value
+
+
+#: File extension of an upload, used to name the file we write.
+_SAFE_SUFFIX = re.compile(r"^\.[A-Za-z0-9]{1,12}$")
+
+
+def safe_suffix(filename: str | None) -> str:
+    """Return the upload's extension, or '' if it is missing or unusual.
+
+    The client controls ``filename``; only the extension is ever used, and only
+    when it looks like a plain extension.
+    """
+    if not filename:
+        return ""
+    suffix = Path(str(filename)).suffix
+    return suffix if _SAFE_SUFFIX.match(suffix) else ""
+
+
+def confine(candidate: str | Path, roots: Iterable[Path] | None = None) -> Path:
+    """Resolve ``candidate`` and require it to sit inside one of ``roots``.
+
+    Resolution happens before the check so symlinks and ``..`` cannot escape.
+    """
+    resolved = Path(candidate).expanduser().resolve()
+    for root in (roots if roots is not None else DATA_ROOTS):
+        try:
+            resolved.relative_to(root)
+            return resolved
+        except ValueError:
+            continue
+    raise HTTPException(
+        status_code=400,
+        detail="Path is outside the permitted directories for this server.",
+    )
+
+
+def save_upload(src: BinaryIO, dest: Path, max_bytes: int = MAX_UPLOAD_BYTES) -> int:
+    """Stream an upload to ``dest``, aborting past ``max_bytes``.
+
+    Replaces bare ``shutil.copyfileobj``, which lets an unauthenticated caller
+    fill the server's disk.
+    """
+    written = 0
+    try:
+        with open(dest, "wb") as out:
+            while True:
+                chunk = src.read(1024 * 1024)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > max_bytes:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"Upload exceeds the {max_bytes // (1024 * 1024)} MB limit.",
+                    )
+                out.write(chunk)
+    except HTTPException:
+        dest.unlink(missing_ok=True)
+        raise
+    return written
+
+
+def safe_copy(src: Path, dest: Path, max_bytes: int = MAX_UPLOAD_BYTES) -> int:
+    """Size-capped copy of a server-side file into a job directory."""
+    with open(src, "rb") as handle:
+        return save_upload(handle, dest, max_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Restricted unpickling
+# ---------------------------------------------------------------------------
+
+#: The only classes ever resolved for real while inspecting a pickle.
+_PICKLE_ALLOWLIST = {
+    ("builtins", "dict"), ("builtins", "list"), ("builtins", "set"),
+    ("builtins", "tuple"), ("builtins", "frozenset"), ("builtins", "bytearray"),
+    ("builtins", "bytes"), ("builtins", "str"), ("builtins", "int"),
+    ("builtins", "float"), ("builtins", "bool"), ("builtins", "complex"),
+    ("builtins", "object"), ("collections", "OrderedDict"),
+}
+
+
+def _make_stub(name: str) -> type:
+    """Build an inert stand-in class for a pickled type we refuse to resolve."""
+
+    def __init__(self: Any, *_args: Any, **_kwargs: Any) -> None:  # noqa: N807, ANN401
+        pass
+
+    def __setstate__(self: Any, state: Any) -> None:  # noqa: N807, ANN401
+        # Keep the attribute names so callers can inspect which fields exist.
+        if isinstance(state, dict):
+            self.__dict__.update(state)
+        elif isinstance(state, tuple) and state and isinstance(state[0], dict):
+            self.__dict__.update(state[0])
+
+    def _append(self: Any, *_a: Any, **_k: Any) -> None:  # noqa: ANN401  (pickle protocol)
+        pass
+
+    return type(f"Stub_{name}", (), {
+        "__init__": __init__,
+        "__setstate__": __setstate__,
+        "append": _append,
+        "extend": _append,
+        "__setitem__": _append,
+    })
+
+
+class RestrictedUnpickler:
+    """Unpickler that never resolves an attacker-chosen callable.
+
+    ``pickle`` executes whatever ``find_class`` returns, so an unpickler that
+    calls ``super().find_class()`` first — as the previous ``_SafeUnpickler``
+    did — will happily resolve ``posix.system`` and run it. This one resolves
+    only the allowlist above and substitutes an inert stub for everything else,
+    which is enough to read a metadata object's field names without ever
+    constructing the real classes.
+    """
+
+    def __init__(self, file) -> None:  # noqa: ANN001
+        import pickle
+
+        outer = self
+
+        class _Impl(pickle.Unpickler):
+            def find_class(self, module: str, name: str):  # noqa: ANN202
+                if (module, name) in _PICKLE_ALLOWLIST:
+                    return super().find_class(module, name)
+                return outer._stub_for(name)
+
+        self._impl = _Impl(file)
+        self._stubs: dict[str, type] = {}
+
+    def _stub_for(self, name: str) -> type:
+        if name not in self._stubs:
+            self._stubs[name] = _make_stub(name)
+        return self._stubs[name]
+
+    def load(self) -> Any:  # noqa: ANN401
+        """Deserialize the stream, substituting stubs for disallowed classes."""
+        return self._impl.load()
+
+
+def load_metadata_fields(path: Path):  # noqa: ANN201
+    """Read a ``model_metadata.pkl`` for field inspection only.
+
+    Uses :class:`RestrictedUnpickler`, so a malicious metadata file cannot
+    execute code during this check.
+    """
+    with open(path, "rb") as handle:
+        return RestrictedUnpickler(handle).load()
+
+
+# ---------------------------------------------------------------------------
+# Error hygiene
+# ---------------------------------------------------------------------------
+
+def safe_detail(exc: BaseException, context: str) -> str:
+    """A client-safe error string.
+
+    Full tracebacks leak absolute server paths, the install layout and library
+    versions — exactly what an attacker needs to aim a path traversal — so they
+    are logged server-side and never returned.
+    """
+    return f"{context}: {type(exc).__name__}"
+
+
+def startup_banner(host: str | None = None) -> str:
+    """Human-readable security posture, printed once at startup."""
+    lines = [
+        "LeakPro webapp backend — security posture",
+        f"  auth      : bearer token required on {', '.join(PROTECTED_PREFIXES)}",
+        f"  origins   : {', '.join(ALLOWED_ORIGINS)}",
+        f"  data roots: {', '.join(str(p) for p in DATA_ROOTS)}",
+        f"  max upload: {MAX_UPLOAD_BYTES // (1024 * 1024)} MB",
+    ]
+    if host:
+        lines.append(f"  bind host : {host}")
+    if TOKEN_WAS_GENERATED:
+        lines += [
+            "",
+            "  No LEAKPRO_WEBAPP_TOKEN set — generated one for this run:",
+            f"      {API_TOKEN}",
+            "  Paste it into the web UI when prompted, or set the variable to pin it.",
+        ]
+    lines += [
+        "",
+        "  This backend loads user pickles and executes user-supplied Python by",
+        "  design. Treat every uploaded file as trusted input and do NOT expose",
+        "  this port to an untrusted network. See leakpro/webapp/SECURITY.md.",
+    ]
+    return "\n".join(lines)

--- a/leakpro/webapp/backend/security.py
+++ b/leakpro/webapp/backend/security.py
@@ -15,12 +15,12 @@ Configuration (all optional, read from the environment at import time):
     Bearer token required on every API request. If unset, a random token is
     generated at startup and printed to the server log.
 ``LEAKPRO_WEBAPP_ORIGINS``
-    Comma-separated CORS/WebSocket origin allowlist.
-    Default: ``http://localhost:5173,http://127.0.0.1:5173``.
+    Comma-separated CORS/WebSocket origin allowlist. Default: localhost and
+    127.0.0.1 on ports 5173 (Vite dev server) and 8000 (backend-served SPA).
 ``LEAKPRO_WEBAPP_DATA_ROOTS``
     Comma-separated directories the server-side ``*-path`` endpoints may read
-    from. Default: the job directory plus the LeakPro repo root (so the bundled
-    ``examples/`` datasets keep working).
+    from. Default: the LeakPro repo root (so the bundled ``examples/``
+    datasets keep working).
 ``LEAKPRO_WEBAPP_MAX_UPLOAD_MB``
     Per-file upload cap in megabytes. Default 2048.
 """
@@ -65,8 +65,11 @@ DATA_ROOTS = [Path(p).expanduser().resolve()
 
 MAX_UPLOAD_BYTES = int(float(os.environ.get("LEAKPRO_WEBAPP_MAX_UPLOAD_MB", "2048")) * 1024 * 1024)
 
-#: Only these URL prefixes require authentication — the rest is the static SPA.
-PROTECTED_PREFIXES = ("/jobs",)
+#: The only paths served without authentication: the static SPA shell and its
+#: build assets. Everything else requires the bearer token, so a route added
+#: later is protected by default (fail closed).
+PUBLIC_PATHS = frozenset({"/", "/index.html", "/logo.jpg"})
+PUBLIC_PREFIXES = ("/assets/",)
 
 
 # ---------------------------------------------------------------------------
@@ -74,10 +77,14 @@ PROTECTED_PREFIXES = ("/jobs",)
 # ---------------------------------------------------------------------------
 
 def token_is_valid(presented: str | None) -> bool:
-    """Constant-time comparison of a presented token against the configured one."""
+    """Constant-time comparison of a presented token against the configured one.
+
+    Compared as bytes: ``compare_digest`` raises ``TypeError`` on non-ASCII
+    *strings*, which would turn a garbage token into an unauthenticated 500.
+    """
     if not presented:
         return False
-    return secrets.compare_digest(presented, API_TOKEN)
+    return secrets.compare_digest(presented.encode("utf-8"), API_TOKEN.encode("utf-8"))
 
 
 def bearer_from_header(header: str | None) -> str | None:
@@ -91,9 +98,9 @@ def bearer_from_header(header: str | None) -> str | None:
 
 
 def path_is_protected(path: str) -> bool:
-    """True when the URL path belongs to the authenticated API surface."""
-    return any(path == p or path.startswith(p + "/") or path.startswith(p + "?")
-               for p in PROTECTED_PREFIXES)
+    """True unless the path is explicitly public (the static SPA)."""
+    return not (path in PUBLIC_PATHS
+                or any(path.startswith(prefix) for prefix in PUBLIC_PREFIXES))
 
 
 def origin_is_allowed(origin: str | None) -> bool:
@@ -112,7 +119,8 @@ def origin_is_allowed(origin: str | None) -> bool:
 # ---------------------------------------------------------------------------
 
 #: A single filesystem path component: no separators, no traversal, no dotfiles.
-_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+#: Matched with fullmatch — `$` under match() accepts a trailing newline.
+_SAFE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}")
 
 
 def safe_name(value: str, field: str = "name") -> str:
@@ -122,7 +130,7 @@ def safe_name(value: str, field: str = "name") -> str:
     files. Without this, ``model_name=/etc/cron.d`` overrides the join entirely
     (``Path('/a/b') / '/etc'`` is ``/etc``) and ``../../`` escapes upward.
     """
-    if not isinstance(value, str) or not _SAFE_NAME.match(value):
+    if not isinstance(value, str) or not _SAFE_NAME.fullmatch(value):
         raise HTTPException(
             status_code=400,
             detail=(f"Invalid {field}: must be 1-64 characters of letters, digits, "
@@ -132,7 +140,7 @@ def safe_name(value: str, field: str = "name") -> str:
 
 
 #: File extension of an upload, used to name the file we write.
-_SAFE_SUFFIX = re.compile(r"^\.[A-Za-z0-9]{1,12}$")
+_SAFE_SUFFIX = re.compile(r"\.[A-Za-z0-9]{1,12}")
 
 
 def safe_suffix(filename: str | None) -> str:
@@ -144,7 +152,7 @@ def safe_suffix(filename: str | None) -> str:
     if not filename:
         return ""
     suffix = Path(str(filename)).suffix
-    return suffix if _SAFE_SUFFIX.match(suffix) else ""
+    return suffix if _SAFE_SUFFIX.fullmatch(suffix) else ""
 
 
 def confine(candidate: str | Path, roots: Iterable[Path] | None = None) -> Path:
@@ -299,7 +307,7 @@ def startup_banner(host: str | None = None) -> str:
     """Human-readable security posture, printed once at startup."""
     lines = [
         "LeakPro webapp backend — security posture",
-        f"  auth      : bearer token required on {', '.join(PROTECTED_PREFIXES)}",
+        "  auth      : bearer token required (fail closed; only the SPA is public)",
         f"  origins   : {', '.join(ALLOWED_ORIGINS)}",
         f"  data roots: {', '.join(str(p) for p in DATA_ROOTS)}",
         f"  max upload: {MAX_UPLOAD_BYTES // (1024 * 1024)} MB",

--- a/leakpro/webapp/docker-compose.yml
+++ b/leakpro/webapp/docker-compose.yml
@@ -5,12 +5,16 @@ services:
     build:
       context: ../../          # repo root (needs leakpro/ package)
       dockerfile: leakpro/webapp/Dockerfile.backend
+    # Bound to the loopback interface: this backend loads user pickles and runs
+    # user-supplied Python by design, so it must not be reachable off-host.
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     volumes:
       - leakpro_jobs:/data/jobs
     environment:
       - PYTHONUNBUFFERED=1
+      # Set a fixed token to pin it; otherwise one is generated and logged.
+      - LEAKPRO_WEBAPP_TOKEN=${LEAKPRO_WEBAPP_TOKEN:-}
     restart: unless-stopped
 
   frontend:
@@ -18,7 +22,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile.frontend
     ports:
-      - "5173:80"
+      - "127.0.0.1:5173:80"
     depends_on:
       - backend
     restart: unless-stopped

--- a/leakpro/webapp/frontend/src/api.ts
+++ b/leakpro/webapp/frontend/src/api.ts
@@ -1,21 +1,52 @@
 /** Typed fetch wrappers for the LeakPro backend API. */
 
 const BASE = "";
+const TOKEN_KEY = "leakpro_api_token";
 
-async function post<T>(path: string, body?: unknown): Promise<T> {
-  const res = await fetch(BASE + path, {
-    method: "POST",
-    headers: body ? { "Content-Type": "application/json" } : {},
-    body: body ? JSON.stringify(body) : undefined,
-  });
+/**
+ * The backend requires a bearer token on every /jobs request. It prints one at
+ * startup (or reads LEAKPRO_WEBAPP_TOKEN). We keep it in localStorage and ask
+ * for it once per browser.
+ */
+export function getToken(): string {
+  let token = localStorage.getItem(TOKEN_KEY);
+  if (!token) {
+    token = window.prompt("LeakPro API token (printed in the backend log at startup):") ?? "";
+    if (token) localStorage.setItem(TOKEN_KEY, token);
+  }
+  return token;
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+function authHeaders(extra?: Record<string, string>): Record<string, string> {
+  return { Authorization: `Bearer ${getToken()}`, ...(extra ?? {}) };
+}
+
+async function handle<T>(res: Response): Promise<T> {
+  if (res.status === 401) {
+    // Stale or wrong token — drop it so the next call re-prompts.
+    clearToken();
+    throw new Error("Unauthorized: check the API token printed in the backend log.");
+  }
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
 
+async function post<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(BASE + path, {
+    method: "POST",
+    headers: authHeaders(body ? { "Content-Type": "application/json" } : undefined),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return handle<T>(res);
+}
+
 async function get<T>(path: string): Promise<T> {
-  const res = await fetch(BASE + path);
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  const res = await fetch(BASE + path, { headers: authHeaders() });
+  return handle<T>(res);
 }
 
 async function upload<T>(path: string, file: File, extra?: Record<string, string>): Promise<T> {
@@ -24,9 +55,8 @@ async function upload<T>(path: string, file: File, extra?: Record<string, string
   const url = extra
     ? BASE + path + "?" + new URLSearchParams(extra).toString()
     : BASE + path;
-  const res = await fetch(url, { method: "POST", body: fd });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  const res = await fetch(url, { method: "POST", body: fd, headers: authHeaders() });
+  return handle<T>(res);
 }
 
 // ---------------------------------------------------------------------------
@@ -72,7 +102,10 @@ export const api = {
   checkCompat: (id: string, modelName: string) =>
     post<CompatResult>(`/jobs/${id}/check?model_name=${encodeURIComponent(modelName)}`),
   removeModel: (id: string, modelName: string) =>
-    fetch(`/jobs/${id}/models/${encodeURIComponent(modelName)}`, { method: "DELETE" }).then((r) => r.json()),
+    fetch(`/jobs/${id}/models/${encodeURIComponent(modelName)}`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    }).then((r) => handle<unknown>(r)),
   trainModel: (id: string, params: TrainParams) => post(`/jobs/${id}/train`, params),
 
   // Step 5

--- a/leakpro/webapp/frontend/src/components/steps/Step6Run.tsx
+++ b/leakpro/webapp/frontend/src/components/steps/Step6Run.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { api } from "../../api";
+import { api, getToken } from "../../api";
 import { ModelEntry } from "./Step4Models";
 
 interface Props {
@@ -37,7 +37,11 @@ export default function Step6Run({ jobId, models, onDone, onRestart }: Props) {
 
     await api.startAudit(jobId);
 
-    const wsUrl = `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/jobs/${jobId}/logs`;
+    // Browsers cannot set an Authorization header on a WebSocket, so the
+    // backend accepts the token as a query parameter for this route only.
+    const wsUrl =
+      `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}` +
+      `/jobs/${jobId}/logs?token=${encodeURIComponent(getToken())}`;
     const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 


### PR DESCRIPTION
**Security fix** for the unauthenticated RCE reported in #453.

The webapp backend deserializes user model files and executes user-supplied Python by design — that's how it audits a model. This PR makes those operations reachable only by an authenticated local operator:

- **Bearer-token auth** on all `/jobs` routes (auto-generated and logged when `LEAKPRO_WEBAPP_TOKEN` is unset, so local dev stays a copy-paste)
- **CORS origin allowlist** replacing `allow_origins=["*"]`
- **WebSocket origin + token check** before `accept()` (WebSockets bypass CORS and cannot carry auth headers)
- **Loopback-only Docker binding** — the shipped compose previously published the backend on `0.0.0.0:8000`
- **Path-component validation**: `model_name` / `TrainParams.name` were joined into filesystem paths unvalidated; since `Path("/a/b") / "/etc"` is `/etc`, this was an arbitrary-file-write primitive, not just traversal
- **Confinement of the six server-side `*-path` endpoints** to configured data roots (`LEAKPRO_WEBAPP_DATA_ROOTS`; bundled examples keep working)
- **A genuinely restricted unpickler** for metadata validation; the previous `_SafeUnpickler` resolved `os.system` as readily as a real class and is renamed `_LenientUnpickler` with its limits documented
- Loaders try `torch.load(weights_only=True)` / `np.load(allow_pickle=False)` before falling back; upload size caps; bounds on `TrainParams`; tracebacks logged instead of returned; `/start` duplicate-submit race closed; `.dockerignore` so job data and `.git` stop being baked into images

**Verification:** unauthenticated → 401, wrong token → 401, cross-site origin → 403, `model_name` traversal/absolute path → 400 with no file written, `/data-path /etc/passwd` → 400, legitimate flow → 200. A canary pickle that provably executes under plain `pickle.load` is inert under the restricted unpickler. 11 new regression tests (`leakpro/tests/test_webapp_security.py`); existing suite passes (254); frontend `tsc` clean. Threat model documented in `leakpro/webapp/SECURITY.md`.

**Follow-ups, deliberately kept out of this diff to keep the security change auditable:** hardening cleanups (PR 2) and safe dataset formats — Parquet/`.npz` — implementing the format recommendation from #453 (PR 3).

Reported by **@mkultraware** (using Accuretta). Thanks for the responsible disclosure.

Refs #453 — the issue stays open until the safe-format PR lands; authentication is the accepted mitigation for the pickle sink in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
