### PR TITLE
fix(webapp): declare pyarrow in the webapp extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ minv = ["torch", "torchvision", "optuna", "kornia", "blobfile", "lpips", "robust
 # resolves cleanly from PyPI. Run `python -m leakpro.utils.hardware_setup
 # --install` after installing the Habana SDK to pull these in.
 hpu = ["lightning-habana"]
-webapp = ["fastapi", "uvicorn[standard]", "python-multipart", "httpx"]
+webapp = ["fastapi", "uvicorn[standard]", "python-multipart", "httpx", "pyarrow"]
 dev = [
   "pytest",
   "pytest-cov",


### PR DESCRIPTION
Fixes the `main` CI failure after #457 merged: `test_parquet_keeps_feature_names` fails with *"Unable to find a usable engine; tried using: 'pyarrow', 'fastparquet'"*.

**Why it only surfaced post-merge:** #457's PR runs predated #456's CI change (`pip install .[dev,webapp]`), so the webapp tests were skipped for a missing `fastapi` and never actually executed in CI until both PRs landed on `main`. The dataio Parquet path (`pd.read_parquet`) needs `pyarrow`, which was present in the local dev environment but never declared — a one-line extras fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)