### PR TITLE
refactor(lira): standardize output variable names

### DIFF
--- a/leakpro/attacks/mia_attacks/base.py
+++ b/leakpro/attacks/mia_attacks/base.py
@@ -135,13 +135,13 @@ class AttackBASE(AbstractMIA):
         ground_truth_indices = dataloader.dataset.targets.numpy()
         assert n_points == len(ground_truth_indices), "Number of points and labels must be the same"
         logger.info(f"Scoring {n_points} points with BASE attack")
-        logits_target = np.array(ModelLogits()([self.target_model], None, None, dataloader)).squeeze(axis=0)
-        log_conf_target = self._log_conf(logits_target, ground_truth_indices)
+        target_outputs = np.array(ModelLogits()([self.target_model], None, None, dataloader)).squeeze(axis=0)
+        log_conf_target = self._log_conf(target_outputs, ground_truth_indices)
         # run points through shadow models and collect the log confidence values
-        logits_sm = []
+        shadow_outputs = []
         for m in tqdm(self.shadow_models, desc="Scoring with shadow models"):
-            logits_sm.append( np.array(ModelLogits()([m], self.handler, None, dataloader)).squeeze(axis=0) )
-        log_conf_shadow_models = np.array([self._log_conf(x, ground_truth_indices) for x in logits_sm])
+            shadow_outputs.append( np.array(ModelLogits()([m], self.handler, None, dataloader)).squeeze(axis=0) )
+        log_conf_shadow_models = np.array([self._log_conf(x, ground_truth_indices) for x in shadow_outputs])
 
         if self.online is True:
             threshold = logsumexp(log_conf_shadow_models, axis=0) - np.log(self.num_shadow_models)
@@ -177,16 +177,16 @@ class AttackBASE(AbstractMIA):
 
         # Load the logits for the target model and shadow models
         ground_truth_indices = self.handler.get_labels(self.audit_dataset["data"])
-        logits_target = ShadowModelHandler().load_logits(name=f"target_{ShadowModelHandler().target_model_hash}")
-        logits_shadow_models = []
+        target_outputs = ShadowModelHandler().load_logits(name=f"target_{ShadowModelHandler().target_model_hash}")
+        shadow_outputs = []
         for indx in self.shadow_model_indices:
-            logits_shadow_models.append(ShadowModelHandler().load_logits(indx=indx))
+            shadow_outputs.append(ShadowModelHandler().load_logits(indx=indx))
 
         # collect the log confidence output of the correct class (which is the negative cross-entropy loss)
-        log_conf_target = self._log_conf(logits_target, ground_truth_indices)
+        log_conf_target = self._log_conf(target_outputs, ground_truth_indices)
 
         # run points through shadow models and collect the log confidence values
-        log_conf_shadow_models = np.array([self._log_conf(x, ground_truth_indices) for x in logits_shadow_models])
+        log_conf_shadow_models = np.array([self._log_conf(x, ground_truth_indices) for x in shadow_outputs])
 
         if self.online is True:
             threshold = logsumexp(log_conf_shadow_models, axis=0) - np.log(self.num_shadow_models)

--- a/leakpro/attacks/mia_attacks/lira.py
+++ b/leakpro/attacks/mia_attacks/lira.py
@@ -128,21 +128,21 @@ class AttackLiRA(AbstractMIA):
         # The signal is applied to the cached logits, so these hold signal values (rescaled logits,
         # an error, a distance, ...) rather than logits; named accordingly, as in MS-LiRA.
         true_labels = self.handler.get_labels(self.audit_dataset["data"])
-        target_logits = ShadowModelHandler().load_logits(name="target")
+        target_outputs = ShadowModelHandler().load_logits(name="target")
         # Classification labels arrive with a spurious singleton axis (e.g. (N, 1)) that must be
         # dropped before rescaled_logits/loss index them as (N,). Forecasting targets, though,
         # already match the cached logits' shape (N, horizon, num_variables) — squeezing them
         # would strip the real num_variables axis and break the mse/dtw/msm/... shape assert.
-        if true_labels.shape != target_logits.shape:
+        if true_labels.shape != target_outputs.shape:
             true_labels = true_labels.squeeze()
-        self.target_signals = self._check_signal_shape(self.signal(target_logits, true_labels),
-                                                       n_audit_points=target_logits.shape[0])
+        self.target_signals = self._check_signal_shape(self.signal(target_outputs, true_labels),
+                                                       n_audit_points=target_outputs.shape[0])
         self.shadow_models_signals = []
         for indx in self.shadow_model_indices:
-            shadow_logits = ShadowModelHandler().load_logits(indx=indx)
+            shadow_outputs = ShadowModelHandler().load_logits(indx=indx)
             self.shadow_models_signals.append(
-                self._check_signal_shape(self.signal(shadow_logits, true_labels),
-                                         n_audit_points=shadow_logits.shape[0])
+                self._check_signal_shape(self.signal(shadow_outputs, true_labels),
+                                         n_audit_points=shadow_outputs.shape[0])
             )
         self.shadow_models_signals = np.array(self.shadow_models_signals)
 

--- a/leakpro/attacks/mia_attacks/loss_trajectory.py
+++ b/leakpro/attacks/mia_attacks/loss_trajectory.py
@@ -275,11 +275,11 @@ class AttackLossTrajectory(AbstractMIA):
             # Calculate the loss for the teacher model
             #---------------------------------------------------------------------
             teacher_model.to(gpu_or_cpu)
-            batch_logit_target = teacher_model(data).squeeze() # TODO: replace with hopskipjump for label only
+            batch_target_output = teacher_model(data).squeeze() # TODO: replace with hopskipjump for label only
             batch_loss_teacher = []
 
-            for (batch_logit_target_i, target_i) in zip(batch_logit_target, target_for_loss):
-                loss = criterion(batch_logit_target_i, target_i)
+            for (batch_target_output_i, target_i) in zip(batch_target_output, target_for_loss):
+                loss = criterion(batch_target_output_i, target_i)
                 batch_loss_teacher.append(loss)
             batch_loss_teacher = np.array([batch_loss_teacher_i.cpu().detach().numpy() for batch_loss_teacher_i in
                                             batch_loss_teacher])

--- a/leakpro/attacks/mia_attacks/multi_signal_lira.py
+++ b/leakpro/attacks/mia_attacks/multi_signal_lira.py
@@ -153,13 +153,13 @@ class AttackMSLiRA(AbstractMIA):
         # signal interprets it (rescaled_logits/loss expect int64 labels; mse/mae/... expect a
         # series matching the cached logits' shape).
         targets = np.asarray(self.handler.get_labels(audit_indices))
-        target_logits = ShadowModelHandler().load_logits(name="target")
-        shadow_logits = [ShadowModelHandler().load_logits(indx=indx) for indx in self.shadow_model_indices]
+        target_outputs = ShadowModelHandler().load_logits(name="target")
+        shadow_outputs = [ShadowModelHandler().load_logits(indx=indx) for indx in self.shadow_model_indices]
         # Classification labels arrive with a spurious singleton axis that must be dropped before
-        # rescaled_logits/loss index them as (N,). Forecasting targets already match target_logits'
+        # rescaled_logits/loss index them as (N,). Forecasting targets already match target_outputs'
         # shape (N, horizon, num_variables) — squeezing them would strip the real num_variables axis
         # and break the mse/dtw/msm/... shape assert.
-        if targets.shape != target_logits.shape:
+        if targets.shape != target_outputs.shape:
             targets = targets.squeeze()
 
         shadow_models_signals = []
@@ -167,14 +167,14 @@ class AttackMSLiRA(AbstractMIA):
         for signal_fn, signal_name in zip(self.signal_fns, self.signals):
             logger.info(f"Calculating {signal_name} for the target model")
             target_signals.append(
-                self._check_signal_shape(signal_fn(target_logits, targets), target_logits.shape[0], signal_name)
+                self._check_signal_shape(signal_fn(target_outputs, targets), target_outputs.shape[0], signal_name)
             )
 
             logger.info(f"Calculating {signal_name} for all {self.num_shadow_models} shadow models")
             # (n_shadow_models, n_audit_points) -> (n_audit_points, n_shadow_models)
             per_model = np.array([
-                self._check_signal_shape(signal_fn(logits, targets), logits.shape[0], signal_name)
-                for logits in shadow_logits
+                self._check_signal_shape(signal_fn(outputs, targets), outputs.shape[0], signal_name)
+                for outputs in shadow_outputs
             ])
             shadow_models_signals.append(per_model.T)
 

--- a/leakpro/attacks/mia_attacks/rmia.py
+++ b/leakpro/attacks/mia_attacks/rmia.py
@@ -157,19 +157,19 @@ shadow-model residuals on the z-population. Ignored for classification models, w
             "detailed": detailed_str,
         }
 
-    def _get_z_logits(self:Self,
-                      logits_cached: np.ndarray,
+    def _get_z_outputs(self:Self,
+                      outputs_cached: np.ndarray,
                       model,  # noqa: ANN001
                       z_indices: np.ndarray,
                       cached_mask: np.ndarray,
                       logit_row: dict) -> np.ndarray:
-        """Return logits for z_indices, reading from cache where available and computing on-the-fly otherwise."""
+        """Return outputs for z_indices, reading from cache where available and computing on-the-fly otherwise."""
         n = len(z_indices)
-        logits = np.zeros((n, *logits_cached.shape[1:]))
+        outputs = np.zeros((n, *outputs_cached.shape[1:]))
 
         if cached_mask.any():
             rows = np.array([logit_row[int(idx)] for idx in z_indices[cached_mask]])
-            logits[cached_mask] = logits_cached[rows]
+            outputs[cached_mask] = outputs_cached[rows]
 
         if (~cached_mask).any():
             # Shadow models are already PytorchModel wrappers; target model is a raw nn.Module.
@@ -184,11 +184,11 @@ shadow-model residuals on the z-population. Ignored for classification models, w
                 self.handler,
                 z_indices[~cached_mask],
             )).squeeze(axis=0)
-            logits[~cached_mask] = unc
+            outputs[~cached_mask] = unc
 
-        return logits
+        return outputs
 
-    def _resolve_scale(self:Self, shadow_logits_z: list, z_labels: np.ndarray) -> None:
+    def _resolve_scale(self:Self, shadow_outputs_z: list, z_labels: np.ndarray) -> None:
         """Resolve the residual-likelihood scale used by the regression signal probability.
 
         With a user-provided sigma (residual std), it is mapped to the scale of the resolved
@@ -201,7 +201,7 @@ shadow-model residuals on the z-population. Ignored for classification models, w
 
         Args:
         ----
-            shadow_logits_z (list): Per-shadow-model predictions on the z-points.
+            shadow_outputs_z (list): Per-shadow-model predictions on the z-points.
             z_labels (np.ndarray): True outputs for the z-points, same shape as each prediction.
 
         """
@@ -213,20 +213,20 @@ shadow-model residuals on the z-population. Ignored for classification models, w
             return
 
         if self.likelihood_family == "gaussian":
-            energies = [np.mean(mse(logits_z, z_labels)) for logits_z in shadow_logits_z]
+            energies = [np.mean(mse(outputs_z, z_labels)) for outputs_z in shadow_outputs_z]
         elif self.likelihood_family == "laplace":
-            energies = [np.mean(mae(logits_z, z_labels)) for logits_z in shadow_logits_z]
+            energies = [np.mean(mae(outputs_z, z_labels)) for outputs_z in shadow_outputs_z]
         else:
-            energies = [np.mean(huber_energy(logits_z, z_labels, self._huber_delta)) for logits_z in shadow_logits_z]
+            energies = [np.mean(huber_energy(outputs_z, z_labels, self._huber_delta)) for outputs_z in shadow_outputs_z]
 
         self._scale = float(np.mean(energies))
         if self._scale <= 0.0:
             # Degenerate case: shadow models reproduce all z-targets exactly.
             self._scale = self.epsilon
         logger.info(f"Estimated {self.likelihood_family} residual scale = {self._scale:.6g} "
-                    f"from {len(shadow_logits_z)} shadow model(s) on {len(z_labels)} z-points")
+                    f"from {len(shadow_outputs_z)} shadow model(s) on {len(z_labels)} z-points")
 
-    def _signal_probability(self:Self, logits: np.ndarray, labels: np.ndarray) -> np.ndarray:
+    def _signal_probability(self:Self, outputs: np.ndarray, labels: np.ndarray) -> np.ndarray:
         """Compute the per-point probability of the true output given a model.
 
         Classification: temperature softmax indexed at the true class (RMIA paper, Sec. 3).
@@ -236,7 +236,7 @@ shadow-model residuals on the z-population. Ignored for classification models, w
 
         Args:
         ----
-            logits ( len(dataset) x ... ): Model outputs (class logits or forecasts).
+            outputs ( len(dataset) x ... ): Model outputs (class logits or forecasts).
             labels ( len(dataset) x ... ): True classes (int) or true outputs (float).
 
         Returns:
@@ -248,11 +248,11 @@ shadow-model residuals on the z-population. Ignored for classification models, w
             if self._scale is None:
                 raise RuntimeError("Residual likelihood scale is unresolved — prepare_attack must run first.")
             if self.likelihood_family == "gaussian":
-                return gaussian_residual_probability(logits, labels, self._scale)
+                return gaussian_residual_probability(outputs, labels, self._scale)
             if self.likelihood_family == "laplace":
-                return laplace_residual_probability(logits, labels, self._scale)
-            return huber_residual_probability(logits, labels, self._scale, self._huber_delta)
-        return softmax_logits(logits, self.temperature)[np.arange(len(labels)), labels]
+                return laplace_residual_probability(outputs, labels, self._scale)
+            return huber_residual_probability(outputs, labels, self._scale, self._huber_delta)
+        return softmax_logits(outputs, self.temperature)[np.arange(len(labels)), labels]
 
     def _prepare_shadow_models(self:Self) -> None:
 
@@ -279,15 +279,15 @@ shadow-model residuals on the z-population. Ignored for classification models, w
         """
         logger.info("Preparing shadow models for RMIA attack")
 
-        # If we already have one run, we dont need to check for shadow models as logits are stored
+        # If we already have one run, we dont need to check for shadow models as outputs are stored
         if not self.load_for_optuna:
             self._prepare_shadow_models()
 
             self.ground_truth = self.handler.get_labels(self.audit_dataset["data"])
-            self.logits_theta = ShadowModelHandler().load_logits(name=f"target_{ShadowModelHandler().target_model_hash}")
-            self.logits_shadow_models = []
+            self.target_outputs = ShadowModelHandler().load_logits(name=f"target_{ShadowModelHandler().target_model_hash}")
+            self.shadow_outputs = []
             for indx in self.shadow_model_indices:
-                self.logits_shadow_models.append(ShadowModelHandler().load_logits(indx=indx))
+                self.shadow_outputs.append(ShadowModelHandler().load_logits(indx=indx))
 
         # Sample z from full population per Algorithm 1 of the RMIA paper.
         # Build a cache lookup (global index → row) once — identical for target and all shadow models.
@@ -312,22 +312,22 @@ shadow-model residuals on the z-population. Ignored for classification models, w
         cached_mask = np.array([int(idx) in logit_row for idx in z_indices])
 
         # Collect raw model outputs on the z-points for the target and all shadow models
-        logits_z_theta = self._get_z_logits(
-            self.logits_theta, self.handler.target_model, z_indices, cached_mask, logit_row)
-        logits_z_shadow_models = [
-            self._get_z_logits(sm_logits, sm, z_indices, cached_mask, logit_row)
-            for sm, sm_logits in zip(self.shadow_models, self.logits_shadow_models)
+        target_outputs_z = self._get_z_outputs(
+            self.target_outputs, self.handler.target_model, z_indices, cached_mask, logit_row)
+        shadow_outputs_z = [
+            self._get_z_outputs(sm_outputs, sm, z_indices, cached_mask, logit_row)
+            for sm, sm_outputs in zip(self.shadow_models, self.shadow_outputs)
         ]
 
         if self.is_regression:
-            self._resolve_scale(logits_z_shadow_models, z_labels)
+            self._resolve_scale(shadow_outputs_z, z_labels)
 
         # p(z | target model)
-        p_z_given_theta = np.atleast_2d(self._signal_probability(logits_z_theta, z_labels))
+        p_z_given_theta = np.atleast_2d(self._signal_probability(target_outputs_z, z_labels))
 
         # p(z | each shadow model)
         p_z_given_shadow_models = np.array(
-            [self._signal_probability(logits_z, z_labels) for logits_z in logits_z_shadow_models])
+            [self._signal_probability(outputs_z, z_labels) for outputs_z in shadow_outputs_z])
 
         # evaluate the marginal p(z)
         if self.online is True:
@@ -345,11 +345,11 @@ shadow-model residuals on the z-population. Ignored for classification models, w
 
         # probability of the true output for each audit point given the target model
         n_audit_points = len(self.ground_truth)
-        p_x_given_theta = np.atleast_2d(self._signal_probability(self.logits_theta, self.ground_truth))
+        p_x_given_theta = np.atleast_2d(self._signal_probability(self.target_outputs, self.ground_truth))
 
         # same per shadow model, to compute the marginal p(x)
         p_x_given_shadow_models = np.array(
-            [self._signal_probability(x, self.ground_truth) for x in self.logits_shadow_models])
+            [self._signal_probability(x, self.ground_truth) for x in self.shadow_outputs])
 
         if self.online is True:
             p_x = np.mean(p_x_given_shadow_models, axis=0, keepdims=True)


### PR DESCRIPTION
## Summary

Standardize local variable names for raw model outputs in the LiRA attack.

## Changes

- Rename `target_logits` to `target_outputs`
- Rename `shadow_logits` to `shadow_outputs`
- Keep `target_signals` and `shadow_models_signals` unchanged
- Preserve the existing `load_logits()` API and attack behavior

## Testing

- `python3 -m py_compile leakpro/attacks/mia_attacks/lira.py`
- `python -m pytest leakpro/tests/mia_attacks/attacks/test_lira.py -v`
  - 7 passed
- `python -m pytest leakpro/tests/mia_attacks/attacks/test_multi_signal_lira.py -v`
  - 16 passed

Closes #444